### PR TITLE
Refactor: Update create-coin page to follow standard layout patterns

### DIFF
--- a/src/app/create-coin/page.tsx
+++ b/src/app/create-coin/page.tsx
@@ -2,11 +2,11 @@
 
 import * as React from "react";
 import { useRouter } from "next/navigation";
-import { ArrowLeft, Coins, ImageIcon, Loader2, Upload, Video } from "lucide-react";
+import { Coins, ImageIcon, Loader2, Upload, Video } from "lucide-react";
 import { toast } from "sonner";
 import { useAccount } from "wagmi";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -272,163 +272,164 @@ export default function CreateCoinPage() {
   };
 
   return (
-    <div className="container max-w-4xl py-8">
-      <Button variant="ghost" size="sm" onClick={() => router.back()} className="mb-6">
-        <ArrowLeft className="mr-2 h-4 w-4" />
-        Back
-      </Button>
-
-      {isPending && (
-        <div className="mb-6 bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
-          <div className="flex items-center gap-3">
-            <Loader2 className="h-5 w-5 animate-spin text-blue-600" />
-            <div>
-              <p className="font-medium text-blue-900 dark:text-blue-100">
-                {transactionHash
-                  ? "Confirming transaction..."
-                  : mediaType === "video" 
-                    ? "Processing video and generating thumbnail..."
-                    : "Uploading to IPFS and preparing transaction..."}
-              </p>
-              <p className="text-sm text-blue-700 dark:text-blue-300 mt-1">
-                {transactionHash
-                  ? "Waiting for blockchain confirmation"
-                  : mediaType === "video"
-                    ? "Generating thumbnail from video frame, then uploading to IPFS"
-                    : "Please sign the transaction in your wallet"}
-              </p>
+    <div className="flex flex-1 flex-col py-8">
+      <div className="space-y-6">
+        {isPending && (
+          <div className="bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
+            <div className="flex items-center gap-3">
+              <Loader2 className="h-5 w-5 animate-spin text-blue-600" />
+              <div>
+                <p className="font-medium text-blue-900 dark:text-blue-100">
+                  {transactionHash
+                    ? "Confirming transaction..."
+                    : mediaType === "video"
+                      ? "Processing video and generating thumbnail..."
+                      : "Uploading to IPFS and preparing transaction..."}
+                </p>
+                <p className="text-sm text-blue-700 dark:text-blue-300 mt-1">
+                  {transactionHash
+                    ? "Waiting for blockchain confirmation"
+                    : mediaType === "video"
+                      ? "Generating thumbnail from video frame, then uploading to IPFS"
+                      : "Please sign the transaction in your wallet"}
+                </p>
+              </div>
             </div>
           </div>
-        </div>
-      )}
+        )}
 
-      {/* Video Thumbnail Selector Modal */}
-      {showThumbnailSelector && mediaFile && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <VideoThumbnailSelector
-            videoFile={mediaFile}
-            onThumbnailSelected={handleThumbnailSelected}
-            onCancel={handleThumbnailCancel}
-          />
-        </div>
-      )}
+        {/* Video Thumbnail Selector Modal */}
+        {showThumbnailSelector && mediaFile && (
+          <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+            <VideoThumbnailSelector
+              videoFile={mediaFile}
+              onThumbnailSelected={handleThumbnailSelected}
+              onCancel={handleThumbnailCancel}
+            />
+          </div>
+        )}
 
