### PR TITLE
fix(tv): NFT-primary qualification, expanded scan, better video detection

### DIFF
--- a/src/app/api/tv/feed/route.ts
+++ b/src/app/api/tv/feed/route.ts
@@ -168,6 +168,15 @@ function computeFarcasterBoost(followerCount?: number): number {
   return (capped / FARCASTER_FOLLOWER_BOOST_CAP) * FARCASTER_FOLLOWER_BOOST_MAX_MS;
 }
 
+const COIN_BALANCE_BOOST_MAX_MS = 1000 * 60 * 60 * 3; // 3 hours
+const COIN_BALANCE_BOOST_CAP = 1_000_000;
+
+function computeCoinBalanceBoost(coinBalance?: number): number {
+  if (!coinBalance || coinBalance <= 0) return 0;
+  const capped = Math.min(coinBalance, COIN_BALANCE_BOOST_CAP);
+  return (capped / COIN_BALANCE_BOOST_CAP) * COIN_BALANCE_BOOST_MAX_MS;
+}
+
 /**
  * Fetch content from creators with concurrency limit
  */
@@ -202,6 +211,7 @@ async function fetchCreatorContent(
 
           const item = mapCoinToTVItem(coin, creator.handle);
           if (item) {
+            item.creatorCoinBalance = creator.coinBalance;
             loadedAddresses.add(addr);
             allItems.push(item);
           }
@@ -433,8 +443,14 @@ export async function GET() {
     allItems.sort((a, b) => {
       const dateA = a.createdAt ? new Date(a.createdAt).getTime() : 0;
       const dateB = b.createdAt ? new Date(b.createdAt).getTime() : 0;
-      const boostedA = dateA + computeFarcasterBoost(a.farcasterFollowerCount);
-      const boostedB = dateB + computeFarcasterBoost(b.farcasterFollowerCount);
+      const boostedA =
+        dateA +
+        computeFarcasterBoost(a.farcasterFollowerCount) +
+        computeCoinBalanceBoost(a.creatorCoinBalance);
+      const boostedB =
+        dateB +
+        computeFarcasterBoost(b.farcasterFollowerCount) +
+        computeCoinBalanceBoost(b.creatorCoinBalance);
       return boostedB - boostedA;
     });
 

--- a/src/app/api/tv/feed/route.ts
+++ b/src/app/api/tv/feed/route.ts
@@ -86,10 +86,36 @@ async function runWithConcurrency<T, R>(
   return results;
 }
 
+const VIDEO_EXTENSIONS = [".mp4", ".webm", ".mov"];
+const IMAGE_EXTENSIONS = [".png", ".jpg", ".jpeg", ".gif", ".webp", ".avif"];
+
+function normalizeMediaUrl(url: string) {
+  return url.toLowerCase().split("?")[0];
+}
+
+async function isVideoUrl(mediaUrl: string): Promise<boolean> {
+  const normalized = normalizeMediaUrl(mediaUrl);
+
+  if (VIDEO_EXTENSIONS.some((ext) => normalized.endsWith(ext))) return true;
+  if (IMAGE_EXTENSIONS.some((ext) => normalized.endsWith(ext))) return false;
+
+  try {
+    const response = await fetch(mediaUrl, { method: "HEAD" });
+    const contentType = response.headers.get("content-type") || "";
+    if (contentType.startsWith("video/")) return true;
+    if (contentType.startsWith("image/")) return false;
+  } catch (error) {
+    console.warn("[api/tv] Failed to detect media type:", error);
+  }
+
+  return false;
+}
+
 /**
- * Extract video URL from coin media
+ * Extract video URL from coin media.
+ * Falls back to HEAD request for ambiguous URIs.
  */
-function extractVideoUrl(coin: CoinNode): string | undefined {
+async function extractVideoUrl(coin: CoinNode): Promise<string | undefined> {
   const media = coin.mediaContent || coin.media;
   if (!media) return undefined;
 
@@ -97,18 +123,32 @@ function extractVideoUrl(coin: CoinNode): string | undefined {
   if (mimeType.startsWith("video/")) {
     return media.originalUri || media.animationUrl || media.videoUrl;
   }
+  if (mimeType.startsWith("image/")) {
+    return undefined;
+  }
 
   const uri = media.originalUri || media.animationUrl || media.videoUrl;
-  if (uri) {
-    const lower = uri.toLowerCase();
-    if (
-      lower.includes(".mp4") ||
-      lower.includes(".webm") ||
-      lower.includes(".mov") ||
-      lower.includes("video")
-    ) {
-      return uri;
-    }
+  if (!uri) return undefined;
+
+  const lower = uri.toLowerCase();
+  // Fast path: recognizable extension
+  if (
+    lower.includes(".mp4") ||
+    lower.includes(".webm") ||
+    lower.includes(".mov") ||
+    lower.includes("video")
+  ) {
+    return uri;
+  }
+
+  // Known image extensions — skip HEAD request
+  if (IMAGE_EXTENSIONS.some((ext) => normalizeMediaUrl(uri).endsWith(ext))) {
+    return undefined;
+  }
+
+  // Ambiguous URI — use HEAD request to detect content type
+  if (await isVideoUrl(uri)) {
+    return uri;
   }
 
   return undefined;
@@ -133,11 +173,13 @@ function extractImageUrl(coin: CoinNode): string | undefined {
 /**
  * Map coin to TV item
  */
-function mapCoinToTVItem(coin: CoinNode, creatorHandle: string): TVItemData | null {
-  const videoUrl = extractVideoUrl(coin);
+async function mapCoinToTVItem(
+  coin: CoinNode,
+  creatorHandle: string,
+): Promise<TVItemData | null> {
+  const videoUrl = await extractVideoUrl(coin);
   const imageUrl = extractImageUrl(coin);
 
-  // Skip if no media
   if (!videoUrl && !imageUrl) return null;
 
   const address = coin.address || coin.contract;
@@ -209,7 +251,7 @@ async function fetchCreatorContent(
           const addr = (coin.address || coin.contract)?.toLowerCase();
           if (!addr || loadedAddresses.has(addr)) continue;
 
-          const item = mapCoinToTVItem(coin, creator.handle);
+          const item = await mapCoinToTVItem(coin, creator.handle);
           if (item) {
             item.creatorCoinBalance = creator.coinBalance;
             loadedAddresses.add(addr);
@@ -262,7 +304,7 @@ async function fetchPairedCoins(loadedAddresses: Set<string>): Promise<TVItemDat
 
           const creatorHandle = coin?.creatorProfile?.handle || pairedCoin.coin.slice(0, 10);
 
-          const item = mapCoinToTVItem(coin, creatorHandle);
+          const item = await mapCoinToTVItem(coin, creatorHandle);
 
           if (item) {
             item.poolCurrencyTokenAddress = GNARS_COIN_ADDRESS;
@@ -298,24 +340,33 @@ async function fetchGnarsProfileContent(loadedAddresses: Set<string>): Promise<T
 
     const edges = (response?.data?.profile?.createdCoins?.edges || []) as CoinEdge[];
 
-    const items = edges
-      .map((edge) => {
-        const node = edge?.node;
-        if (!node) return null;
+    // Build coin list first, then resolve media concurrently
+    const coins: Array<{ coin: CoinNode; addr: string }> = [];
+    for (const edge of edges) {
+      const node = edge?.node;
+      if (!node) continue;
 
-        const coin = ("coin" in node ? node.coin : node) as CoinNode | undefined;
-        if (!coin) return null;
+      const coin = ("coin" in node ? node.coin : node) as CoinNode | undefined;
+      if (!coin) continue;
 
-        const addr = (coin.address || coin.contract)?.toLowerCase();
-        if (!addr || loadedAddresses.has(addr)) return null;
+      const addr = (coin.address || coin.contract)?.toLowerCase();
+      if (!addr || loadedAddresses.has(addr)) continue;
 
-        const item = mapCoinToTVItem(coin, GNARS_PROFILE_HANDLE);
+      coins.push({ coin, addr });
+    }
+
+    const items: TVItemData[] = [];
+    await runWithConcurrency(
+      coins,
+      async ({ coin, addr }) => {
+        const item = await mapCoinToTVItem(coin, GNARS_PROFILE_HANDLE);
         if (item) {
           loadedAddresses.add(addr);
+          items.push(item);
         }
-        return item;
-      })
-      .filter((item): item is TVItemData => item !== null);
+      },
+      MAX_CONCURRENT_COIN_FETCHES,
+    );
 
     console.log(`[api/tv] Loaded ${items.length} from Gnars profile`);
     return items;
@@ -323,31 +374,6 @@ async function fetchGnarsProfileContent(loadedAddresses: Set<string>): Promise<T
     console.warn("[api/tv] Failed to fetch Gnars profile:", err);
     return [];
   }
-}
-
-const VIDEO_EXTENSIONS = [".mp4", ".webm", ".mov"];
-const IMAGE_EXTENSIONS = [".png", ".jpg", ".jpeg", ".gif", ".webp", ".avif"];
-
-function normalizeMediaUrl(url: string) {
-  return url.toLowerCase().split("?")[0];
-}
-
-async function isVideoUrl(mediaUrl: string): Promise<boolean> {
-  const normalized = normalizeMediaUrl(mediaUrl);
-
-  if (VIDEO_EXTENSIONS.some((ext) => normalized.endsWith(ext))) return true;
-  if (IMAGE_EXTENSIONS.some((ext) => normalized.endsWith(ext))) return false;
-
-  try {
-    const response = await fetch(mediaUrl, { method: "HEAD" });
-    const contentType = response.headers.get("content-type") || "";
-    if (contentType.startsWith("video/")) return true;
-    if (contentType.startsWith("image/")) return false;
-  } catch (error) {
-    console.warn("[api/tv] Failed to detect media type:", error);
-  }
-
-  return false;
 }
 
 /**

--- a/src/services/farcaster-tv-aggregator.ts
+++ b/src/services/farcaster-tv-aggregator.ts
@@ -449,9 +449,25 @@ async function fetchProfileWallets(candidates: CandidateCreator[]): Promise<Cand
 }
 
 async function fetchQualifiedCreators(): Promise<QualifiedCreator[]> {
-  const candidates = await fetchCandidateCreators();
-  const candidatesWithWallets = await fetchProfileWallets(candidates);
+  // Path A: Coin holder discovery (Zora SDK)
+  const coinCandidates = await fetchCandidateCreators();
 
+  // Merge & dedup — coin candidates take priority (they have coin balance data)
+  const seenHandles = new Set<string>(coinCandidates.map((c) => c.handle));
+
+  // Path B: NFT holder discovery (Builder DAO subgraph)
+  const nftCandidates = await fetchNftHolderCandidates(seenHandles);
+
+  const allCandidates = [...coinCandidates, ...nftCandidates];
+
+  console.log(
+    `[farcaster-tv] Candidates: ${coinCandidates.length} from coin holders, ${nftCandidates.length} from NFT holders`,
+  );
+
+  // Resolve wallets for all candidates (coin candidates may already have wallets from prior step)
+  const candidatesWithWallets = await fetchProfileWallets(allCandidates);
+
+  // Batch check NFT balances across all wallets
   const allWallets = new Set<string>();
   for (const candidate of candidatesWithWallets) {
     for (const wallet of candidate.wallets) {
@@ -461,6 +477,7 @@ async function fetchQualifiedCreators(): Promise<QualifiedCreator[]> {
 
   const nftBalances = await batchCheckNftBalances(Array.from(allWallets));
 
+  // Qualify: NFT ≥ 1 is the only gate
   const qualifiedCreators: QualifiedCreator[] = [];
 
   for (const candidate of candidatesWithWallets) {
@@ -489,16 +506,6 @@ async function fetchQualifiedCreators(): Promise<QualifiedCreator[]> {
       nftBalance: creator.nftBalance,
     });
   }
-
-  console.log(
-    `[farcaster-tv] Qualified creators (${qualifiedCreators.length}):`,
-    qualifiedCreators.map((creator) => ({
-      handle: creator.handle,
-      wallets: creator.wallets,
-      coinBalance: creator.coinBalance,
-      nftBalance: creator.nftBalance,
-    })),
-  );
 
   return qualifiedCreators;
 }

--- a/src/services/farcaster-tv-aggregator.ts
+++ b/src/services/farcaster-tv-aggregator.ts
@@ -5,6 +5,7 @@ import { unstable_cache } from "next/cache";
 import { getCoin, getCoinHolders, getProfile } from "@zoralabs/coins-sdk";
 import { createPublicClient, http, parseAbi } from "viem";
 import { base } from "viem/chains";
+import { subgraphQuery } from "@/lib/subgraph";
 import {
   assertNeynarApiKey,
   fetchFarcasterProfilesByAddress,
@@ -326,6 +327,88 @@ async function fetchCandidateCreators(): Promise<CandidateCreator[]> {
       break;
     }
   }
+
+  return candidates;
+}
+
+const MAX_NFT_HOLDER_CANDIDATES = 100;
+
+/**
+ * Discover creators by Gnars NFT ownership via Builder DAO subgraph.
+ * Resolves NFT holder wallets to Zora profiles.
+ */
+async function fetchNftHolderCandidates(
+  excludeHandles: Set<string>,
+): Promise<CandidateCreator[]> {
+  const dao = GNARS_NFT_ADDRESS.toLowerCase();
+  const PAGE_SIZE = 100;
+
+  // Query Builder DAO subgraph for top NFT holders
+  const query = /* GraphQL */ `
+    query TopNftHolders($dao: ID!, $first: Int!) {
+      daotokenOwners(
+        where: { dao: $dao }
+        orderBy: daoTokenCount
+        orderDirection: desc
+        first: $first
+      ) {
+        owner
+        daoTokenCount
+      }
+    }
+  `;
+
+  let holders: Array<{ owner: string; daoTokenCount: number }> = [];
+  try {
+    const result = await subgraphQuery<{
+      daotokenOwners: Array<{ owner: string; daoTokenCount: number }>;
+    }>(query, { dao, first: PAGE_SIZE });
+    holders = result.daotokenOwners || [];
+  } catch (err) {
+    console.warn("[farcaster-tv] Failed to fetch NFT holders from subgraph:", err);
+    return [];
+  }
+
+  console.log(`[farcaster-tv] NFT holder candidates from subgraph: ${holders.length}`);
+
+  // Resolve wallets to Zora profiles
+  const candidates: CandidateCreator[] = [];
+
+  await runWithConcurrency(
+    holders.slice(0, MAX_NFT_HOLDER_CANDIDATES),
+    async (holder) => {
+      try {
+        const profileResult = await getProfile({ identifier: holder.owner });
+        const profile = profileResult?.data?.profile;
+        if (!profile) return;
+
+        const handle = (profile as { handle?: string }).handle;
+        if (!handle || excludeHandles.has(handle)) return;
+
+        const avatarRaw = profile as {
+          avatar?: { previewImage?: { medium?: string; small?: string } };
+        };
+        const avatarUrl =
+          avatarRaw.avatar?.previewImage?.medium ||
+          avatarRaw.avatar?.previewImage?.small ||
+          null;
+
+        candidates.push({
+          handle,
+          avatarUrl,
+          coinBalance: 0, // NFT-discovered, no coin balance known yet
+          wallets: [holder.owner.toLowerCase()],
+        });
+      } catch {
+        // Skip wallet if profile resolution fails
+      }
+    },
+    MAX_CONCURRENT_PROFILE_FETCHES,
+  );
+
+  console.log(
+    `[farcaster-tv] NFT holder candidates with Zora profiles: ${candidates.length}`,
+  );
 
   return candidates;
 }

--- a/src/services/farcaster-tv-aggregator.ts
+++ b/src/services/farcaster-tv-aggregator.ts
@@ -76,6 +76,7 @@ export interface TVItemData {
   farcasterUsername?: string;
   farcasterFollowerCount?: number;
   farcasterType?: "coin" | "nft";
+  creatorCoinBalance?: number;
 }
 
 export interface FarcasterTVData {

--- a/src/services/farcaster-tv-aggregator.ts
+++ b/src/services/farcaster-tv-aggregator.ts
@@ -20,7 +20,6 @@ import {
 const GNARS_COIN_ADDRESS = "0x0cf0c3b75d522290d7d12c74d7f1f0cc47ccb23b";
 const GNARS_NFT_ADDRESS = "0x880fb3cf5c6cc2d7dfc13a993e839a9411200c17";
 
-const MIN_COIN_BALANCE = 300_000;
 const MIN_NFT_BALANCE = 1;
 
 const MAX_CONCURRENT_PROFILE_FETCHES = 10;
@@ -281,7 +280,7 @@ async function fetchCandidateCreators(): Promise<CandidateCreator[]> {
   let cursor: string | undefined;
   let page = 1;
 
-  while (page <= 5) {
+  while (page <= 10) {
     try {
       const result = await getCoinHolders({
         address: GNARS_COIN_ADDRESS as `0x${string}`,
@@ -307,8 +306,6 @@ async function fetchCandidateCreators(): Promise<CandidateCreator[]> {
 
         const rawBalance = node.balance || "0";
         const balanceNum = Number(BigInt(rawBalance)) / 1e18;
-
-        if (balanceNum < MIN_COIN_BALANCE) continue;
 
         const avatarUrl =
           profile?.avatar?.previewImage?.medium || profile?.avatar?.previewImage?.small || null;

--- a/src/services/farcaster-tv-aggregator.ts
+++ b/src/services/farcaster-tv-aggregator.ts
@@ -332,7 +332,7 @@ async function fetchCandidateCreators(): Promise<CandidateCreator[]> {
   return candidates;
 }
 
-const MAX_NFT_HOLDER_CANDIDATES = 100;
+const MAX_NFT_HOLDER_CANDIDATES = 200;
 
 /**
  * Discover creators by Gnars NFT ownership via Builder DAO subgraph.
@@ -342,7 +342,7 @@ async function fetchNftHolderCandidates(
   excludeHandles: Set<string>,
 ): Promise<CandidateCreator[]> {
   const dao = GNARS_NFT_ADDRESS.toLowerCase();
-  const PAGE_SIZE = 100;
+  const PAGE_SIZE = 200;
 
   // Query Builder DAO subgraph for top NFT holders
   const query = /* GraphQL */ `


### PR DESCRIPTION
## Summary
- **NFT-primary qualification**: Creators now qualify with ≥1 Gnars NFT instead of requiring ≥300k $GNARS coins AND ≥1 NFT. This surfaces content from active NFT holders like nogenta (9 NFTs) who were previously invisible.
- **Dual discovery**: Added NFT holder discovery via Builder DAO subgraph (top 100 holders) alongside existing $GNARS coin holder scan (now expanded from 250→500 holders).
- **$GNARS coin balance as ranking boost**: Instead of being a hard gate, coin holdings now boost content up to +3 hours in the feed sort (similar to Farcaster follower boost).
- **Video detection**: Added HEAD request fallback for ambiguous media URIs that lack file extensions or mimeType metadata.

## What was wrong
The TV algo required creators to hold ≥300k $GNARS coins AND ≥1 Gnars NFT. Many active community members (like nogenta with 9 NFTs, skatehacker/vlad with 135+ NFTs) hold NFTs but zero $GNARS coins, making them completely invisible to the feed.

## Changes
| File | What |
|------|------|
| `src/services/farcaster-tv-aggregator.ts` | Remove coin balance gate, add `fetchNftHolderCandidates()` via subgraph, merge dual discovery paths, add `creatorCoinBalance` to `TVItemData` |
| `src/app/api/tv/feed/route.ts` | Add `computeCoinBalanceBoost()`, async `extractVideoUrl` with HEAD fallback, update sorting |

## Test plan
- [ ] `pnpm tsc --noEmit` passes (verified)
- [ ] `pnpm lint` — no new errors in modified files (verified)
- [ ] Smoke test `/api/tv/feed` — check that nogenta appears in creators list
- [ ] Verify video items from previously-invisible creators now surface
- [ ] Confirm existing feed items (paired coins, gnars profile, droposals) still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)