### PR TITLE
Feat: Global Noggles copy-to-clipboard footer

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { DaoHeader } from "@/components/layout/DaoHeader";
 import Providers from "@/components/layout/Providers";
 import { ScrollToTop } from "@/components/layout/ScrollToTop";
 import { MiniAppReady } from "@/components/miniapp/MiniAppReady";
+import { NogglesCopyFooter } from "@/components/home/NogglesCopyFooter";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { MINIAPP_EMBED_CONFIG } from "@/lib/miniapp-config";
@@ -70,6 +71,7 @@ export default function RootLayout({
               <ScrollToTop />
               <DaoHeader />
               <main className="max-w-6xl mx-auto px-4">{children}</main>
+              <NogglesCopyFooter />
               <Toaster />
             </TooltipProvider>
           </Providers>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,6 @@ import { AuctionSpotlight } from "@/components/hero/AuctionSpotlight";
 import { ActivityFeedSection } from "@/components/home/ActivityFeedSection";
 import { AnimatedDescription } from "@/components/home/AnimatedDescription";
 import { HeroStatsValues } from "@/components/home/HeroStatsValues";
-import { NogglesCopyFooter } from "@/components/home/NogglesCopyFooter";
 import { HomeStaticContent } from "@/components/home/HomeStaticContent";
 import { RecentProposalsSection } from "@/components/home/RecentProposalsSection";
 import {
@@ -122,7 +121,6 @@ export default function Home() {
           <ContractsList />
         </section>
 
-        <NogglesCopyFooter />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Move `NogglesCopyFooter` from homepage (`page.tsx`) to root layout (`layout.tsx`) so the "made with ⌐◨-◨" tap-to-copy element appears on every page site-wide
- Remove the component from the homepage to avoid duplication

## Test plan
- [ ] Verify the Noggles footer appears on the homepage
- [ ] Verify it appears on other pages (e.g. /proposals, /about, /auctions)
- [ ] Click/tap the footer and confirm the Noggles ASCII is copied to clipboard
- [ ] Verify no duplicate footer on the homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)