### PR TITLE
Simplify droposal header by removing metadata

### DIFF
--- a/src/components/droposals/detail/DroposalHeader.tsx
+++ b/src/components/droposals/detail/DroposalHeader.tsx
@@ -12,7 +12,6 @@
  * - editionSize: string or "Open"
  */
 import Link from "next/link";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 
 export interface DroposalHeaderProps {
@@ -26,29 +25,14 @@ export interface DroposalHeaderProps {
 }
 
 export function DroposalHeader(props: DroposalHeaderProps) {
-  const { proposalNumber, title, fallbackName, createdAtMs, isExecuted, priceEth, editionSize } =
-    props;
+  const { proposalNumber, title, fallbackName } = props;
 
   return (
     <div className="flex items-start justify-between gap-4">
       <div>
-        <div className="flex items-center gap-2 mb-2">
-          <Badge variant={isExecuted ? "secondary" : "outline"}>
-            {isExecuted ? "Executed" : "Pending"}
-          </Badge>
-          <span className="text-xs text-muted-foreground">#{proposalNumber}</span>
-        </div>
         <h1 className="text-3xl font-bold tracking-tight">
           {title || fallbackName || `Droposal #${proposalNumber}`}
         </h1>
-        <div className="mt-3 grid grid-cols-2 sm:flex sm:flex-wrap items-center gap-2">
-          <Badge variant="secondary">{Number(priceEth) === 0 ? "Free" : `${priceEth} ETH`}</Badge>
-          <Badge variant="secondary">Edition: {editionSize === "0" ? "Open" : editionSize}</Badge>
-          <span className="text-xs text-muted-foreground">
-            {new Date(createdAtMs).toLocaleDateString()}
-          </span>
-        </div>
-        {title && <p className="text-muted-foreground mt-2 max-w-2xl">{title}</p>}
       </div>
       <div className="hidden lg:flex items-center gap-2">
         <Button asChild variant="outline" size="sm">


### PR DESCRIPTION
## Summary
- Simplified the DroposalHeader component by removing unnecessary metadata elements
- Kept only the title and back button for a cleaner, more focused UI
- Removed status badges, edition information, and duplicate descriptions

## Changes
- ✂️ Removed status badge (Executed/Pending) and proposal number from header
- ✂️ Removed metadata badges (ETH price, edition size, date)
- ✂️ Removed duplicate title description at bottom
- 🧹 Cleaned up unused Badge component import

## Test plan
- [ ] View a droposal detail page and verify only title and back button are shown
- [ ] Verify title displays correctly with fallback logic
- [ ] Verify back button navigation works properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)