### PR TITLE
Feat: Dark yellow hyperlinks in proposals

### DIFF
--- a/src/components/common/Markdown.tsx
+++ b/src/components/common/Markdown.tsx
@@ -69,7 +69,7 @@ export function Markdown({ children, className }: MarkdownProps) {
             return (
               <a
                 className={cn(
-                  "underline decoration-muted-foreground hover:text-foreground",
+                  "text-amber-400 underline decoration-amber-400/50 hover:decoration-amber-400",
                   className,
                 )}
                 {...props}


### PR DESCRIPTION
## Summary
- Style markdown links in proposal descriptions with the Gnars branding yellow color (amber-400 / `#fbbf24`)
- Links display with a subtle semi-transparent underline that becomes fully opaque on hover
- Applies globally to all markdown-rendered content via the shared `Markdown` component

## Test plan
- [ ] Open a proposal that contains links in its description
- [ ] Verify links appear in dark yellow (#fbbf24) color
- [ ] Verify underline becomes more visible on hover
- [ ] Check appearance in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)