-      {createdCoinData ? (
-        /* Success Preview */
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-2xl">
-              <Coins className="h-6 w-6 text-green-600" />
-              Coin Created Successfully!
-            </CardTitle>
-            <CardDescription>
-              Your coin has been deployed on Base. Here is the summary:
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            {/* Media Preview */}
-            <div className="relative border rounded-lg overflow-hidden">
-              {createdCoinData.mediaFile.type.startsWith("image/") && (
-                <Image
-                  src={URL.createObjectURL(createdCoinData.mediaFile)}
-                  alt={createdCoinData.name}
-                  width={800}
-                  height={450}
-                  className="w-full aspect-video object-contain bg-gray-100"
-                />
-              )}
-              {createdCoinData.mediaFile.type.startsWith("video/") && (
-                <video
-                  src={URL.createObjectURL(createdCoinData.mediaFile)}
-                  controls
-                  className="w-full aspect-video object-contain bg-black"
-                />
-              )}
+        {createdCoinData ? (
+          /* Success Preview */
+          <>
+            <div className="min-w-0">
+              <h1 className="text-3xl font-bold tracking-tight mb-2">
+                Coin Created Successfully!
+              </h1>
+              <p className="text-muted-foreground">
+                Your coin has been deployed on Base. Here is the summary:
+              </p>
             </div>
 
-            {/* Coin Details */}
-            <div className="space-y-4">
-              <div>
-                <h3 className="text-2xl font-bold">{createdCoinData.name}</h3>
-                <p className="text-lg text-muted-foreground">${createdCoinData.symbol}</p>
-              </div>
-
-              {createdCoinData.description && (
-                <div>
-                  <Label>Description</Label>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    {createdCoinData.description}
-                  </p>
+            <Card>
+              <CardContent className="space-y-6 pt-6">
+                {/* Media Preview */}
+                <div className="relative border rounded-lg overflow-hidden">
+                  {createdCoinData.mediaFile.type.startsWith("image/") && (
+                    <Image
+                      src={URL.createObjectURL(createdCoinData.mediaFile)}
+                      alt={createdCoinData.name}
+                      width={800}
+                      height={450}
+                      className="w-full aspect-video object-contain bg-gray-100"
+                    />
+                  )}
+                  {createdCoinData.mediaFile.type.startsWith("video/") && (
+                    <video
+                      src={URL.createObjectURL(createdCoinData.mediaFile)}
+                      controls
+                      className="w-full aspect-video object-contain bg-black"
+                    />
+                  )}
                 </div>
-              )}
 
-              {/* Deployment Info */}
-              <div className="bg-muted rounded-lg p-4 space-y-3 text-sm">
-                <h4 className="font-semibold">Deployment Information</h4>
-
-                {createdCoinData.coinAddress && (
+                {/* Coin Details */}
+                <div className="space-y-4">
                   <div>
-                    <Label className="text-xs">Coin Address</Label>
-                    <p className="font-mono text-xs break-all">{createdCoinData.coinAddress}</p>
+                    <h3 className="text-2xl font-bold">{createdCoinData.name}</h3>
+                    <p className="text-lg text-muted-foreground">${createdCoinData.symbol}</p>
                   </div>
-                )}
 
-                <div>
-                  <Label className="text-xs">Creator Address</Label>
-                  <p className="font-mono text-xs break-all">{createdCoinData.creator}</p>
-                </div>
+                  {createdCoinData.description && (
+                    <div>
+                      <Label>Description</Label>
+                      <p className="text-sm text-muted-foreground mt-1">
+                        {createdCoinData.description}
+                      </p>
+                    </div>
+                  )}
 
-                <div>
-                  <Label className="text-xs">Content Coin Currency</Label>
-                  <p className="font-mono text-xs">{GNARS_CREATOR_COIN}</p>
-                  <p className="text-xs text-muted-foreground">Backing token for this coin</p>
-                </div>
+                  {/* Deployment Info */}
+                  <div className="bg-muted rounded-lg p-4 space-y-3 text-sm">
+                    <h4 className="font-semibold">Deployment Information</h4>
 
-                <div>
-                  <Label className="text-xs">Platform Referrer</Label>
-                  <p className="font-mono text-xs">{PLATFORM_REFERRER}</p>
-                  <p className="text-xs text-muted-foreground">Gnars DAO referrer address</p>
-                </div>
+                    {createdCoinData.coinAddress && (
+                      <div>
+                        <Label className="text-xs">Coin Address</Label>
+                        <p className="font-mono text-xs break-all">{createdCoinData.coinAddress}</p>
+                      </div>
+                    )}
 
-                {createdCoinData.transactionHash && (
-                  <div>
-                    <Label className="text-xs">Transaction Hash</Label>
-                    <p className="font-mono text-xs break-all">{createdCoinData.transactionHash}</p>
+                    <div>
+                      <Label className="text-xs">Creator Address</Label>
+                      <p className="font-mono text-xs break-all">{createdCoinData.creator}</p>
+                    </div>
+
+                    <div>
+                      <Label className="text-xs">Content Coin Currency</Label>
+                      <p className="font-mono text-xs">{GNARS_CREATOR_COIN}</p>
+                      <p className="text-xs text-muted-foreground">Backing token for this coin</p>
+                    </div>
+
+                    <div>
+                      <Label className="text-xs">Platform Referrer</Label>
+                      <p className="font-mono text-xs">{PLATFORM_REFERRER}</p>
+                      <p className="text-xs text-muted-foreground">Gnars DAO referrer address</p>
+                    </div>
+
+                    {createdCoinData.transactionHash && (
+                      <div>
+                        <Label className="text-xs">Transaction Hash</Label>
+                        <p className="font-mono text-xs break-all">
+                          {createdCoinData.transactionHash}
+                        </p>
+                      </div>
+                    )}
+
+                    <div>
+                      <Label className="text-xs">Network</Label>
+                      <p className="text-xs">Base (Chain ID: 8453)</p>
+                    </div>
                   </div>
-                )}
-
-                <div>
-                  <Label className="text-xs">Network</Label>
-                  <p className="text-xs">Base (Chain ID: 8453)</p>
                 </div>
-              </div>
+
+                {/* Actions */}
+                <div className="flex gap-3">
+                  <Button variant="outline" onClick={handleCreateAnother} className="flex-1">
+                    Create Another Coin
+                  </Button>
+                  <Button onClick={() => router.push("/")} className="flex-1">
+                    Go to Dashboard
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          </>
+        ) : (
+          /* Creation Form */
+          <>
+            <div className="min-w-0">
+              <h1 className="text-3xl font-bold tracking-tight mb-2">
+                Create a Zora Coin
+              </h1>
+              <p className="text-muted-foreground">
+                Create a new coin on Zora. Add a name, symbol, and media (image or video) for your
+                coin.
+              </p>
             </div>
 
-            {/* Actions */}
-            <div className="flex gap-3">
-              <Button variant="outline" onClick={handleCreateAnother} className="flex-1">
-                Create Another Coin
-              </Button>
-              <Button onClick={() => router.push("/")} className="flex-1">
-                Go to Dashboard
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
-      ) : (
-        /* Creation Form */
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-2xl">
-              <Coins className="h-6 w-6" />
-              Create a Zora Coin
-            </CardTitle>
-            <CardDescription>
-              Create a new coin on Zora. Add a name, symbol, and media (image or video) for your
-              coin.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
+            <Card>
+              <CardContent className="pt-6">
             <form onSubmit={handleSubmit} className="space-y-6">
               {/* Name */}
               <div className="space-y-2">
@@ -643,9 +644,11 @@ export default function CreateCoinPage() {
                 </p>
               )}
             </form>
-          </CardContent>
-        </Card>
-      )}
+              </CardContent>
+            </Card>
+          </>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

This PR updates the create-coin page to follow the standard layout patterns used across the codebase, specifically matching the auctions page structure.

## Changes

- ✅ Updated container to use `flex flex-1 flex-col py-8` layout matching auctions page
- ✅ Removed back button for cleaner navigation (consistent with other pages)
- ✅ Extracted page title and description from Card components to standalone header sections
- ✅ Applied standard title styling: `text-3xl font-bold tracking-tight mb-2`
- ✅ Removed decorative icons from titles for visual consistency
- ✅ Updated header wrapper to use `min-w-0` instead of `space-y-2`
- ✅ Now inherits `max-w-6xl` from root layout instead of overriding with `max-w-4xl`
- ✅ Cleaned up unused imports (ArrowLeft, CardHeader, CardDescription, CardTitle)

## Visual Changes

- Page now uses full standard width (max-w-6xl) instead of narrower form width
- Title and description appear as standalone section above the card
- Removed back button from top of page
- Overall layout now consistent with auctions, proposals, and treasury pages

## Test Plan

- [x] Lint passes
- [ ] Manual testing: Navigate to /create-coin page
- [ ] Verify layout matches auctions page pattern
- [ ] Test form submission flow still works correctly
- [ ] Verify responsive behavior on mobile/tablet

🤖 Generated with [Claude Code](https://claude.com/claude-code)