### PR TITLE
feat: add error.tsx boundaries to proposals, members, and blogs

### DIFF
--- a/src/app/blogs/error.tsx
+++ b/src/app/blogs/error.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[50vh] gap-4 px-4">
+      <AlertTriangle className="h-12 w-12 text-destructive" />
+      <h2 className="text-xl font-semibold">Something went wrong</h2>
+      <p className="text-muted-foreground text-center max-w-md">
+        {error.message ||
+          "An unexpected error occurred while loading blog posts."}
+      </p>
+      <Button onClick={reset} variant="outline">
+        Try again
+      </Button>
+    </div>
+  );
+}

--- a/src/app/members/error.tsx
+++ b/src/app/members/error.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[50vh] gap-4 px-4">
+      <AlertTriangle className="h-12 w-12 text-destructive" />
+      <h2 className="text-xl font-semibold">Something went wrong</h2>
+      <p className="text-muted-foreground text-center max-w-md">
+        {error.message ||
+          "An unexpected error occurred while loading members."}
+      </p>
+      <Button onClick={reset} variant="outline">
+        Try again
+      </Button>
+    </div>
+  );
+}

--- a/src/app/proposals/error.tsx
+++ b/src/app/proposals/error.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[50vh] gap-4 px-4">
+      <AlertTriangle className="h-12 w-12 text-destructive" />
+      <h2 className="text-xl font-semibold">Something went wrong</h2>
+      <p className="text-muted-foreground text-center max-w-md">
+        {error.message ||
+          "An unexpected error occurred while loading proposals."}
+      </p>
+      <Button onClick={reset} variant="outline">
+        Try again
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `error.tsx` error boundary components to `/proposals`, `/members`, and `/blogs` routes
- Each shows a user-friendly error message with retry button using Shadcn Button and lucide-react AlertTriangle icon
- Follows Next.js App Router error handling best practices

Closes #34

## Test plan
- [ ] Verify each error boundary renders correctly by triggering errors in proposals, members, and blogs routes
- [ ] Confirm "Try again" button calls reset and re-renders the route
- [ ] Check responsive layout on mobile viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)