### PR TITLE
fix: resolve hydration error and QueryClient configuration

### DIFF
--- a/src/components/layout/Providers.tsx
+++ b/src/components/layout/Providers.tsx
@@ -1,12 +1,24 @@
 "use client";
 
+import { useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { WagmiProvider } from "wagmi";
 import { config } from "@/lib/wagmi";
 
-const queryClient = new QueryClient();
-
 export default function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            // With SSR, we usually want to set some default staleTime
+            // above 0 to avoid refetching immediately on the client
+            staleTime: 60 * 1000,
+          },
+        },
+      })
+  );
+
   return (
     <WagmiProvider config={config}>
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>

--- a/src/hooks/use-proposals-per-month.ts
+++ b/src/hooks/use-proposals-per-month.ts
@@ -22,7 +22,6 @@ export function useProposalsPerMonth(months: number = 12) {
     queryFn: () => fetchProposalsPerMonth(months),
     staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
-    enabled: typeof window !== "undefined",
   });
 }
 


### PR DESCRIPTION
## Summary
Fixed critical hydration errors preventing the homepage from loading properly.

## Issues Fixed
1. **Hydration mismatch error** in `ProposalsPerMonthChart`
2. **"No QueryClient set"** runtime error

## Root Causes

### 1. Server/Client Branch in Query Hook
**File**: `src/hooks/use-proposals-per-month.ts`

The `enabled: typeof window !== "undefined"` option caused different behavior between server and client:
- **Server**: Query disabled → `isLoading = false` → rendered chart
- **Client**: Query enabled → `isLoading = true` → rendered skeleton
- **Result**: React hydration mismatch

### 2. Module-level QueryClient
**File**: `src/components/layout/Providers.tsx`

Creating `QueryClient` at module level doesn't work with Next.js App Router:
- Module re-evaluated on each server request
- Causes instability with React Server Components
- Results in "No QueryClient set" error

## Changes Made

### `use-proposals-per-month.ts`
- ❌ Removed `enabled: typeof window !== "undefined"`
- ✅ React Query v5 handles SSR properly without this guard

### `Providers.tsx`
- ❌ Removed module-level `const queryClient = new QueryClient()`
- ✅ Added `useState` pattern with lazy initializer
- ✅ Added default `staleTime: 60s` for SSR optimization

## Testing
- [x] Homepage loads without hydration errors
- [x] Charts render correctly after data fetch
- [x] No console errors on page load
- [x] Dev server runs without issues

## References
- [React Hydration Mismatch](https://react.dev/link/hydration-mismatch)
- [TanStack Query SSR Guide](https://tanstack.com/query/latest/docs/framework/react/guides/ssr)
- [Next.js App Router Patterns](https://nextjs.org/docs/app/building-your-application/rendering/server-components)

🤖 Generated with [Claude Code](https://claude.com/claude-code)