### PR TITLE
feat: auction UX perfection — complete component refactor

### DIFF
--- a/src/components/auction/AuctionBidForm.tsx
+++ b/src/components/auction/AuctionBidForm.tsx
@@ -107,21 +107,33 @@ export function AuctionBidForm({
     });
   }, [queryClient]);
 
+  // Save comment/amount at submission time so optimistic update fires immediately
+  const pendingBidRef = useRef<{ comment: string; amount: string } | null>(null);
+
   const bidTx = useAuctionTransaction({
     onConfirmed: () => {
       toast.success("Bid confirmed!", { description: "Auction data updated." });
       invalidateAuctionData();
-      // Pass comment + amount up for optimistic display before clearing
-      onBidConfirmed?.(bidComment.trim(), bidAmount);
+      pendingBidRef.current = null;
       setBidComment("");
       setIsCommentOpen(false);
-      // Brief "Confirmed!" display, then reset
       resetTimerRef.current = setTimeout(() => bidTx.reset(), 1500);
     },
-    onError: (error) => {
-      toast.error("Bid failed", { description: error.message });
+    onError: () => {
+      // TX failed — clear optimistic state
+      pendingBidRef.current = null;
+      onBidConfirmed?.("", "");
+      toast.error("Bid failed");
     },
   });
+
+  // Set optimistic state as soon as TX is submitted (not confirmed)
+  // This fires before the event subscription updates bid value
+  useEffect(() => {
+    if (bidTx.phase === "submitted" && pendingBidRef.current) {
+      onBidConfirmed?.(pendingBidRef.current.comment, pendingBidRef.current.amount);
+    }
+  }, [bidTx.phase, onBidConfirmed]);
 
   // Handle wallet connect
   const handleConnectAndBid = () => {
@@ -140,6 +152,9 @@ export function AuctionBidForm({
     if (!bidAmountWei || !tokenId || !isValidBid || insufficientBalance) return;
 
     const trimmedComment = bidComment.trim();
+
+    // Store before execute so it's available when phase changes to "submitted"
+    pendingBidRef.current = { comment: trimmedComment, amount: bidAmount };
 
     await bidTx.execute(async () => {
       // Switch network if needed

--- a/src/components/auction/AuctionBidForm.tsx
+++ b/src/components/auction/AuctionBidForm.tsx
@@ -27,12 +27,15 @@ interface AuctionBidFormProps {
   tokenId: bigint | undefined;
   highestBid: string | undefined;
   reservePriceEth: number;
+  /** Called after bid is confirmed — passes the comment for optimistic display */
+  onBidConfirmed?: (comment: string, bidAmount: string) => void;
 }
 
 export function AuctionBidForm({
   tokenId,
   highestBid,
   reservePriceEth,
+  onBidConfirmed,
 }: AuctionBidFormProps) {
   const { address, isConnected, chain } = useAccount();
   const { switchChainAsync } = useSwitchChain();
@@ -108,6 +111,8 @@ export function AuctionBidForm({
     onConfirmed: () => {
       toast.success("Bid confirmed!", { description: "Auction data updated." });
       invalidateAuctionData();
+      // Pass comment + amount up for optimistic display before clearing
+      onBidConfirmed?.(bidComment.trim(), bidAmount);
       setBidComment("");
       setIsCommentOpen(false);
       // Brief "Confirmed!" display, then reset

--- a/src/components/auction/AuctionBidForm.tsx
+++ b/src/components/auction/AuctionBidForm.tsx
@@ -80,12 +80,12 @@ export function AuctionBidForm({
     }
   }, [bidAmount, isValidBid]);
 
-  // Scoped invalidation — only auction-related queries
+  // Scoped invalidation — only auction-related readContract queries
   const invalidateAuctionData = useCallback(() => {
     queryClient.invalidateQueries({
       predicate: (query) => {
         const key = query.queryKey;
-        // Invalidate readContract queries for the auction address
+        // wagmi useReadContract generates keys: ['readContract', { address, functionName, ... }]
         if (key[0] === "readContract" && Array.isArray(key)) {
           const serialized = JSON.stringify(key);
           return serialized.includes(DAO_ADDRESSES.auction.toLowerCase());
@@ -93,8 +93,6 @@ export function AuctionBidForm({
         return false;
       },
     });
-    // Also invalidate the Builder SDK auction query
-    queryClient.invalidateQueries({ queryKey: ["daoAuction"] });
   }, [queryClient]);
 
   const bidTx = useAuctionTransaction({

--- a/src/components/auction/AuctionBidForm.tsx
+++ b/src/components/auction/AuctionBidForm.tsx
@@ -56,22 +56,31 @@ export function AuctionBidForm({
   });
   const balanceEth = balanceData ? Number(formatEther(balanceData.value)) : undefined;
 
-  // Min bid calculation
+  // Min bid calculation — round UP to 6 decimals so displayed value always passes validation
   const minNextBidEth = useMemo(() => {
     const current = Number(highestBid ?? "0");
     if (!Number.isFinite(current) || current <= 0) return reservePriceEth;
-    return Math.max(0, current * 1.01);
+    const raw = current * 1.01;
+    // Ceil to 6 decimal places so displayed min is always >= actual min
+    return Math.ceil(raw * 1e6) / 1e6;
   }, [highestBid, reservePriceEth]);
 
-  const [bidAmount, setBidAmount] = useState(minNextBidEth.toFixed(4));
+  // Format with enough decimals to show the true minimum
+  const minBidDisplay = useMemo(() => {
+    const s = minNextBidEth.toFixed(6);
+    // Trim trailing zeros but keep at least 4 decimals
+    return s.replace(/0+$/, "").replace(/\.$/, "") || s.slice(0, s.indexOf(".") + 5);
+  }, [minNextBidEth]);
+
+  const [bidAmount, setBidAmount] = useState(minBidDisplay);
 
   // Update bid amount when minimum changes — only if current value is below new minimum
   useEffect(() => {
     setBidAmount((prev) => {
       const parsed = parseFloat(prev);
-      return isNaN(parsed) || parsed < minNextBidEth ? minNextBidEth.toFixed(4) : prev;
+      return isNaN(parsed) || parsed < minNextBidEth ? minBidDisplay : prev;
     });
-  }, [minNextBidEth]);
+  }, [minNextBidEth, minBidDisplay]);
 
   // Validation
   const bidAmountNum = parseFloat(bidAmount);
@@ -236,7 +245,7 @@ export function AuctionBidForm({
             min={minNextBidEth}
             value={bidAmount}
             onChange={(e) => setBidAmount(e.target.value)}
-            placeholder={minNextBidEth.toFixed(4)}
+            placeholder={minBidDisplay}
             disabled={bidTx.isActive}
             className="[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
           />
@@ -256,7 +265,7 @@ export function AuctionBidForm({
       {/* Inline status row: balance + insufficient warning + comment toggle */}
       <div className="flex items-center justify-between text-xs">
         <div className="text-muted-foreground flex items-center gap-2">
-          <span>Min: {minNextBidEth.toFixed(4)} ETH</span>
+          <span>Min: {minBidDisplay} ETH</span>
           {isConnected && insufficientBalance ? (
             <span className="text-destructive">
               · Insufficient{balanceEth !== undefined ? ` (${balanceEth.toFixed(4)})` : ""}

--- a/src/components/auction/AuctionBidForm.tsx
+++ b/src/components/auction/AuctionBidForm.tsx
@@ -255,17 +255,16 @@ export function AuctionBidForm({
 
       {/* Inline status row: balance + insufficient warning + comment toggle */}
       <div className="flex items-center justify-between text-xs">
-        <div className="text-muted-foreground">
+        <div className="text-muted-foreground flex items-center gap-2">
+          <span>Min: {minNextBidEth.toFixed(4)} ETH</span>
           {isConnected && insufficientBalance ? (
             <span className="text-destructive">
-              Insufficient balance{balanceEth !== undefined ? ` (${balanceEth.toFixed(4)} ETH)` : ""}
+              · Insufficient{balanceEth !== undefined ? ` (${balanceEth.toFixed(4)})` : ""}
             </span>
           ) : isConnected && balanceEth !== undefined ? (
-            <span>Balance: {balanceEth.toFixed(4)} ETH</span>
+            <span>· Bal: {balanceEth.toFixed(4)}</span>
           ) : isWrongNetwork ? (
-            <span className="text-amber-500">Switch to Base to bid</span>
-          ) : !isConnected ? (
-            <span>Min: {minNextBidEth.toFixed(4)} ETH</span>
+            <span className="text-amber-500">· Wrong network</span>
           ) : null}
         </div>
         <Collapsible open={isCommentOpen} onOpenChange={setIsCommentOpen}>

--- a/src/components/auction/AuctionBidForm.tsx
+++ b/src/components/auction/AuctionBidForm.tsx
@@ -94,7 +94,9 @@ export function AuctionBidForm({
         const key = query.queryKey;
         // wagmi useReadContract generates keys: ['readContract', { address, functionName, ... }]
         if (key[0] === "readContract" && Array.isArray(key)) {
-          const serialized = JSON.stringify(key);
+          const serialized = JSON.stringify(key, (_, v) =>
+            typeof v === "bigint" ? v.toString() : v,
+          );
           return serialized.includes(DAO_ADDRESSES.auction.toLowerCase());
         }
         return false;

--- a/src/components/auction/AuctionBidForm.tsx
+++ b/src/components/auction/AuctionBidForm.tsx
@@ -26,6 +26,8 @@ interface AuctionBidFormProps {
   tokenId: bigint | undefined;
   highestBid: string | undefined;
   reservePriceEth: number;
+  /** Min bid increment percentage from contract (e.g., 10 = 10%) */
+  minBidIncrementPct: number;
   onBidConfirmed?: (comment: string, bidAmount: string) => void;
 }
 
@@ -33,6 +35,7 @@ export function AuctionBidForm({
   tokenId,
   highestBid,
   reservePriceEth,
+  minBidIncrementPct,
   onBidConfirmed,
 }: AuctionBidFormProps) {
   const { address, isConnected, chain } = useAccount();
@@ -56,14 +59,15 @@ export function AuctionBidForm({
   });
   const balanceEth = balanceData ? Number(formatEther(balanceData.value)) : undefined;
 
-  // Min bid calculation — round UP to 6 decimals so displayed value always passes validation
+  // Min bid calculation — use contract's minBidIncrement percentage
   const minNextBidEth = useMemo(() => {
     const current = Number(highestBid ?? "0");
     if (!Number.isFinite(current) || current <= 0) return reservePriceEth;
-    const raw = current * 1.01;
+    const multiplier = 1 + minBidIncrementPct / 100; // e.g., 10% → 1.10
+    const raw = current * multiplier;
     // Ceil to 6 decimal places so displayed min is always >= actual min
     return Math.ceil(raw * 1e6) / 1e6;
-  }, [highestBid, reservePriceEth]);
+  }, [highestBid, reservePriceEth, minBidIncrementPct]);
 
   // Format with enough decimals to show the true minimum
   const minBidDisplay = useMemo(() => {
@@ -125,8 +129,9 @@ export function AuctionBidForm({
       invalidateAuctionData();
       // Force-set bid amount to new minimum based on user's own bid
       if (pendingBidRef.current) {
-        const newMin = (parseFloat(pendingBidRef.current.amount) * 1.01).toFixed(4);
-        setBidAmount(newMin);
+        const multiplier = 1 + minBidIncrementPct / 100;
+        const raw = parseFloat(pendingBidRef.current.amount) * multiplier;
+        setBidAmount((Math.ceil(raw * 1e6) / 1e6).toString());
       }
       pendingBidRef.current = null;
       setBidComment("");

--- a/src/components/auction/AuctionBidForm.tsx
+++ b/src/components/auction/AuctionBidForm.tsx
@@ -15,7 +15,6 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from "@/components/ui/input-group";
 import { Spinner } from "@/components/ui/spinner";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
 import { CHAIN, DAO_ADDRESSES } from "@/lib/config";
 import auctionAbi from "@/utils/abis/auctionAbi";
@@ -27,7 +26,6 @@ interface AuctionBidFormProps {
   tokenId: bigint | undefined;
   highestBid: string | undefined;
   reservePriceEth: number;
-  /** Called after bid is confirmed — passes the comment for optimistic display */
   onBidConfirmed?: (comment: string, bidAmount: string) => void;
 }
 
@@ -48,7 +46,6 @@ export function AuctionBidForm({
   const [isCommentOpen, setIsCommentOpen] = useState(false);
   const resetTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
-  // Cleanup reset timer on unmount
   useEffect(() => () => clearTimeout(resetTimerRef.current), []);
 
   // Balance check
@@ -90,12 +87,11 @@ export function AuctionBidForm({
     }
   }, [bidAmount, isValidBid]);
 
-  // Scoped invalidation — only auction-related readContract queries
+  // Scoped invalidation
   const invalidateAuctionData = useCallback(() => {
     queryClient.invalidateQueries({
       predicate: (query) => {
         const key = query.queryKey;
-        // wagmi useReadContract generates keys: ['readContract', { address, functionName, ... }]
         if (key[0] === "readContract" && Array.isArray(key)) {
           const serialized = JSON.stringify(key, (_, v) =>
             typeof v === "bigint" ? v.toString() : v,
@@ -107,12 +103,10 @@ export function AuctionBidForm({
     });
   }, [queryClient]);
 
-  // Save comment/amount at submission time so optimistic update fires immediately
   const pendingBidRef = useRef<{ comment: string; amount: string } | null>(null);
 
   const bidTx = useAuctionTransaction({
     onSubmitted: () => {
-      // Fires synchronously when TX hash is received — before any React render
       if (pendingBidRef.current) {
         onBidConfirmed?.(pendingBidRef.current.comment, pendingBidRef.current.amount);
       }
@@ -120,6 +114,11 @@ export function AuctionBidForm({
     onConfirmed: () => {
       toast.success("Bid confirmed!", { description: "Auction data updated." });
       invalidateAuctionData();
+      // Force-set bid amount to new minimum based on user's own bid
+      if (pendingBidRef.current) {
+        const newMin = (parseFloat(pendingBidRef.current.amount) * 1.01).toFixed(4);
+        setBidAmount(newMin);
+      }
       pendingBidRef.current = null;
       setBidComment("");
       setIsCommentOpen(false);
@@ -132,15 +131,12 @@ export function AuctionBidForm({
     },
   });
 
-  // Handle wallet connect
   const handleConnectAndBid = () => {
     if (!isConnected) {
       setIsConnectModalOpen(true);
-      return;
     }
   };
 
-  // Handle bid submission
   const handleBid = async () => {
     if (!isConnected) {
       handleConnectAndBid();
@@ -149,12 +145,9 @@ export function AuctionBidForm({
     if (!bidAmountWei || !tokenId || !isValidBid || insufficientBalance) return;
 
     const trimmedComment = bidComment.trim();
-
-    // Store before execute so it's available when phase changes to "submitted"
     pendingBidRef.current = { comment: trimmedComment, amount: bidAmount };
 
     await bidTx.execute(async () => {
-      // Switch network if needed
       if (chain?.id !== base.id) {
         toast.info("Switching to Base network...");
         await switchChainAsync({ chainId: base.id });
@@ -188,7 +181,6 @@ export function AuctionBidForm({
     });
   };
 
-  // Determine button state
   const getButtonContent = () => {
     if (bidTx.isActive) {
       return (
@@ -220,10 +212,9 @@ export function AuctionBidForm({
     if (isWrongNetwork) {
       try {
         await switchChainAsync({ chainId: base.id });
-        // After switching, proceed to bid
         handleBid();
       } catch {
-        // User rejected network switch
+        // User rejected
       }
       return;
     }
@@ -236,29 +227,23 @@ export function AuctionBidForm({
 
   return (
     <>
+      {/* Bid input + button */}
       <div className="flex gap-2">
-        <Tooltip open={isConnected && !isWrongNetwork && !isValidBid && !!bidAmount}>
-          <TooltipTrigger asChild>
-            <InputGroup className="flex-[3]">
-              <InputGroupInput
-                type="number"
-                step="0.0001"
-                min={minNextBidEth}
-                value={bidAmount}
-                onChange={(e) => setBidAmount(e.target.value)}
-                placeholder={minNextBidEth.toFixed(4)}
-                disabled={bidTx.isActive}
-                className="[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-              />
-              <InputGroupAddon align="inline-end">
-                <InputGroupText>ETH</InputGroupText>
-              </InputGroupAddon>
-            </InputGroup>
-          </TooltipTrigger>
-          <TooltipContent side="bottom" className="font-mono">
-            Minimum bid: {minNextBidEth.toFixed(4)} ETH
-          </TooltipContent>
-        </Tooltip>
+        <InputGroup className="flex-[3]">
+          <InputGroupInput
+            type="number"
+            step="0.0001"
+            min={minNextBidEth}
+            value={bidAmount}
+            onChange={(e) => setBidAmount(e.target.value)}
+            placeholder={minNextBidEth.toFixed(4)}
+            disabled={bidTx.isActive}
+            className="[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+          />
+          <InputGroupAddon align="inline-end">
+            <InputGroupText>ETH</InputGroupText>
+          </InputGroupAddon>
+        </InputGroup>
         <Button
           className="flex-[7] touch-manipulation"
           disabled={isButtonDisabled}
@@ -268,51 +253,49 @@ export function AuctionBidForm({
         </Button>
       </div>
 
-      {/* Balance warning */}
-      {isConnected && insufficientBalance && (
-        <p className="text-xs text-destructive">
-          Insufficient balance {balanceEth !== undefined ? `(you have ${balanceEth.toFixed(4)} ETH)` : ""}
-        </p>
-      )}
+      {/* Inline status row: balance + insufficient warning + comment toggle */}
+      <div className="flex items-center justify-between text-xs">
+        <div className="text-muted-foreground">
+          {isConnected && insufficientBalance ? (
+            <span className="text-destructive">
+              Insufficient balance{balanceEth !== undefined ? ` (${balanceEth.toFixed(4)} ETH)` : ""}
+            </span>
+          ) : isConnected && balanceEth !== undefined ? (
+            <span>Balance: {balanceEth.toFixed(4)} ETH</span>
+          ) : isWrongNetwork ? (
+            <span className="text-amber-500">Switch to Base to bid</span>
+          ) : !isConnected ? (
+            <span>Min: {minNextBidEth.toFixed(4)} ETH</span>
+          ) : null}
+        </div>
+        <Collapsible open={isCommentOpen} onOpenChange={setIsCommentOpen}>
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              disabled={bidTx.isActive}
+              className="flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+            >
+              <MessageSquare className="h-3 w-3" />
+              <span>Comment</span>
+              <ChevronDown
+                className={`h-3 w-3 transition-transform duration-200 ${isCommentOpen ? "rotate-180" : ""}`}
+              />
+            </button>
+          </CollapsibleTrigger>
+        </Collapsible>
+      </div>
 
-      {/* Balance display when sufficient */}
-      {isConnected && !insufficientBalance && balanceEth !== undefined && (
-        <p className="text-xs text-muted-foreground">
-          Balance: {balanceEth.toFixed(4)} ETH
-        </p>
-      )}
-
-      {/* Wrong network warning */}
-      {isWrongNetwork && (
-        <p className="text-xs text-amber-500">
-          Switch to Base network to place a bid
-        </p>
-      )}
-
-      {/* Comment collapsible */}
+      {/* Comment textarea — outside the row so it expands below */}
       <Collapsible open={isCommentOpen} onOpenChange={setIsCommentOpen}>
-        <CollapsibleTrigger asChild>
-          <button
-            type="button"
-            disabled={bidTx.isActive}
-            className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 disabled:pointer-events-none"
-          >
-            <MessageSquare className="h-3 w-3" />
-            Add a comment
-            <ChevronDown
-              className={`h-3 w-3 transition-transform duration-200 ${isCommentOpen ? "rotate-180" : ""}`}
-            />
-          </button>
-        </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="mt-2 space-y-1">
+          <div className="space-y-1">
             <textarea
               maxLength={140}
               rows={2}
               value={bidComment}
               onChange={(e) => setBidComment(e.target.value)}
               disabled={bidTx.isActive}
-              placeholder="Optional on-chain comment (recorded permanently)…"
+              placeholder="On-chain comment (recorded permanently)…"
               className="w-full resize-none rounded-md border border-input bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
             />
             <div className="text-right text-xs text-muted-foreground">

--- a/src/components/auction/AuctionBidForm.tsx
+++ b/src/components/auction/AuctionBidForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronDown, MessageSquare, Wallet } from "lucide-react";
 import { encodeFunctionData, concat, formatEther, parseEther, toHex } from "viem";
 import { base } from "wagmi/chains";
@@ -43,6 +43,10 @@ export function AuctionBidForm({
 
   const [bidComment, setBidComment] = useState("");
   const [isCommentOpen, setIsCommentOpen] = useState(false);
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  // Cleanup reset timer on unmount
+  useEffect(() => () => clearTimeout(resetTimerRef.current), []);
 
   // Balance check
   const { data: balanceData } = useBalance({
@@ -61,9 +65,12 @@ export function AuctionBidForm({
 
   const [bidAmount, setBidAmount] = useState(minNextBidEth.toFixed(4));
 
-  // Update bid amount when minimum changes (new bid came in)
+  // Update bid amount when minimum changes — only if current value is below new minimum
   useEffect(() => {
-    setBidAmount(minNextBidEth.toFixed(4));
+    setBidAmount((prev) => {
+      const parsed = parseFloat(prev);
+      return isNaN(parsed) || parsed < minNextBidEth ? minNextBidEth.toFixed(4) : prev;
+    });
   }, [minNextBidEth]);
 
   // Validation
@@ -102,7 +109,7 @@ export function AuctionBidForm({
       setBidComment("");
       setIsCommentOpen(false);
       // Brief "Confirmed!" display, then reset
-      setTimeout(() => bidTx.reset(), 1500);
+      resetTimerRef.current = setTimeout(() => bidTx.reset(), 1500);
     },
     onError: (error) => {
       toast.error("Bid failed", { description: error.message });
@@ -194,13 +201,19 @@ export function AuctionBidForm({
     return "Place Bid";
   };
 
-  const handleButtonClick = () => {
+  const handleButtonClick = async () => {
     if (!isConnected) {
       handleConnectAndBid();
       return;
     }
     if (isWrongNetwork) {
-      switchChainAsync({ chainId: base.id });
+      try {
+        await switchChainAsync({ chainId: base.id });
+        // After switching, proceed to bid
+        handleBid();
+      } catch {
+        // User rejected network switch
+      }
       return;
     }
     handleBid();

--- a/src/components/auction/AuctionBidForm.tsx
+++ b/src/components/auction/AuctionBidForm.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ChevronDown, MessageSquare, Wallet } from "lucide-react";
+import { encodeFunctionData, concat, formatEther, parseEther, toHex } from "viem";
+import { base } from "wagmi/chains";
+import {
+  useAccount,
+  useBalance,
+  useConnect,
+  useSendTransaction,
+  useSwitchChain,
+  useWriteContract,
+} from "wagmi";
+import { useQueryClient } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from "@/components/ui/input-group";
+import { Spinner } from "@/components/ui/spinner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
+import { CHAIN, DAO_ADDRESSES } from "@/lib/config";
+import auctionAbi from "@/utils/abis/auctionAbi";
+import { toast } from "sonner";
+import { useAuctionTransaction } from "@/hooks/use-auction-transaction";
+
+interface AuctionBidFormProps {
+  tokenId: bigint | undefined;
+  highestBid: string | undefined;
+  reservePriceEth: number;
+}
+
+export function AuctionBidForm({
+  tokenId,
+  highestBid,
+  reservePriceEth,
+}: AuctionBidFormProps) {
+  const { address, isConnected, chain } = useAccount();
+  const { connectors, connectAsync } = useConnect();
+  const { switchChainAsync } = useSwitchChain();
+  const { writeContractAsync } = useWriteContract();
+  const { sendTransactionAsync } = useSendTransaction();
+  const queryClient = useQueryClient();
+
+  const [bidComment, setBidComment] = useState("");
+  const [isCommentOpen, setIsCommentOpen] = useState(false);
+
+  // Balance check
+  const { data: balanceData } = useBalance({
+    address: address,
+    chainId: base.id,
+    query: { enabled: isConnected },
+  });
+  const balanceEth = balanceData ? Number(formatEther(balanceData.value)) : undefined;
+
+  // Min bid calculation
+  const minNextBidEth = useMemo(() => {
+    const current = Number(highestBid ?? "0");
+    if (!Number.isFinite(current) || current <= 0) return reservePriceEth;
+    return Math.max(0, current * 1.01);
+  }, [highestBid, reservePriceEth]);
+
+  const [bidAmount, setBidAmount] = useState(minNextBidEth.toFixed(4));
+
+  // Update bid amount when minimum changes (new bid came in)
+  useEffect(() => {
+    setBidAmount(minNextBidEth.toFixed(4));
+  }, [minNextBidEth]);
+
+  // Validation
+  const bidAmountNum = parseFloat(bidAmount);
+  const isValidBid = !isNaN(bidAmountNum) && bidAmountNum >= minNextBidEth;
+  const insufficientBalance = isConnected && balanceEth !== undefined && bidAmountNum > balanceEth;
+  const isWrongNetwork = isConnected && chain?.id !== base.id;
+
+  const bidAmountWei = useMemo(() => {
+    try {
+      return isValidBid ? parseEther(bidAmount) : undefined;
+    } catch {
+      return undefined;
+    }
+  }, [bidAmount, isValidBid]);
+
+  // Scoped invalidation — only auction-related queries
+  const invalidateAuctionData = useCallback(() => {
+    queryClient.invalidateQueries({
+      predicate: (query) => {
+        const key = query.queryKey;
+        // Invalidate readContract queries for the auction address
+        if (key[0] === "readContract" && Array.isArray(key)) {
+          const serialized = JSON.stringify(key);
+          return serialized.includes(DAO_ADDRESSES.auction.toLowerCase());
+        }
+        return false;
+      },
+    });
+    // Also invalidate the Builder SDK auction query
+    queryClient.invalidateQueries({ queryKey: ["daoAuction"] });
+  }, [queryClient]);
+
+  const bidTx = useAuctionTransaction({
+    onConfirmed: () => {
+      toast.success("Bid confirmed!", { description: "Auction data updated." });
+      invalidateAuctionData();
+      setBidComment("");
+      setIsCommentOpen(false);
+      // Brief "Confirmed!" display, then reset
+      setTimeout(() => bidTx.reset(), 1500);
+    },
+    onError: (error) => {
+      toast.error("Bid failed", { description: error.message });
+    },
+  });
+
+  // Handle wallet connect
+  const handleConnectAndBid = async () => {
+    if (!isConnected) {
+      // Open first available connector
+      const connector = connectors[0];
+      if (connector) {
+        try {
+          await connectAsync({ connector });
+        } catch {
+          // User cancelled, do nothing
+        }
+      }
+      return;
+    }
+  };
+
+  // Handle bid submission
+  const handleBid = async () => {
+    if (!isConnected) {
+      handleConnectAndBid();
+      return;
+    }
+    if (!bidAmountWei || !tokenId || !isValidBid || insufficientBalance) return;
+
+    const trimmedComment = bidComment.trim();
+
+    await bidTx.execute(async () => {
+      // Switch network if needed
+      if (chain?.id !== base.id) {
+        toast.info("Switching to Base network...");
+        await switchChainAsync({ chainId: base.id });
+      }
+
+      if (trimmedComment.length > 0) {
+        const baseCalldata = encodeFunctionData({
+          abi: auctionAbi,
+          functionName: "createBid",
+          args: [tokenId],
+        });
+        const commentBytes = toHex(new TextEncoder().encode(trimmedComment));
+        const fullData = concat([baseCalldata, commentBytes]);
+
+        return sendTransactionAsync({
+          to: DAO_ADDRESSES.auction as `0x${string}`,
+          data: fullData,
+          value: bidAmountWei,
+          chainId: base.id,
+        });
+      } else {
+        return writeContractAsync({
+          address: DAO_ADDRESSES.auction as `0x${string}`,
+          abi: auctionAbi,
+          functionName: "createBid",
+          args: [tokenId],
+          value: bidAmountWei,
+          chainId: base.id,
+        });
+      }
+    });
+  };
+
+  // Determine button state
+  const getButtonContent = () => {
+    if (bidTx.isActive) {
+      return (
+        <>
+          <Spinner />
+          {bidTx.buttonLabel("Place Bid")}
+        </>
+      );
+    }
+    if (!isConnected) {
+      return (
+        <>
+          <Wallet className="h-4 w-4" />
+          Connect Wallet to Bid
+        </>
+      );
+    }
+    if (isWrongNetwork) {
+      return "Switch to Base";
+    }
+    return "Place Bid";
+  };
+
+  const handleButtonClick = () => {
+    if (!isConnected) {
+      handleConnectAndBid();
+      return;
+    }
+    if (isWrongNetwork) {
+      switchChainAsync({ chainId: base.id });
+      return;
+    }
+    handleBid();
+  };
+
+  const isButtonDisabled =
+    bidTx.isActive ||
+    (isConnected && !isWrongNetwork && (!isValidBid || insufficientBalance));
+
+  return (
+    <>
+      <div className="flex gap-2">
+        <Tooltip open={isConnected && !isWrongNetwork && !isValidBid && !!bidAmount}>
+          <TooltipTrigger asChild>
+            <InputGroup className="flex-[3]">
+              <InputGroupInput
+                type="number"
+                step="0.0001"
+                min={minNextBidEth}
+                value={bidAmount}
+                onChange={(e) => setBidAmount(e.target.value)}
+                placeholder={minNextBidEth.toFixed(4)}
+                disabled={bidTx.isActive}
+                className="[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+              />
+              <InputGroupAddon align="inline-end">
+                <InputGroupText>ETH</InputGroupText>
+              </InputGroupAddon>
+            </InputGroup>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" className="font-mono">
+            Minimum bid: {minNextBidEth.toFixed(4)} ETH
+          </TooltipContent>
+        </Tooltip>
+        <Button
+          className="flex-[7] touch-manipulation"
+          disabled={isButtonDisabled}
+          onClick={handleButtonClick}
+        >
+          {getButtonContent()}
+        </Button>
+      </div>
+
+      {/* Balance warning */}
+      {isConnected && insufficientBalance && (
+        <p className="text-xs text-destructive">
+          Insufficient balance {balanceEth !== undefined ? `(you have ${balanceEth.toFixed(4)} ETH)` : ""}
+        </p>
+      )}
+
+      {/* Balance display when sufficient */}
+      {isConnected && !insufficientBalance && balanceEth !== undefined && (
+        <p className="text-xs text-muted-foreground">
+          Balance: {balanceEth.toFixed(4)} ETH
+        </p>
+      )}
+
+      {/* Wrong network warning */}
+      {isWrongNetwork && (
+        <p className="text-xs text-amber-500">
+          Switch to Base network to place a bid
+        </p>
+      )}
+
+      {/* Comment collapsible */}
+      <Collapsible open={isCommentOpen} onOpenChange={setIsCommentOpen}>
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            disabled={bidTx.isActive}
+            className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 disabled:pointer-events-none"
+          >
+            <MessageSquare className="h-3 w-3" />
+            Add a comment
+            <ChevronDown
+              className={`h-3 w-3 transition-transform duration-200 ${isCommentOpen ? "rotate-180" : ""}`}
+            />
+          </button>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="mt-2 space-y-1">
+            <textarea
+              maxLength={140}
+              rows={2}
+              value={bidComment}
+              onChange={(e) => setBidComment(e.target.value)}
+              disabled={bidTx.isActive}
+              placeholder="Optional on-chain comment (recorded permanently)…"
+              className="w-full resize-none rounded-md border border-input bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+            />
+            <div className="text-right text-xs text-muted-foreground">
+              {bidComment.length}/140
+            </div>
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+    </>
+  );
+}

--- a/src/components/auction/AuctionBidForm.tsx
+++ b/src/components/auction/AuctionBidForm.tsx
@@ -111,6 +111,12 @@ export function AuctionBidForm({
   const pendingBidRef = useRef<{ comment: string; amount: string } | null>(null);
 
   const bidTx = useAuctionTransaction({
+    onSubmitted: () => {
+      // Fires synchronously when TX hash is received — before any React render
+      if (pendingBidRef.current) {
+        onBidConfirmed?.(pendingBidRef.current.comment, pendingBidRef.current.amount);
+      }
+    },
     onConfirmed: () => {
       toast.success("Bid confirmed!", { description: "Auction data updated." });
       invalidateAuctionData();
@@ -120,20 +126,11 @@ export function AuctionBidForm({
       resetTimerRef.current = setTimeout(() => bidTx.reset(), 1500);
     },
     onError: () => {
-      // TX failed — clear optimistic state
       pendingBidRef.current = null;
       onBidConfirmed?.("", "");
       toast.error("Bid failed");
     },
   });
-
-  // Set optimistic state as soon as TX is submitted (not confirmed)
-  // This fires before the event subscription updates bid value
-  useEffect(() => {
-    if (bidTx.phase === "submitted" && pendingBidRef.current) {
-      onBidConfirmed?.(pendingBidRef.current.comment, pendingBidRef.current.amount);
-    }
-  }, [bidTx.phase, onBidConfirmed]);
 
   // Handle wallet connect
   const handleConnectAndBid = () => {

--- a/src/components/auction/AuctionBidForm.tsx
+++ b/src/components/auction/AuctionBidForm.tsx
@@ -7,7 +7,6 @@ import { base } from "wagmi/chains";
 import {
   useAccount,
   useBalance,
-  useConnect,
   useSendTransaction,
   useSwitchChain,
   useWriteContract,
@@ -22,6 +21,7 @@ import { CHAIN, DAO_ADDRESSES } from "@/lib/config";
 import auctionAbi from "@/utils/abis/auctionAbi";
 import { toast } from "sonner";
 import { useAuctionTransaction } from "@/hooks/use-auction-transaction";
+import { ConnectWalletModal } from "@/components/auction/ConnectWalletModal";
 
 interface AuctionBidFormProps {
   tokenId: bigint | undefined;
@@ -35,8 +35,8 @@ export function AuctionBidForm({
   reservePriceEth,
 }: AuctionBidFormProps) {
   const { address, isConnected, chain } = useAccount();
-  const { connectors, connectAsync } = useConnect();
   const { switchChainAsync } = useSwitchChain();
+  const [isConnectModalOpen, setIsConnectModalOpen] = useState(false);
   const { writeContractAsync } = useWriteContract();
   const { sendTransactionAsync } = useSendTransaction();
   const queryClient = useQueryClient();
@@ -117,17 +117,9 @@ export function AuctionBidForm({
   });
 
   // Handle wallet connect
-  const handleConnectAndBid = async () => {
+  const handleConnectAndBid = () => {
     if (!isConnected) {
-      // Open first available connector
-      const connector = connectors[0];
-      if (connector) {
-        try {
-          await connectAsync({ connector });
-        } catch {
-          // User cancelled, do nothing
-        }
-      }
+      setIsConnectModalOpen(true);
       return;
     }
   };
@@ -310,6 +302,11 @@ export function AuctionBidForm({
           </div>
         </CollapsibleContent>
       </Collapsible>
+
+      <ConnectWalletModal
+        open={isConnectModalOpen}
+        onOpenChange={setIsConnectModalOpen}
+      />
     </>
   );
 }

--- a/src/components/auction/AuctionLiveStatus.tsx
+++ b/src/components/auction/AuctionLiveStatus.tsx
@@ -91,36 +91,12 @@ export function AuctionLiveStatus({
 
   return (
     <>
-      {/* Status line: live indicator + time + current bid */}
-      <div className="flex items-center justify-between text-sm">
-        <div className="flex items-center gap-2 text-muted-foreground">
-          <span className={`inline-block h-2 w-2 rounded-full ${
-            isLive
-              ? isEndingSoon ? "bg-amber-500 animate-pulse" : "bg-green-500"
-              : "bg-muted-foreground"
-          }`} />
-          <span>
-            {isLive
-              ? isEndingSoon
-                ? `Ending soon · ${timeString}`
-                : `Live · ${timeString} left`
-              : "Ended"
-            }
-          </span>
-        </div>
-        <span className={`font-bold text-base transition-all duration-300 ${
-          bidAnimating ? "scale-110 text-primary" : "scale-100"
-        }`}>
-          {highestBid ? `${highestBid} ETH` : "—"}
-        </span>
-      </div>
-
-      {/* Leading bid card */}
-      {hasBidder && (
+      {/* Leading bid card — the hero element */}
+      {hasBidder ? (
         <div className={`rounded-lg border border-border/60 bg-muted/30 p-3 transition-all ${
           bidAnimating ? "ring-2 ring-primary/30" : ""
         }`}>
-          <div className="flex items-center justify-between mb-1">
+          <div className="flex items-center justify-between">
             <AddressDisplay
               address={highestBidder}
               variant="compact"
@@ -132,23 +108,41 @@ export function AuctionLiveStatus({
               onAddressClick={() => {}}
               className="text-sm font-medium text-foreground pointer-events-none"
             />
-            <span className="text-sm font-bold">
+            <span className={`text-lg font-bold transition-all duration-300 ${
+              bidAnimating ? "scale-110 text-primary" : "scale-100"
+            }`}>
               {highestBid ? `${highestBid} ETH` : ""}
             </span>
           </div>
           {leadingBidComment && (
-            <p className="text-xs text-muted-foreground italic pl-7 mt-0.5">
+            <p className="text-xs text-muted-foreground italic pl-7 mt-1">
               &ldquo;{leadingBidComment}&rdquo;
             </p>
           )}
         </div>
+      ) : (
+        <div className="text-center py-2 text-muted-foreground text-sm">
+          No bids yet — be the first!
+        </div>
       )}
 
-      {/* Colored progress bar */}
-      <Progress value={progressPercentage} className={`h-1.5 ${progressColor}`} />
-
-      {/* Bid history link (below the form, rendered by parent) */}
-      {/* This section only shows if there are bids */}
+      {/* Time + progress */}
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <span className={`inline-block h-1.5 w-1.5 rounded-full ${
+          isLive
+            ? isEndingSoon ? "bg-amber-500 animate-pulse" : "bg-green-500"
+            : "bg-muted-foreground"
+        }`} />
+        <span>
+          {isLive
+            ? isEndingSoon
+              ? `Ending soon · ${timeString}`
+              : `${timeString} left`
+            : "Ended"
+          }
+        </span>
+        <Progress value={progressPercentage} className={`h-1 flex-1 ${progressColor}`} />
+      </div>
     </>
   );
 }

--- a/src/components/auction/AuctionLiveStatus.tsx
+++ b/src/components/auction/AuctionLiveStatus.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { ChevronRight } from "lucide-react";
 import { zeroAddress } from "viem";
 import { Progress } from "@/components/ui/progress";
 import { AddressDisplay } from "@/components/ui/address-display";
@@ -11,11 +10,8 @@ interface AuctionLiveStatusProps {
   highestBidder: string | undefined;
   endTime: number | undefined;
   startTime: number | undefined;
-  /** Increments when a new bid is detected — triggers animation */
   bidSignal: number;
-  /** Leading bid's on-chain comment (decoded from calldata) */
   leadingBidComment: string | null | undefined;
-  /** Total number of bids on this auction */
   bidCount: number;
   onBidHistoryOpen: () => void;
 }
@@ -36,7 +32,6 @@ export function AuctionLiveStatus({
   const [bidAnimating, setBidAnimating] = useState(false);
   const prevBidSignal = useRef<number>(bidSignal);
 
-  // Countdown timer
   useEffect(() => {
     if (!endTimeMs) return;
     const tick = () => {
@@ -57,7 +52,6 @@ export function AuctionLiveStatus({
     return () => clearInterval(timer);
   }, [endTimeMs]);
 
-  // Bid animation trigger
   useEffect(() => {
     if (bidSignal > prevBidSignal.current) {
       setBidAnimating(true);
@@ -77,7 +71,6 @@ export function AuctionLiveStatus({
     return { progressPercentage: progress, isLive: live, isEndingSoon: endingSoon };
   }, [startTimeMs, endTimeMs, timeLeft.total]);
 
-  // Progress bar color: green (plenty of time) → amber (< 30%) → red (< 10%)
   const remainingPercent = 100 - progressPercentage;
   const progressColor = remainingPercent <= 10
     ? "[&>div]:bg-red-500"
@@ -91,10 +84,10 @@ export function AuctionLiveStatus({
 
   return (
     <>
-      {/* Leading bid card — the hero element */}
+      {/* Leading bid card */}
       {hasBidder ? (
-        <div className={`rounded-lg border border-border/60 bg-muted/30 p-3 transition-all ${
-          bidAnimating ? "ring-2 ring-primary/30" : ""
+        <div className={`rounded-lg border border-border/60 bg-muted/30 p-3 ${
+          bidAnimating ? "ring-2 ring-primary/30 transition-shadow duration-300" : ""
         }`}>
           <div className="flex items-center justify-between">
             <AddressDisplay
@@ -108,14 +101,14 @@ export function AuctionLiveStatus({
               onAddressClick={() => {}}
               className="text-sm font-medium text-foreground pointer-events-none"
             />
-            <span className={`text-lg font-bold transition-all duration-300 ${
-              bidAnimating ? "scale-110 text-primary" : "scale-100"
+            <span className={`text-lg font-bold ${
+              bidAnimating ? "text-primary transition-colors duration-300" : ""
             }`}>
               {highestBid ? `${highestBid} ETH` : ""}
             </span>
           </div>
           {leadingBidComment && (
-            <p className="text-xs text-muted-foreground italic pl-7 mt-1">
+            <p className="text-xs text-muted-foreground italic pl-7 mt-1 line-clamp-2 break-words">
               &ldquo;{leadingBidComment}&rdquo;
             </p>
           )}
@@ -126,14 +119,14 @@ export function AuctionLiveStatus({
         </div>
       )}
 
-      {/* Time + progress */}
+      {/* Time + progress + bid count — single compact row */}
       <div className="flex items-center gap-2 text-xs text-muted-foreground">
-        <span className={`inline-block h-1.5 w-1.5 rounded-full ${
+        <span className={`inline-block h-1.5 w-1.5 rounded-full shrink-0 ${
           isLive
             ? isEndingSoon ? "bg-amber-500 animate-pulse" : "bg-green-500"
             : "bg-muted-foreground"
         }`} />
-        <span>
+        <span className="shrink-0">
           {isLive
             ? isEndingSoon
               ? `Ending soon · ${timeString}`
@@ -142,29 +135,16 @@ export function AuctionLiveStatus({
           }
         </span>
         <Progress value={progressPercentage} className={`h-1 flex-1 ${progressColor}`} />
+        {bidCount > 0 && (
+          <button
+            type="button"
+            onClick={onBidHistoryOpen}
+            className="shrink-0 hover:text-foreground transition-colors"
+          >
+            {bidCount} {bidCount === 1 ? "bid" : "bids"} →
+          </button>
+        )}
       </div>
     </>
-  );
-}
-
-/** Separate component for the bid history footer link */
-export function AuctionBidHistoryLink({
-  bidCount,
-  onBidHistoryOpen,
-}: {
-  bidCount: number;
-  onBidHistoryOpen: () => void;
-}) {
-  if (bidCount === 0) return null;
-
-  return (
-    <button
-      type="button"
-      onClick={onBidHistoryOpen}
-      className="group flex w-full items-center justify-end gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-    >
-      <span>{bidCount} {bidCount === 1 ? "bid" : "bids"} · View all</span>
-      <ChevronRight className="h-3 w-3 transition-transform group-hover:translate-x-0.5" />
-    </button>
   );
 }

--- a/src/components/auction/AuctionLiveStatus.tsx
+++ b/src/components/auction/AuctionLiveStatus.tsx
@@ -1,13 +1,10 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Clock } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import { zeroAddress } from "viem";
-import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { AddressDisplay } from "@/components/ui/address-display";
-import { getStatusConfig } from "@/components/proposals/utils";
-import { ProposalStatus } from "@/lib/schemas/proposals";
 
 interface AuctionLiveStatusProps {
   highestBid: string | undefined;
@@ -16,6 +13,10 @@ interface AuctionLiveStatusProps {
   startTime: number | undefined;
   /** Increments when a new bid is detected — triggers animation */
   bidSignal: number;
+  /** Leading bid's on-chain comment (decoded from calldata) */
+  leadingBidComment: string | null | undefined;
+  /** Total number of bids on this auction */
+  bidCount: number;
   onBidHistoryOpen: () => void;
 }
 
@@ -25,6 +26,8 @@ export function AuctionLiveStatus({
   endTime,
   startTime,
   bidSignal,
+  leadingBidComment,
+  bidCount,
   onBidHistoryOpen,
 }: AuctionLiveStatusProps) {
   const endTimeMs = endTime ? endTime * 1000 : 0;
@@ -74,57 +77,50 @@ export function AuctionLiveStatus({
     return { progressPercentage: progress, isLive: live, isEndingSoon: endingSoon };
   }, [startTimeMs, endTimeMs, timeLeft.total]);
 
-  const badgeStatus: ProposalStatus = isLive
-    ? isEndingSoon
-      ? ProposalStatus.PENDING
-      : ProposalStatus.ACTIVE
-    : ProposalStatus.DEFEATED;
-  const { color } = getStatusConfig(badgeStatus);
-  const badgeLabel = isLive ? (isEndingSoon ? "Ending Soon" : "Live Auction") : "Ended";
+  // Progress bar color: green (plenty of time) → amber (< 30%) → red (< 10%)
+  const remainingPercent = 100 - progressPercentage;
+  const progressColor = remainingPercent <= 10
+    ? "[&>div]:bg-red-500"
+    : remainingPercent <= 30
+      ? "[&>div]:bg-amber-500"
+      : "[&>div]:bg-green-500";
+
+  const timeString = `${timeLeft.hours.toString().padStart(2, "0")}:${timeLeft.minutes.toString().padStart(2, "0")}:${timeLeft.seconds.toString().padStart(2, "0")}`;
+
+  const hasBidder = highestBidder && highestBidder !== zeroAddress;
 
   return (
     <>
-      <div className="flex items-center justify-between">
-        <div className="flex flex-col text-center items-start">
-          <div className="flex items-center gap-1 text-sm text-muted-foreground">
-            <Clock className="h-3 w-3" />
-            Time left
-          </div>
-          <div className="text-xl font-mono">
-            {timeLeft.hours.toString().padStart(2, "0")}:
-            {timeLeft.minutes.toString().padStart(2, "0")}:
-            {timeLeft.seconds.toString().padStart(2, "0")}
-          </div>
+      {/* Status line: live indicator + time + current bid */}
+      <div className="flex items-center justify-between text-sm">
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <span className={`inline-block h-2 w-2 rounded-full ${
+            isLive
+              ? isEndingSoon ? "bg-amber-500 animate-pulse" : "bg-green-500"
+              : "bg-muted-foreground"
+          }`} />
+          <span>
+            {isLive
+              ? isEndingSoon
+                ? `Ending soon · ${timeString}`
+                : `Live · ${timeString} left`
+              : "Ended"
+            }
+          </span>
         </div>
-        <div className="flex flex-col text-center items-end">
-          <div className="text-sm text-muted-foreground">Current Highest Bid</div>
-          <div
-            className={`text-2xl font-bold transition-all duration-300 ${
-              bidAnimating
-                ? "scale-110 text-primary"
-                : "scale-100"
-            }`}
-          >
-            {highestBid ? `${highestBid} ETH` : "—"}
-          </div>
-        </div>
+        <span className={`font-bold text-base transition-all duration-300 ${
+          bidAnimating ? "scale-110 text-primary" : "scale-100"
+        }`}>
+          {highestBid ? `${highestBid} ETH` : "—"}
+        </span>
       </div>
 
-      <Progress value={progressPercentage} className="h-2" />
-
-      <div className="flex items-center justify-between">
-        <Badge className={`${color} text-xs`}>{badgeLabel}</Badge>
-        {highestBidder && highestBidder !== zeroAddress && (
-          <button
-            type="button"
-            onClick={onBidHistoryOpen}
-            className={`group flex items-center gap-2 rounded-lg border border-border/40 bg-muted/20 px-3 py-1.5 transition-all hover:border-border/80 hover:bg-muted/40 ${
-              bidAnimating ? "ring-2 ring-primary/30" : ""
-            }`}
-          >
-            <span className="text-[11px] text-muted-foreground/60">
-              {isLive ? "Leading" : "Winner"}
-            </span>
+      {/* Leading bid card */}
+      {hasBidder && (
+        <div className={`rounded-lg border border-border/60 bg-muted/30 p-3 transition-all ${
+          bidAnimating ? "ring-2 ring-primary/30" : ""
+        }`}>
+          <div className="flex items-center justify-between mb-1">
             <AddressDisplay
               address={highestBidder}
               variant="compact"
@@ -134,11 +130,47 @@ export function AuctionLiveStatus({
               showExplorer={false}
               truncateLength={4}
               onAddressClick={() => {}}
-              className="text-sm text-foreground pointer-events-none"
+              className="text-sm font-medium text-foreground pointer-events-none"
             />
-          </button>
-        )}
-      </div>
+            <span className="text-sm font-bold">
+              {highestBid ? `${highestBid} ETH` : ""}
+            </span>
+          </div>
+          {leadingBidComment && (
+            <p className="text-xs text-muted-foreground italic pl-7 mt-0.5">
+              &ldquo;{leadingBidComment}&rdquo;
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Colored progress bar */}
+      <Progress value={progressPercentage} className={`h-1.5 ${progressColor}`} />
+
+      {/* Bid history link (below the form, rendered by parent) */}
+      {/* This section only shows if there are bids */}
     </>
+  );
+}
+
+/** Separate component for the bid history footer link */
+export function AuctionBidHistoryLink({
+  bidCount,
+  onBidHistoryOpen,
+}: {
+  bidCount: number;
+  onBidHistoryOpen: () => void;
+}) {
+  if (bidCount === 0) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={onBidHistoryOpen}
+      className="group flex w-full items-center justify-end gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+    >
+      <span>{bidCount} {bidCount === 1 ? "bid" : "bids"} · View all</span>
+      <ChevronRight className="h-3 w-3 transition-transform group-hover:translate-x-0.5" />
+    </button>
   );
 }

--- a/src/components/auction/AuctionLiveStatus.tsx
+++ b/src/components/auction/AuctionLiveStatus.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Clock } from "lucide-react";
+import { zeroAddress } from "viem";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import { AddressDisplay } from "@/components/ui/address-display";
+import { getStatusConfig } from "@/components/proposals/utils";
+import { ProposalStatus } from "@/lib/schemas/proposals";
+
+interface AuctionLiveStatusProps {
+  highestBid: string | undefined;
+  highestBidder: string | undefined;
+  endTime: number | undefined;
+  startTime: number | undefined;
+  /** Increments when a new bid is detected — triggers animation */
+  bidSignal: number;
+  onBidHistoryOpen: () => void;
+}
+
+export function AuctionLiveStatus({
+  highestBid,
+  highestBidder,
+  endTime,
+  startTime,
+  bidSignal,
+  onBidHistoryOpen,
+}: AuctionLiveStatusProps) {
+  const endTimeMs = endTime ? endTime * 1000 : 0;
+  const startTimeMs = startTime ? startTime * 1000 : 0;
+  const [timeLeft, setTimeLeft] = useState({ hours: 0, minutes: 0, seconds: 0, total: 0 });
+  const [bidAnimating, setBidAnimating] = useState(false);
+  const prevBidSignal = useRef<number>(bidSignal);
+
+  // Countdown timer
+  useEffect(() => {
+    if (!endTimeMs) return;
+    const tick = () => {
+      const distance = endTimeMs - Date.now();
+      if (distance > 0) {
+        setTimeLeft({
+          hours: Math.floor((distance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)),
+          minutes: Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60)),
+          seconds: Math.floor((distance % (1000 * 60)) / 1000),
+          total: distance,
+        });
+      } else {
+        setTimeLeft({ hours: 0, minutes: 0, seconds: 0, total: 0 });
+      }
+    };
+    tick();
+    const timer = setInterval(tick, 1000);
+    return () => clearInterval(timer);
+  }, [endTimeMs]);
+
+  // Bid animation trigger
+  useEffect(() => {
+    if (bidSignal > prevBidSignal.current) {
+      setBidAnimating(true);
+      const timeout = setTimeout(() => setBidAnimating(false), 1500);
+      prevBidSignal.current = bidSignal;
+      return () => clearTimeout(timeout);
+    }
+  }, [bidSignal]);
+
+  const { progressPercentage, isLive, isEndingSoon } = useMemo(() => {
+    const fallbackDuration = 24 * 60 * 60 * 1000;
+    const duration = startTimeMs && endTimeMs ? Math.max(endTimeMs - startTimeMs, 0) : fallbackDuration;
+    const elapsed = Math.max(0, Math.min(duration, duration - Math.max(timeLeft.total, 0)));
+    const progress = Math.min(100, Math.max(0, (elapsed / duration) * 100));
+    const live = timeLeft.total > 0;
+    const endingSoon = live && timeLeft.total <= 5 * 60 * 1000;
+    return { progressPercentage: progress, isLive: live, isEndingSoon: endingSoon };
+  }, [startTimeMs, endTimeMs, timeLeft.total]);
+
+  const badgeStatus: ProposalStatus = isLive
+    ? isEndingSoon
+      ? ProposalStatus.PENDING
+      : ProposalStatus.ACTIVE
+    : ProposalStatus.DEFEATED;
+  const { color } = getStatusConfig(badgeStatus);
+  const badgeLabel = isLive ? (isEndingSoon ? "Ending Soon" : "Live Auction") : "Ended";
+
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col text-center items-start">
+          <div className="flex items-center gap-1 text-sm text-muted-foreground">
+            <Clock className="h-3 w-3" />
+            Time left
+          </div>
+          <div className="text-xl font-mono">
+            {timeLeft.hours.toString().padStart(2, "0")}:
+            {timeLeft.minutes.toString().padStart(2, "0")}:
+            {timeLeft.seconds.toString().padStart(2, "0")}
+          </div>
+        </div>
+        <div className="flex flex-col text-center items-end">
+          <div className="text-sm text-muted-foreground">Current Highest Bid</div>
+          <div
+            className={`text-2xl font-bold transition-all duration-300 ${
+              bidAnimating
+                ? "scale-110 text-primary"
+                : "scale-100"
+            }`}
+          >
+            {highestBid ? `${highestBid} ETH` : "—"}
+          </div>
+        </div>
+      </div>
+
+      <Progress value={progressPercentage} className="h-2" />
+
+      <div className="flex items-center justify-between">
+        <Badge className={`${color} text-xs`}>{badgeLabel}</Badge>
+        {highestBidder && highestBidder !== zeroAddress && (
+          <button
+            type="button"
+            onClick={onBidHistoryOpen}
+            className={`group flex items-center gap-2 rounded-lg border border-border/40 bg-muted/20 px-3 py-1.5 transition-all hover:border-border/80 hover:bg-muted/40 ${
+              bidAnimating ? "ring-2 ring-primary/30" : ""
+            }`}
+          >
+            <span className="text-[11px] text-muted-foreground/60">
+              {isLive ? "Leading" : "Winner"}
+            </span>
+            <AddressDisplay
+              address={highestBidder}
+              variant="compact"
+              showAvatar={true}
+              avatarSize="sm"
+              showCopy={false}
+              showExplorer={false}
+              truncateLength={4}
+              onAddressClick={() => {}}
+              className="text-sm text-foreground pointer-events-none"
+            />
+          </button>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/components/auction/AuctionSettleButton.tsx
+++ b/src/components/auction/AuctionSettleButton.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useCallback, useEffect, useRef } from "react";
+import { Wallet } from "lucide-react";
 import { base } from "wagmi/chains";
 import {
   useAccount,
+  useConnect,
   useReadContract,
   useSimulateContract,
   useSwitchChain,
@@ -27,10 +29,13 @@ export function AuctionSettleButton({ isWinner }: AuctionSettleButtonProps) {
   const resetTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   useEffect(() => () => clearTimeout(resetTimerRef.current), []);
 
-  const { chain } = useAccount();
+  const { isConnected, chain } = useAccount();
+  const { connectors, connectAsync } = useConnect();
   const { switchChainAsync } = useSwitchChain();
   const { writeContractAsync } = useWriteContract();
   const queryClient = useQueryClient();
+
+  const isWrongNetwork = isConnected && chain?.id !== base.id;
 
   // Check if auctions are paused
   const { data: isPaused } = useReadContract({
@@ -41,7 +46,7 @@ export function AuctionSettleButton({ isWinner }: AuctionSettleButtonProps) {
     query: { staleTime: 30 * 1000 },
   });
 
-  // Simulation
+  // Simulation — only run when connected and on the right network
   const {
     data: settleData,
     error: settleError,
@@ -51,10 +56,10 @@ export function AuctionSettleButton({ isWinner }: AuctionSettleButtonProps) {
     abi: auctionAbi,
     functionName: isPaused ? "settleAuction" : "settleCurrentAndCreateNewAuction",
     chainId: CHAIN.id,
+    query: { enabled: isConnected && !isWrongNetwork },
   });
 
   // Scoped invalidation — only auction-related readContract queries
-  // wagmi useReadContract generates keys: ['readContract', { address, functionName, ... }]
   const invalidateAuctionData = useCallback(() => {
     queryClient.invalidateQueries({
       predicate: (query) => {
@@ -81,14 +86,32 @@ export function AuctionSettleButton({ isWinner }: AuctionSettleButtonProps) {
     },
   });
 
+  const handleConnect = async () => {
+    const connector = connectors[0];
+    if (connector) {
+      try {
+        await connectAsync({ connector });
+      } catch {
+        // User cancelled
+      }
+    }
+  };
+
   const handleSettle = async () => {
+    if (!isConnected) {
+      handleConnect();
+      return;
+    }
+    if (isWrongNetwork) {
+      try {
+        await switchChainAsync({ chainId: base.id });
+      } catch {
+        return;
+      }
+    }
     if (!settleData || settleError) return;
 
     await settleTx.execute(async () => {
-      if (chain?.id !== base.id) {
-        toast.info("Switching to Base network...");
-        await switchChainAsync({ chainId: base.id });
-      }
       return writeContractAsync({
         ...settleData.request,
         chainId: base.id,
@@ -106,6 +129,17 @@ export function AuctionSettleButton({ isWinner }: AuctionSettleButtonProps) {
         </>
       );
     }
+    if (!isConnected) {
+      return (
+        <>
+          <Wallet className="h-4 w-4" />
+          Connect Wallet to Settle
+        </>
+      );
+    }
+    if (isWrongNetwork) {
+      return "Switch to Base";
+    }
     if (isSimulating) {
       return (
         <>
@@ -120,7 +154,10 @@ export function AuctionSettleButton({ isWinner }: AuctionSettleButtonProps) {
     return "Settle Auction";
   };
 
-  const isDisabled = settleTx.isActive || isSimulating || !!settleError || !settleData;
+  // Button is only disabled when actively transacting or simulation failed (while connected)
+  const isDisabled =
+    settleTx.isActive ||
+    (isConnected && !isWrongNetwork && (isSimulating || !!settleError || !settleData));
 
   return (
     <Tooltip>
@@ -135,7 +172,7 @@ export function AuctionSettleButton({ isWinner }: AuctionSettleButtonProps) {
           </Button>
         </span>
       </TooltipTrigger>
-      {settleError && (
+      {isConnected && !isWrongNetwork && settleError && (
         <TooltipContent side="bottom">
           Settlement not available yet. Try again shortly.
         </TooltipContent>

--- a/src/components/auction/AuctionSettleButton.tsx
+++ b/src/components/auction/AuctionSettleButton.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useCallback } from "react";
+import { base } from "wagmi/chains";
+import {
+  useAccount,
+  useReadContract,
+  useSimulateContract,
+  useSwitchChain,
+  useWriteContract,
+} from "wagmi";
+import { useQueryClient } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { CHAIN, DAO_ADDRESSES } from "@/lib/config";
+import auctionAbi from "@/utils/abis/auctionAbi";
+import { toast } from "sonner";
+import { useAuctionTransaction } from "@/hooks/use-auction-transaction";
+
+interface AuctionSettleButtonProps {
+  /** Whether the connected wallet is the auction winner */
+  isWinner: boolean;
+}
+
+export function AuctionSettleButton({ isWinner }: AuctionSettleButtonProps) {
+  const { chain } = useAccount();
+  const { switchChainAsync } = useSwitchChain();
+  const { writeContractAsync } = useWriteContract();
+  const queryClient = useQueryClient();
+
+  // Check if auctions are paused
+  const { data: isPaused } = useReadContract({
+    address: DAO_ADDRESSES.auction as `0x${string}`,
+    abi: auctionAbi,
+    functionName: "paused",
+    chainId: CHAIN.id,
+    query: { staleTime: 30 * 1000 },
+  });
+
+  // Simulation
+  const {
+    data: settleData,
+    error: settleError,
+    isLoading: isSimulating,
+  } = useSimulateContract({
+    address: DAO_ADDRESSES.auction as `0x${string}`,
+    abi: auctionAbi,
+    functionName: isPaused ? "settleAuction" : "settleCurrentAndCreateNewAuction",
+    chainId: CHAIN.id,
+  });
+
+  // Scoped invalidation
+  const invalidateAuctionData = useCallback(() => {
+    queryClient.invalidateQueries({
+      predicate: (query) => {
+        const key = query.queryKey;
+        if (key[0] === "readContract" && Array.isArray(key)) {
+          const serialized = JSON.stringify(key);
+          return serialized.includes(DAO_ADDRESSES.auction.toLowerCase());
+        }
+        return false;
+      },
+    });
+    queryClient.invalidateQueries({ queryKey: ["daoAuction"] });
+  }, [queryClient]);
+
+  const settleTx = useAuctionTransaction({
+    onConfirmed: () => {
+      toast.success("Settlement confirmed!", {
+        description: "Loading new auction...",
+      });
+      invalidateAuctionData();
+      setTimeout(() => settleTx.reset(), 1500);
+    },
+    onError: (error) => {
+      toast.error("Settlement failed", { description: error.message });
+    },
+  });
+
+  const handleSettle = async () => {
+    if (!settleData || settleError) return;
+
+    await settleTx.execute(async () => {
+      if (chain?.id !== base.id) {
+        toast.info("Switching to Base network...");
+        await switchChainAsync({ chainId: base.id });
+      }
+      return writeContractAsync({
+        ...settleData.request,
+        chainId: base.id,
+      });
+    });
+  };
+
+  // Button content
+  const getButtonContent = () => {
+    if (settleTx.isActive) {
+      return (
+        <>
+          <Spinner />
+          {settleTx.buttonLabel("Settle Auction")}
+        </>
+      );
+    }
+    if (isSimulating) {
+      return (
+        <>
+          <Spinner />
+          Preparing...
+        </>
+      );
+    }
+    if (isWinner) {
+      return "Claim Your Gnar & Start Next Auction";
+    }
+    return "Settle Auction";
+  };
+
+  const isDisabled = settleTx.isActive || isSimulating || !!settleError || !settleData;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="w-full">
+          <Button
+            className="w-full touch-manipulation"
+            disabled={isDisabled}
+            onClick={handleSettle}
+          >
+            {getButtonContent()}
+          </Button>
+        </span>
+      </TooltipTrigger>
+      {settleError && (
+        <TooltipContent side="bottom">
+          Settlement not available yet. Try again shortly.
+        </TooltipContent>
+      )}
+    </Tooltip>
+  );
+}

--- a/src/components/auction/AuctionSettleButton.tsx
+++ b/src/components/auction/AuctionSettleButton.tsx
@@ -50,7 +50,8 @@ export function AuctionSettleButton({ isWinner }: AuctionSettleButtonProps) {
     chainId: CHAIN.id,
   });
 
-  // Scoped invalidation
+  // Scoped invalidation — only auction-related readContract queries
+  // wagmi useReadContract generates keys: ['readContract', { address, functionName, ... }]
   const invalidateAuctionData = useCallback(() => {
     queryClient.invalidateQueries({
       predicate: (query) => {
@@ -62,7 +63,6 @@ export function AuctionSettleButton({ isWinner }: AuctionSettleButtonProps) {
         return false;
       },
     });
-    queryClient.invalidateQueries({ queryKey: ["daoAuction"] });
   }, [queryClient]);
 
   const settleTx = useAuctionTransaction({

--- a/src/components/auction/AuctionSettleButton.tsx
+++ b/src/components/auction/AuctionSettleButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { base } from "wagmi/chains";
 import {
   useAccount,
@@ -24,6 +24,9 @@ interface AuctionSettleButtonProps {
 }
 
 export function AuctionSettleButton({ isWinner }: AuctionSettleButtonProps) {
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  useEffect(() => () => clearTimeout(resetTimerRef.current), []);
+
   const { chain } = useAccount();
   const { switchChainAsync } = useSwitchChain();
   const { writeContractAsync } = useWriteContract();
@@ -71,7 +74,7 @@ export function AuctionSettleButton({ isWinner }: AuctionSettleButtonProps) {
         description: "Loading new auction...",
       });
       invalidateAuctionData();
-      setTimeout(() => settleTx.reset(), 1500);
+      resetTimerRef.current = setTimeout(() => settleTx.reset(), 1500);
     },
     onError: (error) => {
       toast.error("Settlement failed", { description: error.message });

--- a/src/components/auction/AuctionSettleButton.tsx
+++ b/src/components/auction/AuctionSettleButton.tsx
@@ -65,7 +65,9 @@ export function AuctionSettleButton({ isWinner }: AuctionSettleButtonProps) {
       predicate: (query) => {
         const key = query.queryKey;
         if (key[0] === "readContract" && Array.isArray(key)) {
-          const serialized = JSON.stringify(key);
+          const serialized = JSON.stringify(key, (_, v) =>
+            typeof v === "bigint" ? v.toString() : v,
+          );
           return serialized.includes(DAO_ADDRESSES.auction.toLowerCase());
         }
         return false;

--- a/src/components/auction/AuctionSettleButton.tsx
+++ b/src/components/auction/AuctionSettleButton.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Wallet } from "lucide-react";
 import { base } from "wagmi/chains";
 import {
   useAccount,
-  useConnect,
   useReadContract,
   useSimulateContract,
   useSwitchChain,
@@ -19,6 +18,7 @@ import { CHAIN, DAO_ADDRESSES } from "@/lib/config";
 import auctionAbi from "@/utils/abis/auctionAbi";
 import { toast } from "sonner";
 import { useAuctionTransaction } from "@/hooks/use-auction-transaction";
+import { ConnectWalletModal } from "@/components/auction/ConnectWalletModal";
 
 interface AuctionSettleButtonProps {
   /** Whether the connected wallet is the auction winner */
@@ -30,10 +30,10 @@ export function AuctionSettleButton({ isWinner }: AuctionSettleButtonProps) {
   useEffect(() => () => clearTimeout(resetTimerRef.current), []);
 
   const { isConnected, chain } = useAccount();
-  const { connectors, connectAsync } = useConnect();
   const { switchChainAsync } = useSwitchChain();
   const { writeContractAsync } = useWriteContract();
   const queryClient = useQueryClient();
+  const [isConnectModalOpen, setIsConnectModalOpen] = useState(false);
 
   const isWrongNetwork = isConnected && chain?.id !== base.id;
 
@@ -86,20 +86,9 @@ export function AuctionSettleButton({ isWinner }: AuctionSettleButtonProps) {
     },
   });
 
-  const handleConnect = async () => {
-    const connector = connectors[0];
-    if (connector) {
-      try {
-        await connectAsync({ connector });
-      } catch {
-        // User cancelled
-      }
-    }
-  };
-
   const handleSettle = async () => {
     if (!isConnected) {
-      handleConnect();
+      setIsConnectModalOpen(true);
       return;
     }
     if (isWrongNetwork) {
@@ -160,23 +149,30 @@ export function AuctionSettleButton({ isWinner }: AuctionSettleButtonProps) {
     (isConnected && !isWrongNetwork && (isSimulating || !!settleError || !settleData));
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span className="w-full">
-          <Button
-            className="w-full touch-manipulation"
-            disabled={isDisabled}
-            onClick={handleSettle}
-          >
-            {getButtonContent()}
-          </Button>
-        </span>
-      </TooltipTrigger>
-      {isConnected && !isWrongNetwork && settleError && (
-        <TooltipContent side="bottom">
-          Settlement not available yet. Try again shortly.
-        </TooltipContent>
-      )}
-    </Tooltip>
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="w-full">
+            <Button
+              className="w-full touch-manipulation"
+              disabled={isDisabled}
+              onClick={handleSettle}
+            >
+              {getButtonContent()}
+            </Button>
+          </span>
+        </TooltipTrigger>
+        {isConnected && !isWrongNetwork && settleError && (
+          <TooltipContent side="bottom">
+            Settlement not available yet. Try again shortly.
+          </TooltipContent>
+        )}
+      </Tooltip>
+
+      <ConnectWalletModal
+        open={isConnectModalOpen}
+        onOpenChange={setIsConnectModalOpen}
+      />
+    </>
   );
 }

--- a/src/components/auction/BidItem.tsx
+++ b/src/components/auction/BidItem.tsx
@@ -47,8 +47,8 @@ export function BidItem({ bidder, amount, bidTime, comment, isNew }: BidItemProp
 
       <div className="mt-1.5 flex items-center justify-between gap-2">
         {comment ? (
-          <p className="flex-1 truncate text-xs italic text-muted-foreground">
-            &ldquo;{comment.length > 140 ? `${comment.slice(0, 140)}…` : comment}&rdquo;
+          <p className="flex-1 text-xs italic text-muted-foreground line-clamp-2 break-words">
+            &ldquo;{comment}&rdquo;
           </p>
         ) : (
           <span />

--- a/src/components/auction/ConnectWalletModal.tsx
+++ b/src/components/auction/ConnectWalletModal.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useMemo } from "react";
 import { useConnect } from "wagmi";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -13,6 +15,25 @@ import { Spinner } from "@/components/ui/spinner";
 import { toast } from "sonner";
 import { useState } from "react";
 
+const LAST_CONNECTOR_KEY = "gnars-last-connector";
+
+function getLastConnectorId(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return localStorage.getItem(LAST_CONNECTOR_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function setLastConnectorId(id: string) {
+  try {
+    localStorage.setItem(LAST_CONNECTOR_KEY, id);
+  } catch {
+    // localStorage unavailable
+  }
+}
+
 interface ConnectWalletModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -22,10 +43,23 @@ export function ConnectWalletModal({ open, onOpenChange }: ConnectWalletModalPro
   const { connectors, connectAsync } = useConnect();
   const [connectingId, setConnectingId] = useState<string | null>(null);
 
+  const lastConnectorId = useMemo(() => getLastConnectorId(), []);
+
+  // Sort: last used first, then original order
+  const sortedConnectors = useMemo(() => {
+    if (!lastConnectorId) return connectors;
+    return [...connectors].sort((a, b) => {
+      if (a.id === lastConnectorId) return -1;
+      if (b.id === lastConnectorId) return 1;
+      return 0;
+    });
+  }, [connectors, lastConnectorId]);
+
   const handleConnect = async (connector: (typeof connectors)[number]) => {
     setConnectingId(connector.uid);
     try {
       await connectAsync({ connector });
+      setLastConnectorId(connector.id);
       onOpenChange(false);
     } catch (err: unknown) {
       const message =
@@ -52,29 +86,39 @@ export function ConnectWalletModal({ open, onOpenChange }: ConnectWalletModalPro
           </DialogDescription>
         </DialogHeader>
         <div className="flex flex-col gap-2 pt-2">
-          {connectors.map((connector) => (
-            <Button
-              key={connector.uid}
-              variant="outline"
-              className="w-full justify-start gap-3 h-12 cursor-pointer"
-              disabled={connectingId !== null}
-              onClick={() => handleConnect(connector)}
-            >
-              {connectingId === connector.uid ? (
-                <Spinner />
-              ) : (
-                connector.icon && (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img
-                    src={connector.icon}
-                    alt=""
-                    className="h-6 w-6 rounded"
-                  />
-                )
-              )}
-              <span className="font-medium">{connector.name}</span>
-            </Button>
-          ))}
+          {sortedConnectors.map((connector) => {
+            const isLastUsed = connector.id === lastConnectorId;
+            return (
+              <Button
+                key={connector.uid}
+                variant="outline"
+                className={`w-full justify-start gap-3 h-12 cursor-pointer ${
+                  isLastUsed ? "border-primary/50 bg-primary/5" : ""
+                }`}
+                disabled={connectingId !== null}
+                onClick={() => handleConnect(connector)}
+              >
+                {connectingId === connector.uid ? (
+                  <Spinner />
+                ) : (
+                  connector.icon && (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={connector.icon}
+                      alt=""
+                      className="h-6 w-6 rounded"
+                    />
+                  )
+                )}
+                <span className="font-medium flex-1 text-left">{connector.name}</span>
+                {isLastUsed && (
+                  <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
+                    Last used
+                  </Badge>
+                )}
+              </Button>
+            );
+          })}
         </div>
       </DialogContent>
     </Dialog>

--- a/src/components/auction/ConnectWalletModal.tsx
+++ b/src/components/auction/ConnectWalletModal.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useConnect } from "wagmi";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Spinner } from "@/components/ui/spinner";
+import { toast } from "sonner";
+import { useState } from "react";
+
+interface ConnectWalletModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ConnectWalletModal({ open, onOpenChange }: ConnectWalletModalProps) {
+  const { connectors, connectAsync } = useConnect();
+  const [connectingId, setConnectingId] = useState<string | null>(null);
+
+  const handleConnect = async (connector: (typeof connectors)[number]) => {
+    setConnectingId(connector.uid);
+    try {
+      await connectAsync({ connector });
+      onOpenChange(false);
+    } catch (err: unknown) {
+      const message =
+        err && typeof err === "object" && "message" in err
+          ? String((err as { message?: string }).message ?? "Failed to connect")
+          : "Failed to connect";
+      if (/rejected|user|cancel/i.test(message)) {
+        toast("Connection cancelled");
+      } else {
+        toast.error("Connection failed", { description: message });
+      }
+    } finally {
+      setConnectingId(null);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Connect Wallet</DialogTitle>
+          <DialogDescription>
+            Choose a wallet to place bids and interact with Gnars DAO.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-2 pt-2">
+          {connectors.map((connector) => (
+            <Button
+              key={connector.uid}
+              variant="outline"
+              className="w-full justify-start gap-3 h-12 cursor-pointer"
+              disabled={connectingId !== null}
+              onClick={() => handleConnect(connector)}
+            >
+              {connectingId === connector.uid ? (
+                <Spinner />
+              ) : (
+                connector.icon && (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={connector.icon}
+                    alt=""
+                    className="h-6 w-6 rounded"
+                  />
+                )
+              )}
+              <span className="font-medium">{connector.name}</span>
+            </Button>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/feed/AuctionEventCard.tsx
+++ b/src/components/feed/AuctionEventCard.tsx
@@ -6,6 +6,7 @@
 
 "use client";
 
+import { useMemo } from "react";
 import Link from "next/link";
 import { formatDistanceToNow } from "date-fns";
 import { Palette, DollarSign, Trophy, Clock, Radio } from "lucide-react";
@@ -16,6 +17,7 @@ import { TokenImage } from "@/components/ui/token-image";
 import { cn } from "@/lib/utils";
 import { formatETH } from "@/lib/utils";
 import type { FeedEvent } from "@/lib/types/feed-events";
+import { useBidComments } from "@/hooks/use-bid-comments";
 
 export interface AuctionEventCardProps {
   event: Extract<FeedEvent, { category: "auction" }>;
@@ -136,6 +138,11 @@ function AuctionBidContent({ event, compact }: {
     ? ((parseFloat(event.amount) - parseFloat(event.previousBid)) / parseFloat(event.previousBid) * 100).toFixed(1)
     : null;
 
+  // Decode on-chain comment from TX calldata
+  const txHashes = useMemo(() => [event.transactionHash], [event.transactionHash]);
+  const { comments } = useBidComments(txHashes);
+  const comment = comments.get(event.transactionHash);
+
   return (
     <div className="space-y-2">
       <div className="flex items-center gap-2 flex-wrap">
@@ -156,6 +163,11 @@ function AuctionBidContent({ event, compact }: {
           <span className="text-xs text-muted-foreground">(+{increase}%)</span>
         )}
       </div>
+      {comment && (
+        <p className="text-xs text-muted-foreground italic pl-1">
+          &ldquo;{comment}&rdquo;
+        </p>
+      )}
       {event.extended && !compact && (
         <Badge variant="secondary" className="text-xs">
           Auction Extended

--- a/src/components/hero/AuctionSpotlight.tsx
+++ b/src/components/hero/AuctionSpotlight.tsx
@@ -1,45 +1,40 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { Clock, ChevronDown, ChevronRight, MessageSquare } from "lucide-react";
-import { formatEther, parseEther, zeroAddress, encodeFunctionData, concat, toHex } from "viem";
-import { base } from "wagmi/chains";
+import { useEffect, useState } from "react";
+import { formatEther } from "viem";
+import { useAccount, useReadContract } from "wagmi";
 import { useDaoAuction } from "@buildeross/hooks";
-import { useAccount, useReadContract, useSimulateContract, useWriteContract, useWaitForTransactionReceipt, useSwitchChain, useSendTransaction } from "wagmi";
-import { useQueryClient } from "@tanstack/react-query";
 import { GnarImageTile } from "@/components/auctions/GnarImageTile";
-import { AddressDisplay } from "@/components/ui/address-display";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from "@/components/ui/input-group";
-import { Progress } from "@/components/ui/progress";
-import { Spinner } from "@/components/ui/spinner";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
 import { CHAIN, DAO_ADDRESSES } from "@/lib/config";
-import { getStatusConfig } from "@/components/proposals/utils";
-import { ProposalStatus } from "@/lib/schemas/proposals";
 import auctionAbi from "@/utils/abis/auctionAbi";
 import { toast } from "sonner";
 import { BidHistoryModal } from "@/components/auction/BidHistoryModal";
+import { AuctionLiveStatus } from "@/components/auction/AuctionLiveStatus";
+import { AuctionBidForm } from "@/components/auction/AuctionBidForm";
+import { AuctionSettleButton } from "@/components/auction/AuctionSettleButton";
+import { useAuctionLive } from "@/hooks/use-auction-live";
 
 export function AuctionSpotlight() {
-  const { address, isConnected, chain } = useAccount();
-  const { switchChainAsync } = useSwitchChain();
-  const queryClient = useQueryClient();
+  const { address } = useAccount();
+  const [isBidHistoryOpen, setIsBidHistoryOpen] = useState(false);
+
+  // Primary auction data (metadata, tokenUri)
   const { highestBid, highestBidder, endTime, startTime, tokenId, tokenUri } = useDaoAuction({
     collectionAddress: DAO_ADDRESSES.token,
     auctionAddress: DAO_ADDRESSES.auction,
     chainId: CHAIN.id,
   });
 
-  // Invalidate all wagmi contract reads to refresh auction data without page reload
-  const invalidateAuctionData = useCallback(() => {
-    queryClient.invalidateQueries({ queryKey: ["readContract"] });
-  }, [queryClient]);
+  // Live updates (event subscription + polling fallback)
+  const auctionLive = useAuctionLive(tokenId ? BigInt(tokenId) : undefined);
 
-  // Read reserve price from auction contract
+  // Use live data when available, fall back to SDK data
+  const displayBid = auctionLive.polledHighestBid ?? highestBid;
+  const displayBidder = auctionLive.polledHighestBidder ?? highestBidder;
+  const displayEndTime = auctionLive.polledEndTime ?? endTime;
+
+  // Reserve price for min bid calculation
   const { data: reservePriceWei } = useReadContract({
     address: DAO_ADDRESSES.auction as `0x${string}`,
     abi: auctionAbi,
@@ -49,400 +44,77 @@ export function AuctionSpotlight() {
   });
   const reservePriceEth = reservePriceWei ? Number(formatEther(reservePriceWei)) : 0.01;
 
-  const [isSettling, setIsSettling] = useState(false);
-  const [settleTxHash, setSettleTxHash] = useState<`0x${string}` | undefined>();
-  const [isBidding, setIsBidding] = useState(false);
-  const [bidTxHash, setBidTxHash] = useState<`0x${string}` | undefined>();
-  const [bidComment, setBidComment] = useState("");
-  const [isCommentOpen, setIsCommentOpen] = useState(false);
-  const [isBidHistoryOpen, setIsBidHistoryOpen] = useState(false);
-
-  // Calculate minimum bid: reserve price when no bids, otherwise 1% increment
-  const minNextBidEth = useMemo(() => {
-    const current = Number(highestBid ?? "0");
-    if (!Number.isFinite(current) || current <= 0) return reservePriceEth;
-    return Math.max(0, current * 1.01);
-  }, [highestBid, reservePriceEth]);
-
-  const [bidAmount, setBidAmount] = useState(minNextBidEth.toFixed(4));
+  // Derived state
   const tokenName = tokenUri?.name;
   const imageUrl = tokenUri?.image
     ? tokenUri.image.startsWith("ipfs://")
       ? tokenUri.image.replace("ipfs://", "https://ipfs.io/ipfs/")
       : tokenUri.image
     : undefined;
-  const endTimeMs = endTime ? new Date(endTime * 1000).getTime() : 0;
-  const startTimeMs = startTime ? new Date(startTime * 1000).getTime() : 0;
-  const [timeLeft, setTimeLeft] = useState({ hours: 0, minutes: 0, seconds: 0, total: 0 });
 
-  useEffect(() => {
-    if (!endTimeMs) return;
-    const timer = setInterval(() => {
-      const now = Date.now();
-      const distance = endTimeMs - now;
-      if (distance > 0) {
-        setTimeLeft({
-          hours: Math.floor((distance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)),
-          minutes: Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60)),
-          seconds: Math.floor((distance % (1000 * 60)) / 1000),
-          total: distance,
-        });
-      } else {
-        setTimeLeft({ hours: 0, minutes: 0, seconds: 0, total: 0 });
-      }
-    }, 1000);
-    return () => clearInterval(timer);
-  }, [endTimeMs]);
-
-  const { progressPercentage, isLive, isEndingSoon } = useMemo(() => {
-    const fallbackDuration = 24 * 60 * 60 * 1000;
-    const duration = startTimeMs && endTimeMs ? Math.max(endTimeMs - startTimeMs, 0) : fallbackDuration;
-    const elapsed = Math.max(0, Math.min(duration, duration - Math.max(timeLeft.total, 0)));
-    const progress = Math.min(100, Math.max(0, (elapsed / duration) * 100));
-    const live = timeLeft.total > 0;
-    const endingSoon = live && timeLeft.total <= 5 * 60 * 1000;
-    return { progressPercentage: progress, isLive: live, isEndingSoon: endingSoon };
-  }, [startTimeMs, endTimeMs, timeLeft.total]);
-
-  const badgeStatus: ProposalStatus = isLive
-    ? isEndingSoon
-      ? ProposalStatus.PENDING
-      : ProposalStatus.ACTIVE
-    : ProposalStatus.DEFEATED;
-  const { color } = getStatusConfig(badgeStatus);
-  const badgeLabel = isLive ? (isEndingSoon ? "Ending Soon" : "Live Auction") : "Ended";
-
-  // Update bid amount when minimum changes
-  useEffect(() => {
-    setBidAmount(minNextBidEth.toFixed(4));
-  }, [minNextBidEth]);
-
-  // Validate bid amount
-  const bidAmountNum = parseFloat(bidAmount);
-  const isValidBid = !isNaN(bidAmountNum) && bidAmountNum >= minNextBidEth;
-  
-  const bidAmountWei = useMemo(() => {
-    try {
-      return isValidBid ? parseEther(bidAmount) : undefined;
-    } catch {
-      return undefined;
-    }
-  }, [bidAmount, isValidBid]);
-
-  // Check if auctions are paused - cache for 30 seconds since this can change
-  const { data: isPaused } = useReadContract({
-    address: DAO_ADDRESSES.auction as `0x${string}`,
-    abi: auctionAbi,
-    functionName: "paused",
-    chainId: CHAIN.id,
-    query: {
-      staleTime: 30 * 1000, // 30 seconds
-      refetchInterval: false,
-    },
-  });
-
-  const { writeContractAsync } = useWriteContract();
-  const { sendTransactionAsync } = useSendTransaction();
-
-  // Wait for bid transaction confirmation
-  const { isLoading: isBidConfirming, isSuccess: isBidConfirmed } = useWaitForTransactionReceipt({
-    hash: bidTxHash,
-    chainId: CHAIN.id,
-  });
-
-  // Refresh auction data when bid is confirmed
-  useEffect(() => {
-    if (isBidConfirmed && bidTxHash) {
-      toast.success("Bid confirmed!", {
-        description: "Auction data updated.",
-      });
-      invalidateAuctionData();
-      setBidTxHash(undefined);
-      setIsBidding(false);
-      setBidComment("");
-      setIsCommentOpen(false);
-    }
-  }, [isBidConfirmed, bidTxHash, invalidateAuctionData]);
-
-  // Handle bid submission
-  const handleBid = async () => {
-    if (!isConnected || !bidAmountWei || !tokenId || !isValidBid) return;
-
-    const trimmedComment = bidComment.trim();
-
-    try {
-      setIsBidding(true);
-
-      if (chain?.id !== base.id) {
-        toast.info("Switching to Base network...");
-        await switchChainAsync({ chainId: base.id });
-      }
-
-      let hash: `0x${string}`;
-
-      if (trimmedComment.length > 0) {
-        // Comment path: encode createBid calldata + append UTF-8 comment bytes
-        const baseCalldata = encodeFunctionData({
-          abi: auctionAbi,
-          functionName: "createBid",
-          args: [BigInt(tokenId)],
-        });
-        const commentBytes = toHex(new TextEncoder().encode(trimmedComment));
-        const fullData = concat([baseCalldata, commentBytes]);
-
-        hash = await sendTransactionAsync({
-          to: DAO_ADDRESSES.auction as `0x${string}`,
-          data: fullData,
-          value: bidAmountWei,
-          chainId: base.id,
-        });
-      } else {
-        // Original path (no regression)
-        hash = await writeContractAsync({
-          address: DAO_ADDRESSES.auction as `0x${string}`,
-          abi: auctionAbi,
-          functionName: "createBid",
-          args: [BigInt(tokenId)],
-          value: bidAmountWei,
-          chainId: base.id,
-        });
-      }
-
-      setBidTxHash(hash);
-      toast.success("Bid submitted", {
-        description: "Waiting for confirmation...",
-      });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to submit bid";
-      toast.error("Bid failed", { description: message });
-      setIsBidding(false);
-    }
-  };
-
-  // Settlement simulation - only when auction has ended
-  const isAuctionEnded = !isLive && timeLeft.total <= 0;
-  const { data: settleData, error: settleError } = useSimulateContract({
-    address: DAO_ADDRESSES.auction as `0x${string}`,
-    abi: auctionAbi,
-    functionName: isPaused ? "settleAuction" : "settleCurrentAndCreateNewAuction",
-    chainId: CHAIN.id,
-    query: { enabled: isAuctionEnded },
-  });
-
-  // Check if connected user is the winner
   const isWinner =
-    address && highestBidder && address.toLowerCase() === highestBidder.toLowerCase();
+    address && displayBidder && address.toLowerCase() === displayBidder.toLowerCase();
 
-  // Wait for settlement transaction confirmation
-  const { isLoading: isConfirming, isSuccess: isConfirmed } = useWaitForTransactionReceipt({
-    hash: settleTxHash,
-    chainId: CHAIN.id,
-  });
-
-  // Settlement handler
-  const handleSettle = async () => {
-    if (!settleData || settleError) return;
-
-    try {
-      setIsSettling(true);
-      
-      // Check if on correct network, switch if needed
-      if (chain?.id !== base.id) {
-        toast.info("Switching to Base network...");
-        await switchChainAsync({ chainId: base.id });
-      }
-      
-      const hash = await writeContractAsync({
-        ...settleData.request,
-        chainId: base.id,
-      });
-      setSettleTxHash(hash);
-      toast.success("Settlement submitted", {
-        description: "Waiting for confirmation...",
-      });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to settle auction";
-      toast.error("Settlement failed", { description: message });
-      setIsSettling(false);
-      setSettleTxHash(undefined);
-    }
-  };
-
-  // Handle successful settlement confirmation — refresh auction data
+  // Determine if auction is live — re-check every second
+  const [isLive, setIsLive] = useState(false);
   useEffect(() => {
-    if (isConfirmed && settleTxHash) {
-      toast.success("Settlement confirmed!", {
-        description: "Loading new auction...",
+    if (!displayEndTime) { setIsLive(false); return; }
+    const check = () => setIsLive(displayEndTime * 1000 > Date.now());
+    check();
+    const timer = setInterval(check, 1000);
+    return () => clearInterval(timer);
+  }, [displayEndTime]);
+
+  // Outbid notification
+  const { wasOutbid, latestBid, clearOutbid } = auctionLive;
+  useEffect(() => {
+    if (wasOutbid && latestBid) {
+      toast.warning("You've been outbid!", {
+        description: `Current bid: ${latestBid.amountEth} ETH`,
+        action: {
+          label: "Bid Again",
+          onClick: () => {
+            // Focus the bid input — the form will handle scrolling
+            const input = document.querySelector<HTMLInputElement>(
+              'input[type="number"]',
+            );
+            input?.focus();
+          },
+        },
+        duration: 8000,
       });
-      invalidateAuctionData();
-      setIsSettling(false);
-      setSettleTxHash(undefined);
+      clearOutbid();
     }
-  }, [isConfirmed, settleTxHash, invalidateAuctionData]);
+  }, [wasOutbid, latestBid, clearOutbid]);
 
   return (
     <Card className="w-full bg-card">
       <CardContent className="py-2">
         <div className="space-y-4">
-          <div className="flex items-center justify-between">
-            <div className="text-xl font-semibold">
-              {tokenName || (tokenId ? `#${tokenId.toString()}` : "Latest Auction")}
-            </div>
-            <Badge className={`${color} text-xs`}>{badgeLabel}</Badge>
+          <div className="text-xl font-semibold">
+            {tokenName || (tokenId ? `#${tokenId.toString()}` : "Latest Auction")}
           </div>
 
           <GnarImageTile tokenId={Number(tokenId || 0)} imageUrl={imageUrl} />
 
           <div className="space-y-3">
-            <div className="flex items-center justify-between">
-              <div className="flex flex-col text-center items-start">
-                <div className="flex items-center gap-1 text-sm text-muted-foreground">
-                  <Clock className="h-3 w-3" />
-                  Time left
-                </div>
-                <div className="text-xl font-mono">
-                  {timeLeft.hours.toString().padStart(2, "0")}:{timeLeft.minutes
-                    .toString()
-                    .padStart(2, "0")}:{timeLeft.seconds.toString().padStart(2, "0")}
-                </div>
-              </div>
-              <div className="flex flex-col text-center items-end">
-                <div className="text-sm text-muted-foreground">Current Highest Bid</div>
-                <div className="text-2xl font-bold">{highestBid ? `${highestBid} ETH` : "—"}</div>
-              </div>
-            </div>
-
-            <Progress value={progressPercentage} className="h-2" />
+            <AuctionLiveStatus
+              highestBid={displayBid}
+              highestBidder={displayBidder}
+              endTime={displayEndTime}
+              startTime={startTime}
+              bidSignal={auctionLive.bidCount}
+              onBidHistoryOpen={() => setIsBidHistoryOpen(true)}
+            />
 
             {isLive ? (
-              <>
-                <div className="flex gap-2">
-                  <Tooltip open={isLive && !isValidBid && isConnected && !!bidAmount}>
-                    <TooltipTrigger asChild>
-                      <InputGroup className="flex-[3]">
-                        <InputGroupInput
-                          type="number"
-                          step="0.0001"
-                          min={minNextBidEth}
-                          value={bidAmount}
-                          onChange={(e) => setBidAmount(e.target.value)}
-                          placeholder={minNextBidEth.toFixed(4)}
-                          disabled={!isConnected || isBidding}
-                          className="[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                        />
-                        <InputGroupAddon align="inline-end">
-                          <InputGroupText>ETH</InputGroupText>
-                        </InputGroupAddon>
-                      </InputGroup>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" className="font-mono">
-                      Minimum bid: {minNextBidEth} ETH
-                    </TooltipContent>
-                  </Tooltip>
-                  <Button
-                    className="flex-[7] touch-manipulation"
-                    disabled={!isConnected || isBidding || isBidConfirming || !isValidBid}
-                    onClick={handleBid}
-                  >
-                    {isBidConfirming ? (
-                      <>
-                        <Spinner />
-                        Confirming...
-                      </>
-                    ) : isBidding ? (
-                      <>
-                        <Spinner />
-                        Bidding...
-                      </>
-                    ) : (
-                      "Place Bid"
-                    )}
-                  </Button>
-                </div>
-                <Collapsible open={isCommentOpen} onOpenChange={setIsCommentOpen}>
-                  <CollapsibleTrigger asChild>
-                    <button
-                      type="button"
-                      disabled={!isConnected || isBidding}
-                      className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 disabled:pointer-events-none"
-                    >
-                      <MessageSquare className="h-3 w-3" />
-                      Add a comment
-                      <ChevronDown
-                        className={`h-3 w-3 transition-transform duration-200 ${isCommentOpen ? "rotate-180" : ""}`}
-                      />
-                    </button>
-                  </CollapsibleTrigger>
-                  <CollapsibleContent>
-                    <div className="mt-2 space-y-1">
-                      <textarea
-                        maxLength={140}
-                        rows={2}
-                        value={bidComment}
-                        onChange={(e) => setBidComment(e.target.value)}
-                        disabled={!isConnected || isBidding}
-                        placeholder="Optional on-chain comment (recorded permanently)…"
-                        className="w-full resize-none rounded-md border border-input bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
-                      />
-                      <div className="text-right text-xs text-muted-foreground">
-                        {bidComment.length}/140
-                      </div>
-                    </div>
-                  </CollapsibleContent>
-                </Collapsible>
-              </>
+              <AuctionBidForm
+                tokenId={tokenId ? BigInt(tokenId) : undefined}
+                highestBid={displayBid}
+                reservePriceEth={reservePriceEth}
+              />
             ) : (
-              <Button
-                className="w-full touch-manipulation"
-                disabled={isSettling || isConfirming || !!settleError}
-                onClick={handleSettle}
-              >
-                {isSettling || isConfirming ? (
-                  <>
-                    <Spinner />
-                    {isConfirming ? "Confirming..." : "Settling…"}
-                  </>
-                ) : isWinner ? (
-                  "Claim NFT"
-                ) : (
-                  "Settle Auction"
-                )}
-              </Button>
-            )}
-
-            {isLive && !isConnected && (
-              <p className="text-xs text-muted-foreground text-center">
-                Connect your wallet to place a bid
-              </p>
-            )}
-
-            {highestBidder && highestBidder !== zeroAddress && (
-              <button
-                type="button"
-                onClick={() => setIsBidHistoryOpen(true)}
-                className="group flex w-full flex-col gap-1 rounded-lg border border-border/40 bg-muted/20 px-3 py-2.5 transition-all hover:border-border/80 hover:bg-muted/40"
-              >
-                <span className="text-[11px] text-muted-foreground/60">
-                  {isLive ? "Leading bidder" : "Winner"}
-                </span>
-                <div className="flex w-full items-center justify-between">
-                  <AddressDisplay
-                    address={highestBidder}
-                    variant="compact"
-                    showAvatar={true}
-                    avatarSize="sm"
-                    showCopy={false}
-                    showExplorer={false}
-                    truncateLength={4}
-                    onAddressClick={() => {}}
-                    className="text-sm text-foreground pointer-events-none"
-                  />
-                  <div className="flex items-center gap-1 text-xs text-muted-foreground transition-colors group-hover:text-foreground">
-                    <span>View bids</span>
-                    <ChevronRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" />
-                  </div>
-                </div>
-              </button>
+              <AuctionSettleButton isWinner={!!isWinner} />
             )}
 
             <BidHistoryModal
@@ -457,5 +129,3 @@ export function AuctionSpotlight() {
     </Card>
   );
 }
-
-

--- a/src/components/hero/AuctionSpotlight.tsx
+++ b/src/components/hero/AuctionSpotlight.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { formatEther } from "viem";
 import { useAccount, useReadContract } from "wagmi";
 import { useDaoAuction } from "@buildeross/hooks";
@@ -21,11 +21,12 @@ export function AuctionSpotlight() {
   const { address } = useAccount();
   const [isBidHistoryOpen, setIsBidHistoryOpen] = useState(false);
 
-  // Optimistic state — shown immediately after user's bid confirms
+  // Optimistic state — shown immediately after user's TX is submitted
   const [optimistic, setOptimistic] = useState<{
     comment: string;
     bidAmount: string;
   } | null>(null);
+  const bidsCountWhenOptimisticRef = useRef<number>(0);
 
   // Primary auction data (metadata, tokenUri)
   const { highestBid, highestBidder, endTime, startTime, tokenId, tokenUri } = useDaoAuction({
@@ -45,12 +46,12 @@ export function AuctionSpotlight() {
   // Fetch bids for this auction (always enabled — lightweight subgraph query)
   const { bids } = useAuctionBids(tokenId?.toString(), true, 15_000);
 
-  // Clear optimistic state once subgraph catches up (bids array updates)
+  // Clear optimistic state once subgraph has indexed the new bid
   useEffect(() => {
-    if (optimistic && bids.length > 0) {
+    if (optimistic && bids.length > bidsCountWhenOptimisticRef.current) {
       setOptimistic(null);
     }
-  }, [bids, optimistic]);
+  }, [bids.length, optimistic]);
 
   // Fetch comment for the leading bid
   const leadingBidTxHash = bids.length > 0 ? bids[0].transactionHash : undefined;
@@ -120,8 +121,9 @@ export function AuctionSpotlight() {
   }, [wasOutbid, latestBid, clearOutbid]);
 
   const handleBidConfirmed = useCallback((comment: string, bidAmount: string) => {
+    bidsCountWhenOptimisticRef.current = bids.length;
     setOptimistic({ comment, bidAmount });
-  }, []);
+  }, [bids.length]);
 
   return (
     <Card className="w-full bg-card">

--- a/src/components/hero/AuctionSpotlight.tsx
+++ b/src/components/hero/AuctionSpotlight.tsx
@@ -10,7 +10,7 @@ import { CHAIN, DAO_ADDRESSES } from "@/lib/config";
 import auctionAbi from "@/utils/abis/auctionAbi";
 import { toast } from "sonner";
 import { BidHistoryModal } from "@/components/auction/BidHistoryModal";
-import { AuctionLiveStatus, AuctionBidHistoryLink } from "@/components/auction/AuctionLiveStatus";
+import { AuctionLiveStatus } from "@/components/auction/AuctionLiveStatus";
 import { AuctionBidForm } from "@/components/auction/AuctionBidForm";
 import { AuctionSettleButton } from "@/components/auction/AuctionSettleButton";
 import { useAuctionLive } from "@/hooks/use-auction-live";
@@ -158,12 +158,6 @@ export function AuctionSpotlight() {
               <AuctionSettleButton isWinner={!!isWinner} />
             )}
 
-            {optimisticBidCount > 0 && (
-              <AuctionBidHistoryLink
-                bidCount={optimisticBidCount}
-                onBidHistoryOpen={() => setIsBidHistoryOpen(true)}
-              />
-            )}
           </div>
 
           <BidHistoryModal

--- a/src/components/hero/AuctionSpotlight.tsx
+++ b/src/components/hero/AuctionSpotlight.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { formatEther } from "viem";
 import { useAccount, useReadContract } from "wagmi";
 import { useDaoAuction } from "@buildeross/hooks";
@@ -21,6 +21,12 @@ export function AuctionSpotlight() {
   const { address } = useAccount();
   const [isBidHistoryOpen, setIsBidHistoryOpen] = useState(false);
 
+  // Optimistic state — shown immediately after user's bid confirms
+  const [optimistic, setOptimistic] = useState<{
+    comment: string;
+    bidAmount: string;
+  } | null>(null);
+
   // Primary auction data (metadata, tokenUri)
   const { highestBid, highestBidder, endTime, startTime, tokenId, tokenUri } = useDaoAuction({
     collectionAddress: DAO_ADDRESSES.token,
@@ -39,6 +45,13 @@ export function AuctionSpotlight() {
   // Fetch bids for this auction (always enabled — lightweight subgraph query)
   const { bids } = useAuctionBids(tokenId?.toString(), true, 15_000);
 
+  // Clear optimistic state once subgraph catches up (bids array updates)
+  useEffect(() => {
+    if (optimistic && bids.length > 0) {
+      setOptimistic(null);
+    }
+  }, [bids, optimistic]);
+
   // Fetch comment for the leading bid
   const leadingBidTxHash = bids.length > 0 ? bids[0].transactionHash : undefined;
   const txHashes = useMemo(
@@ -46,9 +59,13 @@ export function AuctionSpotlight() {
     [leadingBidTxHash],
   );
   const { comments } = useBidComments(txHashes);
-  const leadingBidComment = leadingBidTxHash
+  const fetchedComment = leadingBidTxHash
     ? comments.get(leadingBidTxHash) ?? undefined
     : undefined;
+
+  // Use optimistic comment until real data arrives
+  const leadingBidComment = optimistic?.comment || fetchedComment;
+  const optimisticBidCount = optimistic ? bids.length + 1 : bids.length;
 
   // Reserve price for min bid calculation
   const { data: reservePriceWei } = useReadContract({
@@ -102,6 +119,10 @@ export function AuctionSpotlight() {
     }
   }, [wasOutbid, latestBid, clearOutbid]);
 
+  const handleBidConfirmed = useCallback((comment: string, bidAmount: string) => {
+    setOptimistic({ comment, bidAmount });
+  }, []);
+
   return (
     <Card className="w-full bg-card">
       <CardContent className="py-2">
@@ -112,7 +133,7 @@ export function AuctionSpotlight() {
 
           <GnarImageTile tokenId={Number(tokenId || 0)} imageUrl={imageUrl} />
 
-          <div className="space-y-3">
+          <div className="space-y-2">
             <AuctionLiveStatus
               highestBid={displayBid}
               highestBidder={displayBidder}
@@ -120,7 +141,7 @@ export function AuctionSpotlight() {
               startTime={startTime}
               bidSignal={auctionLive.bidCount}
               leadingBidComment={leadingBidComment}
-              bidCount={bids.length}
+              bidCount={optimisticBidCount}
               onBidHistoryOpen={() => setIsBidHistoryOpen(true)}
             />
 
@@ -129,23 +150,26 @@ export function AuctionSpotlight() {
                 tokenId={tokenId ? BigInt(tokenId) : undefined}
                 highestBid={displayBid}
                 reservePriceEth={reservePriceEth}
+                onBidConfirmed={handleBidConfirmed}
               />
             ) : (
               <AuctionSettleButton isWinner={!!isWinner} />
             )}
 
-            <AuctionBidHistoryLink
-              bidCount={bids.length}
-              onBidHistoryOpen={() => setIsBidHistoryOpen(true)}
-            />
-
-            <BidHistoryModal
-              tokenId={tokenId?.toString()}
-              tokenName={tokenUri?.name}
-              open={isBidHistoryOpen}
-              onOpenChange={setIsBidHistoryOpen}
-            />
+            {optimisticBidCount > 0 && (
+              <AuctionBidHistoryLink
+                bidCount={optimisticBidCount}
+                onBidHistoryOpen={() => setIsBidHistoryOpen(true)}
+              />
+            )}
           </div>
+
+          <BidHistoryModal
+            tokenId={tokenId?.toString()}
+            tokenName={tokenUri?.name}
+            open={isBidHistoryOpen}
+            onOpenChange={setIsBidHistoryOpen}
+          />
         </div>
       </CardContent>
     </Card>

--- a/src/components/hero/AuctionSpotlight.tsx
+++ b/src/components/hero/AuctionSpotlight.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { formatEther } from "viem";
 import { useAccount, useReadContract } from "wagmi";
 import { useDaoAuction } from "@buildeross/hooks";
@@ -10,10 +10,12 @@ import { CHAIN, DAO_ADDRESSES } from "@/lib/config";
 import auctionAbi from "@/utils/abis/auctionAbi";
 import { toast } from "sonner";
 import { BidHistoryModal } from "@/components/auction/BidHistoryModal";
-import { AuctionLiveStatus } from "@/components/auction/AuctionLiveStatus";
+import { AuctionLiveStatus, AuctionBidHistoryLink } from "@/components/auction/AuctionLiveStatus";
 import { AuctionBidForm } from "@/components/auction/AuctionBidForm";
 import { AuctionSettleButton } from "@/components/auction/AuctionSettleButton";
 import { useAuctionLive } from "@/hooks/use-auction-live";
+import { useAuctionBids } from "@/hooks/use-auction-bids";
+import { useBidComments } from "@/hooks/use-bid-comments";
 
 export function AuctionSpotlight() {
   const { address } = useAccount();
@@ -33,6 +35,20 @@ export function AuctionSpotlight() {
   const displayBid = auctionLive.polledHighestBid ?? highestBid;
   const displayBidder = auctionLive.polledHighestBidder ?? highestBidder;
   const displayEndTime = auctionLive.polledEndTime ?? endTime;
+
+  // Fetch bids for this auction (always enabled — lightweight subgraph query)
+  const { bids } = useAuctionBids(tokenId?.toString(), true, 15_000);
+
+  // Fetch comment for the leading bid
+  const leadingBidTxHash = bids.length > 0 ? bids[0].transactionHash : undefined;
+  const txHashes = useMemo(
+    () => (leadingBidTxHash ? [leadingBidTxHash] : []),
+    [leadingBidTxHash],
+  );
+  const { comments } = useBidComments(txHashes);
+  const leadingBidComment = leadingBidTxHash
+    ? comments.get(leadingBidTxHash) ?? undefined
+    : undefined;
 
   // Reserve price for min bid calculation
   const { data: reservePriceWei } = useReadContract({
@@ -74,7 +90,6 @@ export function AuctionSpotlight() {
         action: {
           label: "Bid Again",
           onClick: () => {
-            // Focus the bid input — the form will handle scrolling
             const input = document.querySelector<HTMLInputElement>(
               'input[type="number"]',
             );
@@ -104,6 +119,8 @@ export function AuctionSpotlight() {
               endTime={displayEndTime}
               startTime={startTime}
               bidSignal={auctionLive.bidCount}
+              leadingBidComment={leadingBidComment}
+              bidCount={bids.length}
               onBidHistoryOpen={() => setIsBidHistoryOpen(true)}
             />
 
@@ -116,6 +133,11 @@ export function AuctionSpotlight() {
             ) : (
               <AuctionSettleButton isWinner={!!isWinner} />
             )}
+
+            <AuctionBidHistoryLink
+              bidCount={bids.length}
+              onBidHistoryOpen={() => setIsBidHistoryOpen(true)}
+            />
 
             <BidHistoryModal
               tokenId={tokenId?.toString()}

--- a/src/components/hero/AuctionSpotlight.tsx
+++ b/src/components/hero/AuctionSpotlight.tsx
@@ -68,7 +68,7 @@ export function AuctionSpotlight() {
   const leadingBidComment = optimistic?.comment || fetchedComment;
   const optimisticBidCount = optimistic ? bids.length + 1 : bids.length;
 
-  // Reserve price for min bid calculation
+  // Reserve price and min bid increment from contract
   const { data: reservePriceWei } = useReadContract({
     address: DAO_ADDRESSES.auction as `0x${string}`,
     abi: auctionAbi,
@@ -77,6 +77,15 @@ export function AuctionSpotlight() {
     query: { staleTime: 60 * 1000 },
   });
   const reservePriceEth = reservePriceWei ? Number(formatEther(reservePriceWei)) : 0.01;
+
+  const { data: minBidIncrementRaw } = useReadContract({
+    address: DAO_ADDRESSES.auction as `0x${string}`,
+    abi: auctionAbi,
+    functionName: "minBidIncrement",
+    chainId: CHAIN.id,
+    query: { staleTime: 60 * 1000 },
+  });
+  const minBidIncrementPct = minBidIncrementRaw ? Number(minBidIncrementRaw) : 10;
 
   // Derived state
   const tokenName = tokenUri?.name;
@@ -152,6 +161,7 @@ export function AuctionSpotlight() {
                 tokenId={tokenId ? BigInt(tokenId) : undefined}
                 highestBid={displayBid}
                 reservePriceEth={reservePriceEth}
+                minBidIncrementPct={minBidIncrementPct}
                 onBidConfirmed={handleBidConfirmed}
               />
             ) : (

--- a/src/components/ui/ConnectButton.tsx
+++ b/src/components/ui/ConnectButton.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { ChevronDown, LogOut, User, Wallet } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useAccount, useConnect, useDisconnect } from "wagmi";
+import { useAccount, useDisconnect } from "wagmi";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -13,105 +13,83 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { AddressDisplay } from "@/components/ui/address-display";
 import { toast } from "sonner";
+import { ConnectWalletModal } from "@/components/auction/ConnectWalletModal";
 
 export function ConnectButton() {
   const { address, isConnected } = useAccount();
   const { disconnect } = useDisconnect();
-  const { connectors, connectAsync } = useConnect();
   const router = useRouter();
+  const [isConnectModalOpen, setIsConnectModalOpen] = useState(false);
 
   const shortAddress = useMemo(() => {
     if (!address) return "";
     return `${address.slice(0, 6)}…${address.slice(-4)}`;
   }, [address]);
 
+  if (!isConnected) {
+    return (
+      <>
+        <Button
+          size="sm"
+          variant="default"
+          className="w-full cursor-pointer"
+          onClick={() => setIsConnectModalOpen(true)}
+        >
+          <Wallet className="mr-2 h-4 w-4" />
+          Connect
+        </Button>
+        <ConnectWalletModal
+          open={isConnectModalOpen}
+          onOpenChange={setIsConnectModalOpen}
+        />
+      </>
+    );
+  }
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button size="sm" variant={isConnected ? "ghost" : "default"} className="w-full cursor-pointer">
-          {isConnected && address ? (
-            <>
-              <span className="hidden sm:inline">
-                <AddressDisplay address={address} variant="compact" avatarSize="sm" showAvatar={true} showENS={true} showCopy={false} showExplorer={false} onAddressClick={() => {}} />
-              </span>
-              <span className="sm:hidden">{shortAddress}</span>
-            </>
-          ) : (
-            <>
-              <Wallet className="mr-2 h-4 w-4" />
-              Connect
-            </>
-          )}
+        <Button size="sm" variant="ghost" className="w-full cursor-pointer">
+          <span className="hidden sm:inline">
+            <AddressDisplay address={address!} variant="compact" avatarSize="sm" showAvatar={true} showENS={true} showCopy={false} showExplorer={false} onAddressClick={() => {}} />
+          </span>
+          <span className="sm:hidden">{shortAddress}</span>
           <ChevronDown className="ml-2 h-4 w-4 opacity-70" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent side="top">
-        {!isConnected ? (
-          <>
-            {connectors.map((connector) => (
-              <DropdownMenuItem
-                key={connector.uid}
-                className="cursor-pointer"
-                onSelect={async (e) => {
-                  e.preventDefault();
-                  try {
-                    await connectAsync({ connector });
-                  } catch (err: unknown) {
-                    const message =
-                      err && typeof err === "object" && "message" in err
-                        ? String((err as { message?: string }).message ?? "Failed to connect")
-                        : "Failed to connect";
-                    if (/rejected|user|cancel/i.test(message)) {
-                      toast("Connection cancelled");
-                    } else {
-                      toast.error("Connection failed", { description: message });
-                    }
-                  }
-                }}
-              >
-                {connector.name}
-              </DropdownMenuItem>
-            ))}
-          </>
-        ) : (
-          <>
-            <DropdownMenuItem
-              className="cursor-pointer"
-              onSelect={(e) => {
-                e.preventDefault();
-                if (!address) return;
-                router.push(`/members/${address}`);
-              }}
-            >
-              <User className="mr-2 h-4 w-4" />
-              Profile
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              variant="destructive"
-              className="cursor-pointer"
-              onSelect={async (e) => {
-                e.preventDefault();
-                try {
-                  // Disconnect all active connections if any, else just disconnect
-                  disconnect();
-                  toast("Disconnected");
-                } catch (err: unknown) {
-                  const message =
-                    err && typeof err === "object" && "message" in err
-                      ? String((err as { message?: string }).message ?? "Failed to disconnect")
-                      : "Failed to disconnect";
-                  toast.error("Disconnect failed", { description: message });
-                }
-              }}
-            >
-            <LogOut className="mr-2 h-4 w-4 text-red-600" />
-            <span className="text-red-600">Disconnect</span>
-            </DropdownMenuItem>
-          </>
-        )}
+        <DropdownMenuItem
+          className="cursor-pointer"
+          onSelect={(e) => {
+            e.preventDefault();
+            if (!address) return;
+            router.push(`/members/${address}`);
+          }}
+        >
+          <User className="mr-2 h-4 w-4" />
+          Profile
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          variant="destructive"
+          className="cursor-pointer"
+          onSelect={async (e) => {
+            e.preventDefault();
+            try {
+              disconnect();
+              toast("Disconnected");
+            } catch (err: unknown) {
+              const message =
+                err && typeof err === "object" && "message" in err
+                  ? String((err as { message?: string }).message ?? "Failed to disconnect")
+                  : "Failed to disconnect";
+              toast.error("Disconnect failed", { description: message });
+            }
+          }}
+        >
+          <LogOut className="mr-2 h-4 w-4 text-red-600" />
+          <span className="text-red-600">Disconnect</span>
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );
 }
-
-

--- a/src/hooks/use-auction-live.ts
+++ b/src/hooks/use-auction-live.ts
@@ -1,0 +1,132 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { formatEther } from "viem";
+import { useAccount, useReadContract, useWatchContractEvent } from "wagmi";
+import { base } from "wagmi/chains";
+import { CHAIN, DAO_ADDRESSES } from "@/lib/config";
+import auctionAbi from "@/utils/abis/auctionAbi";
+
+interface NewBidEvent {
+  tokenId: bigint;
+  bidder: `0x${string}`;
+  amount: bigint;
+  amountEth: string;
+  extended: boolean;
+  endTime: bigint;
+}
+
+interface UseAuctionLiveReturn {
+  /** Signal: increments on every new bid detected */
+  bidCount: number;
+  /** The latest bid event (if any detected via events) */
+  latestBid: NewBidEvent | undefined;
+  /** Whether the connected wallet was just outbid */
+  wasOutbid: boolean;
+  /** Clear the outbid flag (after user acknowledges) */
+  clearOutbid: () => void;
+  /** Polled auction data as fallback */
+  polledHighestBid: string | undefined;
+  polledHighestBidder: `0x${string}` | undefined;
+  polledEndTime: number | undefined;
+}
+
+export function useAuctionLive(
+  currentTokenId: bigint | undefined,
+): UseAuctionLiveReturn {
+  const { address } = useAccount();
+  const [bidCount, setBidCount] = useState(0);
+  const [latestBid, setLatestBid] = useState<NewBidEvent | undefined>();
+  const [wasOutbid, setWasOutbid] = useState(false);
+  const previousBidderRef = useRef<string | undefined>(undefined);
+
+  // Watch AuctionBid events
+  useWatchContractEvent({
+    address: DAO_ADDRESSES.auction as `0x${string}`,
+    abi: auctionAbi,
+    eventName: "AuctionBid",
+    chainId: base.id,
+    enabled: currentTokenId !== undefined,
+    onLogs(logs) {
+      for (const log of logs) {
+        const args = log.args as {
+          tokenId?: bigint;
+          bidder?: `0x${string}`;
+          amount?: bigint;
+          extended?: boolean;
+          endTime?: bigint;
+        };
+        if (!args.tokenId || !args.bidder || !args.amount) continue;
+        // Only process bids for the current auction
+        if (currentTokenId && args.tokenId !== currentTokenId) continue;
+
+        const event: NewBidEvent = {
+          tokenId: args.tokenId,
+          bidder: args.bidder,
+          amount: args.amount,
+          amountEth: formatEther(args.amount),
+          extended: args.extended ?? false,
+          endTime: args.endTime ?? 0n,
+        };
+
+        // Check if connected user was outbid
+        if (
+          address &&
+          previousBidderRef.current &&
+          previousBidderRef.current.toLowerCase() === address.toLowerCase() &&
+          args.bidder.toLowerCase() !== address.toLowerCase()
+        ) {
+          setWasOutbid(true);
+        }
+
+        previousBidderRef.current = args.bidder.toLowerCase();
+        setLatestBid(event);
+        setBidCount((c) => c + 1);
+      }
+    },
+  });
+
+  // Polling fallback: read auction() every 12s
+  const { data: auctionData } = useReadContract({
+    address: DAO_ADDRESSES.auction as `0x${string}`,
+    abi: auctionAbi,
+    functionName: "auction",
+    chainId: CHAIN.id,
+    query: {
+      refetchInterval: 12_000,
+      staleTime: 6_000,
+    },
+  });
+
+  // Update previousBidderRef from polled data too
+  useEffect(() => {
+    if (auctionData) {
+      const [, , bidder] = auctionData;
+      if (bidder) {
+        previousBidderRef.current = (bidder as string).toLowerCase();
+      }
+    }
+  }, [auctionData]);
+
+  const clearOutbid = useCallback(() => setWasOutbid(false), []);
+
+  const polledHighestBid = auctionData
+    ? formatEther(auctionData[1] as bigint)
+    : undefined;
+  const polledHighestBidder = auctionData
+    ? (auctionData[2] as `0x${string}`)
+    : undefined;
+  const polledEndTime = auctionData
+    ? Number(auctionData[4] as unknown as bigint)
+    : undefined;
+
+  return {
+    bidCount,
+    latestBid,
+    wasOutbid,
+    clearOutbid,
+    polledHighestBid,
+    polledHighestBidder,
+    polledEndTime,
+  };
+}

--- a/src/hooks/use-auction-transaction.ts
+++ b/src/hooks/use-auction-transaction.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useWaitForTransactionReceipt } from "wagmi";
 import { CHAIN } from "@/lib/config";
 
@@ -38,6 +38,12 @@ export function useAuctionTransaction(
   const [phase, setPhase] = useState<TxPhase>("idle");
   const [txHash, setTxHash] = useState<`0x${string}` | undefined>();
 
+  // Stable refs for callbacks to avoid stale closures in effects
+  const onConfirmedRef = useRef(onConfirmed);
+  const onErrorRef = useRef(onError);
+  useEffect(() => { onConfirmedRef.current = onConfirmed; });
+  useEffect(() => { onErrorRef.current = onError; });
+
   const { isSuccess: isConfirmed } = useWaitForTransactionReceipt({
     hash: txHash,
     chainId: CHAIN.id,
@@ -47,9 +53,9 @@ export function useAuctionTransaction(
   useEffect(() => {
     if (isConfirmed && txHash && phase === "submitted") {
       setPhase("confirmed");
-      onConfirmed?.(txHash);
+      onConfirmedRef.current?.(txHash);
     }
-  }, [isConfirmed, txHash, phase, onConfirmed]);
+  }, [isConfirmed, txHash, phase]);
 
   const execute = useCallback(
     async (txFn: () => Promise<`0x${string}`>) => {
@@ -61,12 +67,12 @@ export function useAuctionTransaction(
       } catch (err) {
         const error =
           err instanceof Error ? err : new Error("Transaction failed");
-        onError?.(error);
+        onErrorRef.current?.(error);
         setPhase("idle");
         setTxHash(undefined);
       }
     },
-    [onError],
+    [],
   );
 
   const reset = useCallback(() => {

--- a/src/hooks/use-auction-transaction.ts
+++ b/src/hooks/use-auction-transaction.ts
@@ -1,0 +1,101 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useWaitForTransactionReceipt } from "wagmi";
+import { CHAIN } from "@/lib/config";
+
+export type TxPhase = "idle" | "wallet_confirm" | "submitted" | "confirmed";
+
+interface UseAuctionTransactionOptions {
+  /** Called when TX is confirmed onchain */
+  onConfirmed?: (hash: `0x${string}`) => void;
+  /** Called when TX fails at any phase */
+  onError?: (error: Error) => void;
+}
+
+interface UseAuctionTransactionReturn {
+  /** Current phase of the transaction lifecycle */
+  phase: TxPhase;
+  /** The TX hash once submitted */
+  txHash: `0x${string}` | undefined;
+  /** Whether any TX is in progress (not idle) */
+  isActive: boolean;
+  /** Button label for current phase */
+  buttonLabel: (idle: string) => string;
+  /**
+   * Execute a transaction. Pass an async function that calls
+   * writeContractAsync or sendTransactionAsync and returns the hash.
+   */
+  execute: (txFn: () => Promise<`0x${string}`>) => Promise<void>;
+  /** Reset back to idle (e.g., after confirmed toast) */
+  reset: () => void;
+}
+
+export function useAuctionTransaction(
+  options: UseAuctionTransactionOptions = {},
+): UseAuctionTransactionReturn {
+  const { onConfirmed, onError } = options;
+  const [phase, setPhase] = useState<TxPhase>("idle");
+  const [txHash, setTxHash] = useState<`0x${string}` | undefined>();
+
+  const { isSuccess: isConfirmed } = useWaitForTransactionReceipt({
+    hash: txHash,
+    chainId: CHAIN.id,
+  });
+
+  // Transition: submitted → confirmed
+  useEffect(() => {
+    if (isConfirmed && txHash && phase === "submitted") {
+      setPhase("confirmed");
+      onConfirmed?.(txHash);
+    }
+  }, [isConfirmed, txHash, phase, onConfirmed]);
+
+  const execute = useCallback(
+    async (txFn: () => Promise<`0x${string}`>) => {
+      try {
+        setPhase("wallet_confirm");
+        const hash = await txFn();
+        setTxHash(hash);
+        setPhase("submitted");
+      } catch (err) {
+        const error =
+          err instanceof Error ? err : new Error("Transaction failed");
+        onError?.(error);
+        setPhase("idle");
+        setTxHash(undefined);
+      }
+    },
+    [onError],
+  );
+
+  const reset = useCallback(() => {
+    setPhase("idle");
+    setTxHash(undefined);
+  }, []);
+
+  const buttonLabel = useCallback(
+    (idle: string) => {
+      switch (phase) {
+        case "wallet_confirm":
+          return "Confirm in wallet...";
+        case "submitted":
+          return "Transaction submitted...";
+        case "confirmed":
+          return "Confirmed!";
+        default:
+          return idle;
+      }
+    },
+    [phase],
+  );
+
+  return {
+    phase,
+    txHash,
+    isActive: phase !== "idle",
+    buttonLabel,
+    execute,
+    reset,
+  };
+}

--- a/src/hooks/use-auction-transaction.ts
+++ b/src/hooks/use-auction-transaction.ts
@@ -7,6 +7,8 @@ import { CHAIN } from "@/lib/config";
 export type TxPhase = "idle" | "wallet_confirm" | "submitted" | "confirmed";
 
 interface UseAuctionTransactionOptions {
+  /** Called when TX hash is received (submitted to mempool) */
+  onSubmitted?: (hash: `0x${string}`) => void;
   /** Called when TX is confirmed onchain */
   onConfirmed?: (hash: `0x${string}`) => void;
   /** Called when TX fails at any phase */
@@ -14,33 +16,26 @@ interface UseAuctionTransactionOptions {
 }
 
 interface UseAuctionTransactionReturn {
-  /** Current phase of the transaction lifecycle */
   phase: TxPhase;
-  /** The TX hash once submitted */
   txHash: `0x${string}` | undefined;
-  /** Whether any TX is in progress (not idle) */
   isActive: boolean;
-  /** Button label for current phase */
   buttonLabel: (idle: string) => string;
-  /**
-   * Execute a transaction. Pass an async function that calls
-   * writeContractAsync or sendTransactionAsync and returns the hash.
-   */
   execute: (txFn: () => Promise<`0x${string}`>) => Promise<void>;
-  /** Reset back to idle (e.g., after confirmed toast) */
   reset: () => void;
 }
 
 export function useAuctionTransaction(
   options: UseAuctionTransactionOptions = {},
 ): UseAuctionTransactionReturn {
-  const { onConfirmed, onError } = options;
+  const { onSubmitted, onConfirmed, onError } = options;
   const [phase, setPhase] = useState<TxPhase>("idle");
   const [txHash, setTxHash] = useState<`0x${string}` | undefined>();
 
-  // Stable refs for callbacks to avoid stale closures in effects
+  // Stable refs for callbacks — called synchronously, no effect timing issues
+  const onSubmittedRef = useRef(onSubmitted);
   const onConfirmedRef = useRef(onConfirmed);
   const onErrorRef = useRef(onError);
+  useEffect(() => { onSubmittedRef.current = onSubmitted; });
   useEffect(() => { onConfirmedRef.current = onConfirmed; });
   useEffect(() => { onErrorRef.current = onError; });
 
@@ -64,6 +59,8 @@ export function useAuctionTransaction(
         const hash = await txFn();
         setTxHash(hash);
         setPhase("submitted");
+        // Fire immediately — no useEffect delay
+        onSubmittedRef.current?.(hash);
       } catch (err) {
         const error =
           err instanceof Error ? err : new Error("Transaction failed");

--- a/src/utils/abis/auctionAbi.ts
+++ b/src/utils/abis/auctionAbi.ts
@@ -59,6 +59,13 @@ const auctionAbi = [
     outputs: [{ name: "", type: "uint256" }],
   },
   {
+    type: "function",
+    stateMutability: "view",
+    name: "minBidIncrement",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
     type: "event",
     name: "AuctionBid",
     inputs: [

--- a/src/utils/abis/auctionAbi.ts
+++ b/src/utils/abis/auctionAbi.ts
@@ -58,6 +58,17 @@ const auctionAbi = [
     inputs: [],
     outputs: [{ name: "", type: "uint256" }],
   },
+  {
+    type: "event",
+    name: "AuctionBid",
+    inputs: [
+      { name: "tokenId", type: "uint256", indexed: false },
+      { name: "bidder", type: "address", indexed: false },
+      { name: "amount", type: "uint256", indexed: false },
+      { name: "extended", type: "bool", indexed: false },
+      { name: "endTime", type: "uint256", indexed: false },
+    ],
+  },
 ] as const;
 
 export default auctionAbi;


### PR DESCRIPTION
## Summary
- Extract monolithic AuctionSpotlight (~460 lines) into focused sub-components with dedicated hooks
- 3-phase TX feedback: "Confirm in wallet" → "Transaction submitted" → "Confirmed!"
- Live auction updates via event subscription (useWatchContractEvent) + 12s polling fallback
- Outbid toast notification with "Bid Again" CTA
- Wallet balance check with insufficient funds prevention
- Connect wallet modal with all providers + "Last used" badge
- Leading bid hero card with on-chain comment visible by default
- Colored progress bar (green → amber → red)
- Optimistic UI updates at TX submission time
- Read minBidIncrement from contract (was hardcoded at 1%, actual is 10%)
- Show bid comments in feed events
- Scoped query invalidation (no more global readContract invalidation)

## Changes
- **New:** `useAuctionTransaction` — 3-phase TX state machine hook
- **New:** `useAuctionLive` — event subscription + polling for live bid updates
- **New:** `AuctionBidForm` — bid input, validation, balance check, connect trigger
- **New:** `AuctionSettleButton` — simulation states, winner-aware copy
- **New:** `AuctionLiveStatus` — countdown, animated bid card, progress bar
- **New:** `ConnectWalletModal` — wallet picker with icons and last-used memory
- **Modified:** `AuctionSpotlight` → layout shell composing sub-components
- **Modified:** `ConnectButton` → uses shared ConnectWalletModal
- **Modified:** `AuctionEventCard` → shows decoded bid comments
- **Modified:** `auctionAbi` → added AuctionBid event + minBidIncrement

## Test plan
- [ ] Disconnected: bid input visible, "Connect Wallet to Bid" opens modal
- [ ] Wrong network: "Switch to Base" button works
- [ ] Bid below minimum: shows correct min, button disabled
- [ ] Bid above balance: red "Insufficient" text, button disabled
- [ ] Place bid: 3-phase button states with comment preserved optimistically
- [ ] Settle auction: simulation spinner → winner-aware copy
- [ ] Live updates: new bids animate in real-time
- [ ] Feed: bid comments visible on auction bid events
- [ ] Connect modal: all providers shown, last used highlighted

Generated with [Claude Code](https://claude.com/claude-code)