### PR TITLE
Fix bid component: smart refresh + comment layout

### DIFF
--- a/src/components/auction/BidItem.tsx
+++ b/src/components/auction/BidItem.tsx
@@ -2,7 +2,6 @@
 "use client";
 
 import { formatDistanceToNowStrict } from "date-fns";
-import { MessageSquare } from "lucide-react";
 import { formatEther } from "viem";
 import { AddressDisplay } from "@/components/ui/address-display";
 import { cn } from "@/lib/utils";
@@ -46,17 +45,17 @@ export function BidItem({ bidder, amount, bidTime, comment, isNew }: BidItemProp
         </span>
       </div>
 
-      {comment && (
-        <div className="mt-2 flex items-start gap-1.5">
-          <MessageSquare className="mt-0.5 h-3 w-3 shrink-0 text-indigo-400" />
-          <p className="rounded border-l-2 border-indigo-500/50 bg-indigo-500/5 px-2 py-1 text-xs text-indigo-300">
-            {comment.length > 140 ? `${comment.slice(0, 140)}…` : comment}
+      <div className="mt-1.5 flex items-center justify-between gap-2">
+        {comment ? (
+          <p className="flex-1 truncate text-xs italic text-muted-foreground">
+            &ldquo;{comment.length > 140 ? `${comment.slice(0, 140)}…` : comment}&rdquo;
           </p>
-        </div>
-      )}
-
-      <div className="mt-1.5 text-right text-[10px] text-muted-foreground">
-        {timeAgo}
+        ) : (
+          <span />
+        )}
+        <span className="shrink-0 text-[10px] text-muted-foreground">
+          {timeAgo}
+        </span>
       </div>
     </div>
   );

--- a/src/components/hero/AuctionSpotlight.tsx
+++ b/src/components/hero/AuctionSpotlight.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Clock, ChevronDown, ChevronRight, MessageSquare } from "lucide-react";
 import { formatEther, parseEther, zeroAddress, encodeFunctionData, concat, toHex } from "viem";
 import { base } from "wagmi/chains";
 import { useDaoAuction } from "@buildeross/hooks";
 import { useAccount, useReadContract, useSimulateContract, useWriteContract, useWaitForTransactionReceipt, useSwitchChain, useSendTransaction } from "wagmi";
+import { useQueryClient } from "@tanstack/react-query";
 import { GnarImageTile } from "@/components/auctions/GnarImageTile";
 import { AddressDisplay } from "@/components/ui/address-display";
 import { Badge } from "@/components/ui/badge";
