### PR TITLE
feat: add ENS loading indicator to all AddressDisplay variants

### DIFF
--- a/src/components/ui/address-display.tsx
+++ b/src/components/ui/address-display.tsx
@@ -116,6 +116,9 @@ export function AddressDisplay({
             ? ensData.name
             : truncateAddress(normalizedAddress, truncateLength)}
         </span>
+        {isLoading && (
+          <div className="h-2.5 w-2.5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+        )}
       </div>
     );
   }
@@ -141,6 +144,9 @@ export function AddressDisplay({
             >
               {showENS && ensData?.name ? ensData.name : "Unnamed Address"}
             </span>
+            {isLoading && (
+              <div className="h-3 w-3 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+            )}
           </div>
 
           <div className="flex items-center gap-2">
@@ -194,6 +200,9 @@ export function AddressDisplay({
               >
                 {showENS && ensData?.name ? ensData.name : "Unnamed Address"}
               </span>
+              {isLoading && (
+                <div className="h-3 w-3 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+              )}
             </div>
 
             <code className="text-sm text-muted-foreground font-mono">


### PR DESCRIPTION
## Summary
- Add spinning loading indicator to compact, detailed, and card variants of AddressDisplay
- Previously only the default variant showed a spinner during ENS resolution
- Compact variant uses a smaller spinner (h-2.5 w-2.5) to match its scale

Closes #32

## Test plan
- [ ] Verify spinner appears in compact variant while ENS resolves
- [ ] Verify spinner appears in detailed variant while ENS resolves
- [ ] Verify spinner appears in card variant while ENS resolves
- [ ] Verify spinner disappears once ENS name is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)