### PR TITLE
fix: proposal 404 on RPC rate limit

### DIFF
--- a/src/app/proposals/[chain]/[id]/page.tsx
+++ b/src/app/proposals/[chain]/[id]/page.tsx
@@ -32,13 +32,10 @@ async function fetchProposalData(chain: string, id: string): Promise<MultiChainP
   if (!VALID_CHAINS.includes(chain as ProposalSource)) {
     return null;
   }
-  
-  try {
-    return await getMultiChainProposal(id, chain as ProposalSource);
-  } catch (error) {
-    console.error("Failed to fetch proposal:", error);
-    return null;
-  }
+
+  // Let errors propagate — they'll be caught by error.tsx with a retry button.
+  // Only return null for genuinely missing proposals (not RPC/network failures).
+  return await getMultiChainProposal(id, chain as ProposalSource);
 }
 
 interface ProposalPageProps {

--- a/src/lib/rpc.ts
+++ b/src/lib/rpc.ts
@@ -1,0 +1,31 @@
+import { createPublicClient, fallback, http } from "viem";
+import { base } from "viem/chains";
+
+const BASE_RPC_URLS = [
+  ...(process.env.NEXT_PUBLIC_BASE_RPC_URL ? [process.env.NEXT_PUBLIC_BASE_RPC_URL] : []),
+  "https://base.api.pocket.network",
+  "https://1rpc.io/base",
+  "https://base.meowrpc.com",
+  "https://base-rpc.publicnode.com",
+  "https://api.zan.top/base-mainnet",
+  "https://base.llamarpc.com",
+  "https://mainnet.base.org",
+];
+
+export const serverPublicClient = createPublicClient({
+  chain: base,
+  transport: fallback(
+    BASE_RPC_URLS.map((url) =>
+      http(url, {
+        timeout: 8_000,
+        retryCount: 1,
+        retryDelay: 500,
+      }),
+    ),
+    {
+      rank: false,
+      retryCount: BASE_RPC_URLS.length,
+      retryDelay: 100,
+    },
+  ),
+});

--- a/src/services/proposals.ts
+++ b/src/services/proposals.ts
@@ -1,13 +1,13 @@
 import { cache } from "react";
 import {
-  formatAndFetchState,
-  getProposals,
   SubgraphSDK,
+  governorAbi,
   type Proposal_Filter,
   type Proposal as SdkProposal,
 } from "@buildeross/sdk";
 import type { Proposal } from "@/components/proposals/types";
 import { CHAIN, GNARS_ADDRESSES, SUBGRAPH } from "@/lib/config";
+import { serverPublicClient } from "@/lib/rpc";
 import { getProposalStatus } from "@/lib/schemas/proposals";
 
 /** Fetch vote timestamps from subgraph (the SDK fragment omits this field) */
@@ -40,6 +40,38 @@ async function fetchVoteTimestamps(
   } catch {
     return {};
   }
+}
+
+/**
+ * Fetch proposal state from the governor contract using our resilient RPC client.
+ * Replaces the SDK's internal client which only uses mainnet.base.org.
+ */
+async function fetchProposalState(
+  governorAddress: string,
+  proposalId: string,
+): Promise<number> {
+  return serverPublicClient.readContract({
+    address: governorAddress as `0x${string}`,
+    abi: governorAbi,
+    functionName: "state",
+    args: [proposalId as `0x${string}`],
+  }) as Promise<number>;
+}
+
+/**
+ * Format a raw subgraph proposal with on-chain state fetched via our resilient client.
+ * Replaces SDK's formatAndFetchState.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function formatWithState(raw: any): Promise<SdkProposal> {
+  const governorAddress = raw.dao?.governorAddress ?? GNARS_ADDRESSES.governor;
+  const state = await fetchProposalState(governorAddress, raw.proposalId);
+
+  return {
+    ...raw,
+    calldatas: raw.calldatas ? raw.calldatas.split(":") : [],
+    state,
+  } as SdkProposal;
 }
 
 // Minimal transformation: SDK Proposal → App Proposal
@@ -104,69 +136,54 @@ function transformProposal(p: SdkProposal): Proposal {
 }
 
 export const listProposals = cache(async (limit = 200, page = 0): Promise<Proposal[]> => {
-  const { proposals: sdkProposals } = await getProposals(
-    CHAIN.id,
-    GNARS_ADDRESSES.token,
-    limit,
-    page,
-  );
+  const data = await SubgraphSDK.connect(CHAIN.id).proposals({
+    where: { dao: GNARS_ADDRESSES.token.toLowerCase() },
+    first: limit,
+    skip: page * limit,
+  });
 
-  return ((sdkProposals as SdkProposal[] | undefined) ?? []).map(transformProposal);
+  const sdkProposals = data.proposals ?? [];
+
+  return Promise.all(
+    sdkProposals.map((raw) => formatWithState(raw).then(transformProposal)),
+  );
 });
 
 export const getProposalByIdOrNumber = cache(
   async (idOrNumber: string): Promise<Proposal | null> => {
-    try {
-      const isHexId = idOrNumber.startsWith("0x");
+    const isHexId = idOrNumber.startsWith("0x");
 
-      // Build the where filter for direct subgraph query
-      const where: Proposal_Filter = isHexId
-        ? {
-            proposalId: idOrNumber.toLowerCase(),
-          }
-        : {
-            proposalNumber: Number.parseInt(idOrNumber, 10),
-            dao: GNARS_ADDRESSES.token.toLowerCase(),
-          };
+    const where: Proposal_Filter = isHexId
+      ? { proposalId: idOrNumber.toLowerCase() }
+      : {
+          proposalNumber: Number.parseInt(idOrNumber, 10),
+          dao: GNARS_ADDRESSES.token.toLowerCase(),
+        };
 
-      // Direct query using SubgraphSDK (same pattern as Nouns Builder)
-      const data = await SubgraphSDK.connect(CHAIN.id).proposals({
-        where,
-        first: 1,
-      });
+    const data = await SubgraphSDK.connect(CHAIN.id).proposals({
+      where,
+      first: 1,
+    });
 
-      if (!data.proposals || data.proposals.length === 0) {
-        return null;
-      }
-
-      // Use formatAndFetchState to get proposal state from contract
-      const sdkProposal = await formatAndFetchState(CHAIN.id, data.proposals[0]);
-
-      if (!sdkProposal) {
-        return null;
-      }
-
-      const proposal = transformProposal(sdkProposal);
-
-      // Supplement votes with timestamps (SDK fragment omits this field)
-      // and sort newest first
-      if (proposal.votes && proposal.votes.length > 0) {
-        const timestampMap = await fetchVoteTimestamps(proposal.proposalId);
-        proposal.votes = proposal.votes
-          .map((v) => ({
-            ...v,
-            timestamp: timestampMap[v.voter.toLowerCase()] ?? v.timestamp,
-          }))
-          .sort((a, b) => (b.timestamp ?? 0) - (a.timestamp ?? 0));
-      }
-
-      return proposal;
-    } catch (err) {
-      console.error("[proposals:getProposalByIdOrNumber] error", {
-        idOrNumber,
-        error: err instanceof Error ? { message: err.message, stack: err.stack } : String(err),
-      });
-      return null;
+    if (!data.proposals || data.proposals.length === 0) {
+      return null; // Genuinely not found
     }
+
+    // RPC errors will propagate (not swallowed) so callers can distinguish
+    // "not found" (null) from "transient failure" (thrown error)
+    const sdkProposal = await formatWithState(data.proposals[0]);
+    const proposal = transformProposal(sdkProposal);
+
+    if (proposal.votes && proposal.votes.length > 0) {
+      const timestampMap = await fetchVoteTimestamps(proposal.proposalId);
+      proposal.votes = proposal.votes
+        .map((v) => ({
+          ...v,
+          timestamp: timestampMap[v.voter.toLowerCase()] ?? v.timestamp,
+        }))
+        .sort((a, b) => (b.timestamp ?? 0) - (a.timestamp ?? 0));
+    }
+
+    return proposal;
   },
 );


### PR DESCRIPTION
## Summary

- The SDK's `formatAndFetchState` uses an internal RPC client that only falls back to `mainnet.base.org`. When that endpoint is rate-limited (HTTP 429), the error was caught and returned as `null`, which the proposal page interpreted as "not found" → 404.
- Added `src/lib/rpc.ts`: a server-side viem `createPublicClient` with a `fallback` transport over 8 Base RPC endpoints (same list as the client-side wagmi config).
- Replaced `formatAndFetchState` / `getProposals` with `SubgraphSDK` + a custom `formatWithState` that reads on-chain proposal state via the resilient client.
- Removed the `try/catch` in `fetchProposalData` (proposal page) so transient RPC errors propagate to `error.tsx` (which has a "Try again" button) instead of silently rendering a false 404.

## Test plan

- [ ] Visit a proposal page while mainnet.base.org is unavailable — should now load via fallback RPCs
- [ ] Visit a genuinely non-existent proposal ID — should still return 404
- [ ] Trigger a transient RPC error — should surface error boundary with retry, not 404
- [ ] `npx tsc --noEmit` passes with no errors
- [ ] ESLint reports no warnings or errors on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)