@@ -26,11 +27,17 @@ import { BidHistoryModal } from "@/components/auction/BidHistoryModal";
 export function AuctionSpotlight() {
   const { address, isConnected, chain } = useAccount();
   const { switchChainAsync } = useSwitchChain();
+  const queryClient = useQueryClient();
   const { highestBid, highestBidder, endTime, startTime, tokenId, tokenUri } = useDaoAuction({
     collectionAddress: DAO_ADDRESSES.token,
     auctionAddress: DAO_ADDRESSES.auction,
     chainId: CHAIN.id,
   });
+
+  // Invalidate all wagmi contract reads to refresh auction data without page reload
+  const invalidateAuctionData = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ["readContract"] });
+  }, [queryClient]);
 
   // Read reserve price from auction contract
   const { data: reservePriceWei } = useReadContract({
@@ -45,6 +52,7 @@ export function AuctionSpotlight() {
   const [isSettling, setIsSettling] = useState(false);
   const [settleTxHash, setSettleTxHash] = useState<`0x${string}` | undefined>();
   const [isBidding, setIsBidding] = useState(false);
+  const [bidTxHash, setBidTxHash] = useState<`0x${string}` | undefined>();
   const [bidComment, setBidComment] = useState("");
   const [isCommentOpen, setIsCommentOpen] = useState(false);
   const [isBidHistoryOpen, setIsBidHistoryOpen] = useState(false);
@@ -136,6 +144,26 @@ export function AuctionSpotlight() {
   const { writeContractAsync } = useWriteContract();
   const { sendTransactionAsync } = useSendTransaction();
 
+  // Wait for bid transaction confirmation
+  const { isLoading: isBidConfirming, isSuccess: isBidConfirmed } = useWaitForTransactionReceipt({
+    hash: bidTxHash,
+    chainId: CHAIN.id,
+  });
+
+  // Refresh auction data when bid is confirmed
+  useEffect(() => {
+    if (isBidConfirmed && bidTxHash) {
+      toast.success("Bid confirmed!", {
+        description: "Auction data updated.",
+      });
+      invalidateAuctionData();
+      setBidTxHash(undefined);
+      setIsBidding(false);
+      setBidComment("");
+      setIsCommentOpen(false);
+    }
+  }, [isBidConfirmed, bidTxHash, invalidateAuctionData]);
+
   // Handle bid submission
   const handleBid = async () => {
     if (!isConnected || !bidAmountWei || !tokenId || !isValidBid) return;
@@ -150,6 +178,8 @@ export function AuctionSpotlight() {
         await switchChainAsync({ chainId: base.id });
       }
 
+      let hash: `0x${string}`;
+
       if (trimmedComment.length > 0) {
         // Comment path: encode createBid calldata + append UTF-8 comment bytes
         const baseCalldata = encodeFunctionData({
@@ -160,7 +190,7 @@ export function AuctionSpotlight() {
         const commentBytes = toHex(new TextEncoder().encode(trimmedComment));
         const fullData = concat([baseCalldata, commentBytes]);
 
-        await sendTransactionAsync({
+        hash = await sendTransactionAsync({
           to: DAO_ADDRESSES.auction as `0x${string}`,
           data: fullData,
           value: bidAmountWei,
@@ -168,7 +198,7 @@ export function AuctionSpotlight() {
         });
       } else {
         // Original path (no regression)
-        await writeContractAsync({
+        hash = await writeContractAsync({
           address: DAO_ADDRESSES.auction as `0x${string}`,
           abi: auctionAbi,
           functionName: "createBid",
@@ -178,16 +208,13 @@ export function AuctionSpotlight() {
         });
       }
 
+      setBidTxHash(hash);
       toast.success("Bid submitted", {
-        description: trimmedComment.length > 0
-          ? "Your comment was recorded on-chain."
-          : "Waiting for confirmation...",
+        description: "Waiting for confirmation...",
       });
-      setTimeout(() => window.location.reload(), 3000);
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to submit bid";
       toast.error("Bid failed", { description: message });
-    } finally {
       setIsBidding(false);
     }
   };
@@ -241,15 +268,17 @@ export function AuctionSpotlight() {
     }
   };
 
-  // Handle successful confirmation
+  // Handle successful settlement confirmation — refresh auction data
   useEffect(() => {
     if (isConfirmed && settleTxHash) {
       toast.success("Settlement confirmed!", {
-        description: "Reloading to show new auction...",
+        description: "Loading new auction...",
       });
-      setTimeout(() => window.location.reload(), 2000);
+      invalidateAuctionData();
+      setIsSettling(false);
+      setSettleTxHash(undefined);
     }
-  }, [isConfirmed, settleTxHash]);
+  }, [isConfirmed, settleTxHash, invalidateAuctionData]);
 
   return (
     <Card className="w-full bg-card">
@@ -312,10 +341,15 @@ export function AuctionSpotlight() {
                   </Tooltip>
                   <Button
                     className="flex-[7] touch-manipulation"
-                    disabled={!isConnected || isBidding || !isValidBid}
+                    disabled={!isConnected || isBidding || isBidConfirming || !isValidBid}
                     onClick={handleBid}
                   >
-                    {isBidding ? (
+                    {isBidConfirming ? (
+                      <>
+                        <Spinner />
+                        Confirming...
+                      </>
+                    ) : isBidding ? (
                       <>
                         <Spinner />
                         Bidding...


### PR DESCRIPTION
## Summary
- Replace `window.location.reload()` with proper tx receipt watching + TanStack Query invalidation for both bid and settlement flows
- Track bid tx hash with `useWaitForTransactionReceipt` showing "Bidding..." → "Confirming..." → "Bid confirmed!" states
- Fix bid comment layout in history modal: replace the disconnected indigo border-left block with clean inline italic quoted text

## Changes
- `src/components/hero/AuctionSpotlight.tsx` — Smart refresh via `useQueryClient().invalidateQueries()`, bid tx receipt tracking, 3-state button UX
- `src/components/auction/BidItem.tsx` — Comment displays as inline italic quote next to timestamp instead of separate indigo block

## Test plan
- [ ] Place a bid and verify the component updates without page reload
- [ ] Verify button shows "Bidding..." → "Confirming..." → resets to "Place Bid"
- [ ] Settle an ended auction and verify new auction loads without page reload
- [ ] Open bid history modal and verify comments display cleanly inline
- [ ] Verify bids without comments still show timestamp properly

Generated with [Claude Code](https://claude.com/claude-code)