### PR TITLE
docs: GNARS token migration strategy (Zora to Clanker)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -28,6 +28,7 @@ This is the canonical entry point for project documentation. Everything below sh
 ## Strategy
 
 - `docs/strategy/gnars-token-migration.md` — GNARS token migration from Zora to Clanker: decisions, codebase impact audit (63 files), 3-phase plan, blockers, and open questions
+- `docs/strategy/gnars-migration-decisions.md` — Decision checklist (7 areas) to review with Vlad before any proposal or technical work
 
 ## Specs
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -25,6 +25,10 @@ This is the canonical entry point for project documentation. Everything below sh
 - `docs/integrations/pinata.md` — IPFS upload integration
 - `docs/integrations/splits.md` — 0xSplits droposal revenue sharing
 
+## Strategy
+
+- `docs/strategy/gnars-token-migration.md` — GNARS token migration from Zora to Clanker: decisions, codebase impact audit (63 files), 3-phase plan, blockers, and open questions
+
 ## Specs
 
 - `docs/superpowers/specs/2026-03-16-vote-card-delegation-breakdown-design.md` — vote card own vs delegated breakdown

--- a/docs/strategy/gnars-migration-decisions.md
+++ b/docs/strategy/gnars-migration-decisions.md
@@ -3,6 +3,45 @@
 > Para revisar com Vlad antes de qualquer proposal on-chain ou trabalho tecnico.
 > Marcar cada item com a decisao tomada e data.
 
+## Estado Atual (on-chain, 2026-04-06)
+
+### Token GNARS atual (Zora Creator Coin on Base)
+- **Endereco:** `0x0cf0c3b75d522290d7d12c74d7f1f0cc47ccb23b`
+- **Symbol:** gnars | **Decimals:** 18
+- **Supply total:** 1,000,000,000 (1B)
+- **Treasury holds:** 562,256 GNARS (~0.056% do supply)
+
+### Gnars NFTs (Builder DAO)
+- **Endereco:** `0x880fb3cf5c6cc2d7dfc13a993e839a9411200c17`
+- **Total minted:** 6,001 NFTs
+
+### Treasury (Base: `0x72ad986ebac0246d2b3c565ab2a1ce3a14ce6f88`)
+| Asset | Quantidade |
+|-------|-----------|
+| ETH | 6.77 |
+| USDC | 15,496.24 |
+| WETH | 0.03 |
+| SENDIT | 474,092,938 |
+| GNARS ERC20 | 562,256 |
+
+### Content Coins (GNARS-paired)
+- **Subgraph Goldsky:** OFFLINE (404) — precisa redeploy
+- **Contagem exata de coins:** indisponivel sem subgraph; dados vem via Zora SDK no runtime
+
+### Contratos do DAO (Base)
+| Contrato | Endereco |
+|----------|----------|
+| Governor | `0x3dd4e53a232b7b715c9ae455f4e732465ed71b4c` |
+| Treasury | `0x72ad986ebac0246d2b3c565ab2a1ce3a14ce6f88` |
+| Auction | `0x494eaa55ecf6310658b8fc004b0888dcb698097f` |
+| Metadata | `0xdc9799d424ebfdcf5310f3bad3ddcce3931d4b58` |
+| Lootbox V4 | `0xc934804520ccc172909a093bae5bb07188e77cb2` |
+
+### Governance (historico)
+- **~119 proposals** on-chain, **77 executadas**
+- **Timing:** ~2 dias voting delay + ~5 dias voting period + timelock
+- **Tipos de proposal existentes:** send-eth, send-usdc, send-tokens, send-nfts, buy-coin, droposal, custom
+
 ---
 
 ## 1. Aprovar a Migracao
@@ -26,6 +65,7 @@
 
 ### Supply
 - [ ] Total supply: 100B (conforme call) ou outro valor? ____________
+  - **Contexto:** Supply atual do GNARS Zora = 1B. Clanker padrao = 100B. Multiplicador = 100x.
 - [ ] Justificativa para o supply escolhido: ____________
 
 ### Distribuicao
@@ -64,6 +104,7 @@
 
 ### Parametros
 - [ ] Ratio de troca: 1 old GNARS = ______ new GNARS
+  - **Se 100B/1B:** ratio natural = 100:1 (cada 1 GNARS antigo = 100 novos)
 - [ ] Duracao da janela de migracao: ______ dias/semanas
 - [ ] O que acontece com tokens nao migrados apos a janela?
   - [ ] Queimados
@@ -74,7 +115,11 @@
 ### Snapshot (se aplicavel)
 - [ ] Data/bloco do snapshot: ____________
 - [ ] Quais tokens contam? (GNARS creator coin? content coins? NFTs?)
+  - **GNARS ERC20:** `0x0cf0c3b75d522290d7d12c74d7f1f0cc47ccb23b` (1B supply, 18 decimals)
+  - **Gnars NFTs:** `0x880fb3cf5c6cc2d7dfc13a993e839a9411200c17` (6,001 minted)
+  - **Content coins:** quantidade exata indisponivel (subgraph offline)
 - [ ] Multiplicador: holdings x ______ (para igualar novo supply)
+  - **Se 100B/1B:** multiplicador = 100
 
 **Decisao:** ____________
 **Data:** ____________
@@ -86,23 +131,29 @@
 **Pergunta central:** Quem recebe tokens alem dos holders atuais, e quanto?
 
 ### Categorias de contribuicao
-- [ ] NFT holders (Gnars NFTs do auction)
-- [ ] Content creators (Skatehive, droposals)
-- [ ] Atletas patrocinados
-- [ ] Builders/devs
-- [ ] Votantes ativos em proposals
-- [ ] Holders de tokens relacionados (sk hacker, etc.)
+- [ ] NFT holders (Gnars NFTs do auction) — **6,001 NFTs existem, dados via Builder subgraph**
+- [ ] Content creators (Skatehive, droposals) — **dados via Skatehive API + 6 droposals executadas**
+- [ ] Atletas patrocinados — **26 proposals de sponsorship executadas (34% do total)**
+- [ ] Builders/devs — **7 proposals de dev/tech executadas**
+- [ ] Votantes ativos em proposals — **dados on-chain via Governor contract**
+- [ ] Holders de tokens relacionados (sk hacker, etc.) — **mencionado por Vlad na call**
 - [ ] Outras categorias? ____________
 
 ### Peso
 - [ ] Formula de peso: ____________
   - Exemplos: NFTs held x tempo + proposals votadas + content criado
+  - **Dados disponiveis on-chain:** NFT holdings (subgraph), votes (Governor events), proposals criadas
+  - **Dados off-chain necessarios:** Skatehive posts, contribuicoes comunitarias
 - [ ] Threshold minimo para qualificar: ____________
 - [ ] Cap maximo por wallet: ____________
 
 ### Dados
-- [ ] Onde buscar dados on-chain? (subgraph, Etherscan, Skatehive API)
-- [ ] Dados off-chain contam? (contribuicoes no Discord/Telegram)
+- [ ] Onde buscar dados on-chain?
+  - **Builder subgraph:** NFT holders, proposals, votes — `api.goldsky.com/.../nouns-builder-base-mainnet/latest/gn`
+  - **Governor contract:** `0x3dd4e53a232b7b715c9ae455f4e732465ed71b4c` — VoteCast events
+  - **GNARS ERC20:** `0x0cf0c3b75d522290d7d12c74d7f1f0cc47ccb23b` — Transfer events para snapshot de holders
+  - **Eth mainnet subgraph:** `api.studio.thegraph.com/query/84885/gnars-mainnet/v1.0.0` — dados historicos pre-Base
+- [ ] Dados off-chain contam? (contribuicoes no Discord/Telegram/Skatehive)
 - [ ] Quem valida a lista final antes do airdrop?
 
 **Decisao:** ____________
@@ -122,9 +173,9 @@
 - [ ] **Hibrido** — manter na Zora mas novos coins so no Clanker
 
 ### Impacto
-- [ ] Quantos content coins existem pareados com GNARS? ____________
-- [ ] Qual o TVL aproximado? ____________
-- [ ] Criadores mais afetados: ____________
+- [ ] Quantos content coins existem pareados com GNARS? **Subgraph offline (Goldsky 404). Precisa redeploy ou query via Zora SDK para contar.**
+- [ ] Qual o TVL aproximado? **Indisponivel sem subgraph. Zora SDK retorna marketCap e volume por coin.**
+- [ ] Criadores mais afetados: **Allowlist conhecida: skatehacker (Vlad), nogenta. Demais precisam de query.**
 - [ ] Precisamos comunicar individualmente com criadores?
 
 **Decisao:** ____________
@@ -138,27 +189,30 @@
 
 ### Liquidez
 - [ ] Quanto ETH do treasury para liquidez inicial no Clanker? ______ ETH
-- [ ] Isso precisa de proposal separada? (envolve movimentacao de fundos)
+  - **Disponivel:** 6.77 ETH + 15,496 USDC (~total ~$28k USD assumindo ETH ~$1,800)
+- [ ] Isso precisa de proposal separada? (envolve movimentacao de fundos) — **SIM, qualquer send-eth/send-usdc requer proposal**
 - [ ] Quem executa o deposit de liquidez?
 
 ### Holdings atuais
 - [ ] Treasury migra seus Zora coin holdings para o novo sistema?
-- [ ] Treasury tem GNARS creator coins? Quanto? ____________
-- [ ] Treasury tem content coins? Quais? ____________
+- [ ] Treasury tem GNARS creator coins? **SIM — 562,256 GNARS (~0.056% do 1B supply)**
+- [ ] Treasury tem content coins? **Precisa query via Zora SDK (`getProfileBalances`)**
 
 ### Autoridade operacional
 - [ ] Tudo via proposal on-chain? (lento — ~2 semanas por operacao)
+  - **Fluxo atual:** proposal → 2 dias delay → 5 dias voting → timelock → execute
+  - **Tipo "custom" existe** e permite calldata arbitrario — pode ser usado para operacoes de migracao
 - [ ] Delegar autoridade temporaria para um multisig?
   - [ ] Se sim, quais signers? ____________
   - [ ] Com que limite de valor? ____________
   - [ ] Por quanto tempo? ____________
 
 ### Custos estimados
-- [ ] Gas para deploy do novo token: ~______ ETH
-- [ ] Gas para migracao/airdrop: ~______ ETH
+- [ ] Gas para deploy do novo token: ~______ ETH (**Base gas e barato, ~$0.01-0.10 por tx**)
+- [ ] Gas para migracao/airdrop: ~______ ETH (**depende do numero de holders — batch com Multicall3 possivel**)
 - [ ] Liquidez inicial: ~______ ETH
 - [ ] Total estimado: ~______ ETH
-- [ ] Treasury tem saldo suficiente?
+- [ ] Treasury tem saldo suficiente? **6.77 ETH + 15,496 USDC disponiveis. Gas nao e problema no Base. A questao e quanto alocar para liquidez.**
 
 **Decisao:** ____________
 **Data:** ____________
@@ -177,12 +231,12 @@
 - [ ] **Fim da janela** — quando? ____________
 
 ### Canais
-- [ ] Farcaster (post oficial)
-- [ ] GM Farcaster (Jack ofereceu feature)
-- [ ] Telegram group
-- [ ] Website banner/popup
+- [ ] Farcaster (post oficial) — **ja usado pela comunidade**
+- [ ] GM Farcaster (Jack ofereceu feature) — **conta branded do Farcaster no X, boa distribuicao**
+- [ ] Telegram group — **Jack criou grupo na call (Vlad, r4to, Jack, + Compre)**
+- [ ] Website banner/popup — **gnars.com, podemos implementar**
 - [ ] Twitter/X
-- [ ] Skatehive
+- [ ] Skatehive — **comunidade organica ativa, posts monetizados**
 - [ ] Outros? ____________
 
 ### Mensagem

--- a/docs/strategy/gnars-migration-decisions.md
+++ b/docs/strategy/gnars-migration-decisions.md
@@ -1,0 +1,224 @@
+# GNARS Migration — Decision Checklist
+
+> Para revisar com Vlad antes de qualquer proposal on-chain ou trabalho tecnico.
+> Marcar cada item com a decisao tomada e data.
+
+---
+
+## 1. Aprovar a Migracao
+
+**Pergunta central:** A DAO autoriza migrar o token GNARS de Zora para Clanker?
+
+- [ ] Concordamos que Zora nao atende mais as necessidades do projeto?
+- [ ] Concordamos que Clanker e o ecossistema certo para migrar?
+- [ ] Temos confianca suficiente no Clanker (imutabilidade, independencia dos tokens)?
+- [ ] Quem redige a proposal on-chain? ____________
+- [ ] Qual o framing da justificativa? (tecnico? estrategico? financeiro?)
+
+**Decisao:** ____________
+**Data:** ____________
+
+---
+
+## 2. Token Economics
+
+**Pergunta central:** Quais sao os parametros do novo token GNARS?
+
+### Supply
+- [ ] Total supply: 100B (conforme call) ou outro valor? ____________
+- [ ] Justificativa para o supply escolhido: ____________
+
+### Distribuicao
+- [ ] % para holders existentes (migracao direta): ______%
+- [ ] % para airdrop por contribuicao: ______%
+- [ ] % para vault/treasury reserve: ______%
+- [ ] % para operacoes/equipe (se houver): ______%
+- [ ] % para liquidez inicial no Clanker: ______%
+- [ ] Soma = 100%? ______
+
+### Pairing Asset
+- [ ] Par com ETH? (Jack sugeriu — "cold hard cash" para criadores)
+- [ ] Par com GNARS? (mantem mecanica atual — cada buy de content coin compra GNARS)
+- [ ] Par com USDC? (estavel, menos volatilidade)
+- [ ] Outro? ____________
+- [ ] Podemos mudar o par depois ou e permanente no Clanker?
+
+### Fee Structure
+- [ ] Qual % de fee no pool? ____________
+- [ ] Fees vao para onde? (treasury? burn? stakers?)
+- [ ] Fee no token pareado ou no GNARS?
+
+**Decisao:** ____________
+**Data:** ____________
+
+---
+
+## 3. Metodo de Migracao
+
+**Pergunta central:** Como holders trocam tokens antigos pelos novos?
+
+### Metodo
+- [ ] Compre migration tool (preferido na call — deposit old → receive new)
+- [ ] Snapshot + airdrop (mais simples, mas menos controle)
+- [ ] Hibrido (snapshot para holders pequenos, tool para holders grandes)
+
+### Parametros
+- [ ] Ratio de troca: 1 old GNARS = ______ new GNARS
+- [ ] Duracao da janela de migracao: ______ dias/semanas
+- [ ] O que acontece com tokens nao migrados apos a janela?
+  - [ ] Queimados
+  - [ ] Vao para treasury
+  - [ ] Janela fica aberta indefinidamente
+- [ ] Migracao em ondas ou tudo de uma vez?
+
+### Snapshot (se aplicavel)
+- [ ] Data/bloco do snapshot: ____________
+- [ ] Quais tokens contam? (GNARS creator coin? content coins? NFTs?)
+- [ ] Multiplicador: holdings x ______ (para igualar novo supply)
+
+**Decisao:** ____________
+**Data:** ____________
+
+---
+
+## 4. Criterios do Airdrop
+
+**Pergunta central:** Quem recebe tokens alem dos holders atuais, e quanto?
+
+### Categorias de contribuicao
+- [ ] NFT holders (Gnars NFTs do auction)
+- [ ] Content creators (Skatehive, droposals)
+- [ ] Atletas patrocinados
+- [ ] Builders/devs
+- [ ] Votantes ativos em proposals
+- [ ] Holders de tokens relacionados (sk hacker, etc.)
+- [ ] Outras categorias? ____________
+
+### Peso
+- [ ] Formula de peso: ____________
+  - Exemplos: NFTs held x tempo + proposals votadas + content criado
+- [ ] Threshold minimo para qualificar: ____________
+- [ ] Cap maximo por wallet: ____________
+
+### Dados
+- [ ] Onde buscar dados on-chain? (subgraph, Etherscan, Skatehive API)
+- [ ] Dados off-chain contam? (contribuicoes no Discord/Telegram)
+- [ ] Quem valida a lista final antes do airdrop?
+
+**Decisao:** ____________
+**Data:** ____________
+
+---
+
+## 5. Content Coins Existentes na Zora
+
+**Pergunta central:** O que fazemos com os content coins que ja existem pareados com GNARS na Zora?
+
+### Opcoes
+- [ ] **Manter na Zora** — funcionam independente, criadores mantem valor
+- [ ] **Tool de agregacao** — criadores trocam Zora coins → novo GNARS (ideia do Vlad na call)
+- [ ] **Snapshot + airdrop equivalente** — snapshot dos holders de content coins, airdrop no Clanker
+- [ ] **Depreciar** — fresh start, sem migracao de content coins
+- [ ] **Hibrido** — manter na Zora mas novos coins so no Clanker
+
+### Impacto
+- [ ] Quantos content coins existem pareados com GNARS? ____________
+- [ ] Qual o TVL aproximado? ____________
+- [ ] Criadores mais afetados: ____________
+- [ ] Precisamos comunicar individualmente com criadores?
+
+**Decisao:** ____________
+**Data:** ____________
+
+---
+
+## 6. Treasury Operations
+
+**Pergunta central:** Como o treasury participa da migracao?
+
+### Liquidez
+- [ ] Quanto ETH do treasury para liquidez inicial no Clanker? ______ ETH
+- [ ] Isso precisa de proposal separada? (envolve movimentacao de fundos)
+- [ ] Quem executa o deposit de liquidez?
+
+### Holdings atuais
+- [ ] Treasury migra seus Zora coin holdings para o novo sistema?
+- [ ] Treasury tem GNARS creator coins? Quanto? ____________
+- [ ] Treasury tem content coins? Quais? ____________
+
+### Autoridade operacional
+- [ ] Tudo via proposal on-chain? (lento — ~2 semanas por operacao)
+- [ ] Delegar autoridade temporaria para um multisig?
+  - [ ] Se sim, quais signers? ____________
+  - [ ] Com que limite de valor? ____________
+  - [ ] Por quanto tempo? ____________
+
+### Custos estimados
+- [ ] Gas para deploy do novo token: ~______ ETH
+- [ ] Gas para migracao/airdrop: ~______ ETH
+- [ ] Liquidez inicial: ~______ ETH
+- [ ] Total estimado: ~______ ETH
+- [ ] Treasury tem saldo suficiente?
+
+**Decisao:** ____________
+**Data:** ____________
+
+---
+
+## 7. Comunicacao
+
+**Pergunta central:** Como e quando comunicamos para a comunidade?
+
+### Timeline
+- [ ] **Pre-anuncio** (teaser) — quando? ____________
+- [ ] **Anuncio oficial** (detalhes completos) — quando? ____________
+- [ ] **Proposal on-chain** — quando? ____________
+- [ ] **Inicio da migracao** — quando? ____________
+- [ ] **Fim da janela** — quando? ____________
+
+### Canais
+- [ ] Farcaster (post oficial)
+- [ ] GM Farcaster (Jack ofereceu feature)
+- [ ] Telegram group
+- [ ] Website banner/popup
+- [ ] Twitter/X
+- [ ] Skatehive
+- [ ] Outros? ____________
+
+### Mensagem
+- [ ] Quem redige o texto principal? ____________
+- [ ] Jack ajuda com comms? (ofereceu na call)
+- [ ] FAQ pronto antes do anuncio?
+- [ ] Instrucoes passo-a-passo para holders?
+- [ ] Video explicativo?
+
+### Tom
+- [ ] Positivo (upgrade, novo ecossistema, mais oportunidades)
+- [ ] Transparente (problemas com Zora, motivos da mudanca)
+- [ ] Urgente (migrem agora) vs calmo (temos tempo, sem pressa)
+
+**Decisao:** ____________
+**Data:** ____________
+
+---
+
+## Resumo de Decisoes
+
+| # | Decisao | Resposta | Data |
+|---|---------|----------|------|
+| 1 | Aprovar migracao | | |
+| 2 | Token economics | | |
+| 3 | Metodo de migracao | | |
+| 4 | Criterios do airdrop | | |
+| 5 | Content coins Zora | | |
+| 6 | Treasury ops | | |
+| 7 | Comunicacao | | |
+
+---
+
+## Proximo Passo
+
+Depois de preencher este doc com Vlad:
+1. Bundlar decisoes 1-3 em uma Migration Authorization Proposal
+2. Postar proposal on-chain
+3. Enquanto voto rola (~2 semanas), avancar pesquisa tecnica em paralelo

--- a/docs/strategy/gnars-token-migration.md
+++ b/docs/strategy/gnars-token-migration.md
@@ -13,14 +13,127 @@ The GNARS creator coin is currently paired with Zora. Problems:
 
 **Decision:** Relaunch the GNARS token on Clanker with a new ERC20 (100B supply), migrate holders, and rebuild content coin infrastructure on the Clanker ecosystem.
 
+## DAO Internal Decisions Required
+
+Before any technical work or external coordination, **the DAO needs to vote on the migration itself**. Gnars is a Builder DAO — proposals go through on-chain voting (~2 day delay, ~5 day voting period, + timelock). Nothing happens without governance approval.
+
+### Decision 1: Approve Token Migration (PROPOSAL REQUIRED)
+
+**What:** DAO vote to officially approve migrating from Zora-paired GNARS to Clanker-based GNARS.
+
+**Must define:**
+- Rationale for migration (Zora underperformance, ecosystem risks)
+- Commitment to Clanker ecosystem
+- Authorization for the team to execute the migration plan
+
+**Why first:** Without this, no one has authority to deploy a new token or move treasury funds. This is the legitimacy layer — everything else is unauthorized until the DAO votes FOR.
+
+### Decision 2: New Token Economics
+
+**What:** Define the new GNARS token parameters.
+
+**Must define:**
+- Total supply (100B discussed, but needs DAO approval)
+- Distribution split:
+  - Migration allocation (what % for existing holders?)
+  - Airdrop allocation (what % for contribution-weighted airdrop?)
+  - Treasury/vault reserve (up to 90% can be vaulted per Clanker)
+  - Team/operations allocation (if any)
+- Pairing asset: ETH vs GNARS vs other (Jack suggested ETH for "cold hard cash")
+- Fee structure on the Clanker pool
+
+**Trade-off:** More supply in vault = more runway for future growth, but less initial distribution = less holder engagement. Need community input.
+
+### Decision 3: Migration Method & Parameters
+
+**What:** Confirm migration tool and parameters.
+
+**Must define:**
+- Migration method: Compre tool (preferred) vs snapshot
+- Migration window duration (1 week discussed, but needs agreement)
+- Exchange ratio (old GNARS → new GNARS)
+- Deadline policy: what happens to unclaimed tokens after window closes?
+- Whether to support migration in waves or all-at-once
+
+### Decision 4: Airdrop Criteria
+
+**What:** Define who qualifies for the contribution-weighted airdrop beyond existing holders.
+
+**Must define:**
+- Criteria categories: NFT holders, content creators, athletes, builders, community contributors
+- Weighting formula (e.g., NFTs held x time + proposals voted + content created)
+- Data sources for snapshot (on-chain activity, Skatehive contributions, etc.)
+- Minimum threshold to qualify
+- Whether to include holders of related tokens (sk hacker, other creator coins)
+
+**From the call:** Jack suggested "weighting contributions to give people skin in the game" and Vlad mentioned potentially aggregating liquidity from other community tokens like sk hacker.
+
+### Decision 5: Existing Zora Content Coins
+
+**What:** What happens to content coins currently paired with GNARS on Zora?
+
+**Options:**
+1. Let them stay on Zora (they still work independently)
+2. Build aggregation tool: trade Zora creator coins → new GNARS (Vlad's idea from call)
+3. Snapshot holders and airdrop equivalent on Clanker
+4. Deprecate and start fresh on Clanker
+
+**This is critical** — creators have real value locked in Zora content coins. The decision affects community trust.
+
+### Decision 6: Treasury Operations
+
+**What:** What treasury actions are needed to support the migration?
+
+**Must define:**
+- How much ETH/USDC from treasury for initial liquidity on Clanker?
+- Does the treasury migrate its Zora coin holdings?
+- Who has execution authority? (Currently proposals go through Governor → Treasury timelock)
+- Do we need a multisig for faster operational decisions during migration?
+
+### Decision 7: Communication Plan
+
+**What:** How and when to communicate with holders.
+
+**Must define:**
+- Timeline: announce → explain → execute → follow-up
+- Channels: Farcaster, Telegram, website banner, GM Farcaster (Jack offered)
+- Who drafts messaging (Jack offered help with comms)
+- FAQ for holders (what to do, what not to do, deadlines)
+
+### Governance Path
+
+```
+1. Draft proposal (informal discussion — Telegram, Farcaster)
+   ↓
+2. Post proposal on-chain (Decisions 1-6 bundled or split)
+   ↓
+3. Voting delay (~2 days)
+   ↓
+4. Voting period (~5 days)
+   ↓
+5. If SUCCEEDED → Queue
+   ↓
+6. Timelock delay
+   ↓
+7. Execute — team authorized to proceed
+```
+
+**Minimum timeline from proposal to execution: ~2 weeks.**
+
+**Recommendation:** Bundle Decisions 1-3 into a single "Migration Authorization Proposal" that gives the team a mandate. Decisions 4-7 can be refined in parallel and executed under that mandate.
+
+---
+
 ## Migration Strategy (3 Phases)
 
 ### Phase 1: Pre-Migration (current)
 
-**Goal:** Research, plan, communicate.
+**Goal:** Get DAO approval, research, plan, communicate.
 
 | Task | Owner | Status | Blocker |
 |------|-------|--------|---------|
+| **DAO governance decisions (see above)** | Vlad + team | **TODO — CRITICAL** | Must pass before Phase 2 |
+| Draft migration authorization proposal | Vlad + r4to | TODO | Needs token economics defined |
 | Receive Clanker SDK method for custom pairing | Jack Dishman | WAITING | - |
 | Intro with Compreny/Kabrini (migration tool) | Jack Dishman | WAITING | - |
 | Research Clanker SDK and token pairing mechanics | r4to | TODO | SDK docs needed |
@@ -150,9 +263,19 @@ The GNARS creator coin is currently paired with Zora. Problems:
 
 ## Next Steps (Immediate)
 
-1. **r4to:** Wait for Clanker SDK docs from Jack → research token pairing mechanics
-2. **r4to:** Complete detailed per-file audit of what changes (this doc is the start)
-3. **Vlad:** Summarize call intentions for Telegram group with Compre
-4. **Jack:** Create Telegram group, intro Compre, send SDK method
-5. **Team:** Define contribution-weighted airdrop criteria
-6. **Team:** Create Trello cards for Phase 1 tasks
+### Step 0: Internal alignment (BEFORE anything external)
+1. **Vlad + r4to:** Align on the 7 DAO decisions above — draft answers
+2. **Vlad:** Discuss token economics with core team (supply, distribution, pairing asset)
+3. **Vlad + r4to:** Draft migration authorization proposal for DAO vote
+4. **Team:** Post proposal on-chain → voting → execution (~2 weeks minimum)
+
+### Step 1: Parallel research (while governance runs)
+5. **r4to:** Wait for Clanker SDK docs from Jack → research token pairing mechanics
+6. **r4to:** Complete detailed per-file audit of what changes (this doc is the start)
+7. **Vlad:** Summarize call intentions for Telegram group with Compre
+8. **Jack:** Create Telegram group, intro Compre, send SDK method
+
+### Step 2: Post-approval execution
+9. **Team:** Define contribution-weighted airdrop criteria
+10. **Team:** Create Trello cards for Phase 2 tasks
+11. **r4to:** Begin website migration work (only after DAO vote passes)

--- a/docs/strategy/gnars-token-migration.md
+++ b/docs/strategy/gnars-token-migration.md
@@ -1,0 +1,158 @@
+# GNARS Token Migration: Zora to Clanker
+
+> Source: Call with Jack Dishman (Clanker) + Vlad Nikolaev (Gnars) + r4to — 2026-03-26
+> Status: **PLANNING** — blocked on Clanker SDK docs and Compre intro
+
+## Context
+
+The GNARS creator coin is currently paired with Zora. Problems:
+
+- Token price bleeding due to Zora's underperformance
+- Zora SDK limitations and poor communication
+- Zora ecosystem instability ("shady moves" per Vlad)
+
+**Decision:** Relaunch the GNARS token on Clanker with a new ERC20 (100B supply), migrate holders, and rebuild content coin infrastructure on the Clanker ecosystem.
+
+## Migration Strategy (3 Phases)
+
+### Phase 1: Pre-Migration (current)
+
+**Goal:** Research, plan, communicate.
+
+| Task | Owner | Status | Blocker |
+|------|-------|--------|---------|
+| Receive Clanker SDK method for custom pairing | Jack Dishman | WAITING | - |
+| Intro with Compreny/Kabrini (migration tool) | Jack Dishman | WAITING | - |
+| Research Clanker SDK and token pairing mechanics | r4to | TODO | SDK docs needed |
+| Audit all Zora-dependent code in gnars-website | r4to | IN PROGRESS | - |
+| Define contribution-weighted airdrop criteria | Vlad + team | TODO | - |
+| Draft holder communication (pre-migration) | Vlad + Jack | TODO | - |
+| Create Trello cards for execution | team | TODO | - |
+
+### Phase 2: Migration
+
+**Goal:** Deploy new token, run migration tool, airdrop.
+
+1. Deploy new GNARS token on Clanker (100B supply)
+2. Open migration window via Compre tool (holders deposit old tokens → receive new tokens)
+3. Run contribution-weighted airdrop to active creators/contributors
+4. Close migration window after ~1 week
+
+**Key decisions made:**
+- Use Compre migration tool (NOT snapshot) — clearer communication, no one "caught off guard"
+- Single strong token launch — no multiple creator tokens splitting attention
+- GNARS token must be live first before custom pairing works on Clanker
+- Future tokens may pair with ETH instead of GNARS ("cold hard cash" for creators)
+
+### Phase 3: Post-Migration (Website Rebuild)
+
+**Goal:** Replace all Zora integrations with Clanker equivalents.
+
+- Swap Zora SDK for Clanker SDK across all hooks/components
+- Deploy new subgraph for Clanker-paired coins
+- Update content coin creation flow
+- Update trading/swap mechanics
+- Update treasury display
+- Update proposal builder (buy-coin transaction type)
+
+## Codebase Impact Audit
+
+### Critical (63 files reference Zora)
+
+**Core Config:**
+- `src/lib/config.ts` — GNARS creator coin address, Zora handles, factory address, referrer
+- `src/lib/zora-coins-subgraph.ts` — subgraph client for GNARS-paired coins
+- `src/lib/zora/poolConfig.ts` — Uniswap V4 pool config for content coins
+- `src/lib/zora/factoryAbi.ts` — Zora factory ABI
+- `src/lib/zora-helpers.ts` — utility functions
+
+**Hooks (business logic):**
+- `src/hooks/useCreateCoin.ts` — creates content coins via Zora SDK
+- `src/hooks/use-trade-creator-coin.ts` — buy creator coins via Zora SDK
+- `src/hooks/use-batch-coin-purchase.ts` — batch buy via Multicall3
+- `src/hooks/use-zora-profile.ts` — resolve Zora profiles
+- `src/hooks/use-profile-coins.ts` — fetch profile coin data
+
+**Pages:**
+- `src/app/create-coin/page.tsx` — create content coins
+- `src/app/coin-proposal/page.tsx` — propose DAO coin purchases
+- `src/app/tv/[coinAddress]/page.tsx` — individual coin view
+- `src/app/treasury/page.tsx` — treasury with Zora holdings
+
+**Components:**
+- `src/components/tv/GnarsTVFeed.tsx` — TV feed (creator coins)
+- `src/components/tv/BuyAllModal.tsx` — bulk purchase UI
+- `src/components/tv/TVVideoCardInfo.tsx` — coin info display
+- `src/components/treasury/ZoraCoinHoldings.tsx` — treasury Zora holdings
+- `src/components/treasury/ZoraCoinHoldingsClient.tsx` — client-side holdings
+- `src/components/coin-proposal/CoinProposalWizard.tsx` — proposal wizard
+- `src/components/coin-proposal/CoinPurchaseForm.tsx` — purchase form
+- `src/components/members/ZoraProfileSummary.tsx` — member Zora profile
+- `src/components/members/detail/MemberCreatedCoinsGrid.tsx` — member coins
+- `src/components/proposals/builder/forms/buy-coin-form.tsx` — proposal form
+- `src/components/proposals/transaction/BuyCoinTransactionDetails.tsx` — tx display
+
+**API Routes:**
+- `src/app/api/coins/gnars-paired/route.ts` — fetch GNARS-paired coins
+- `src/app/api/coins/create/route.ts` — coin creation API
+- `src/app/api/tv/feed/route.ts` — TV feed data
+
+**Subgraph:**
+- `subgraphs/zora-coins/` — indexes GNARS-paired coins from Uniswap V4
+
+**Dependencies:**
+- `@zoralabs/coins-sdk` — primary SDK for all coin operations
+
+### Not Affected
+- Auction system (Builder DAO, independent of Zora coins)
+- Governance/voting (Builder Governor)
+- NFT minting (droposals use separate Zora NFT contracts, different concern)
+- Lootbox (independent contract)
+- Blog/static content
+
+## External Dependencies & Contacts
+
+| Who | Role | Action Item |
+|-----|------|-------------|
+| Jack Dishman | Clanker team | SDK docs, Compre intro, comms help, GM Farcaster feature |
+| Compreny/Kabrini | Migration tool builder | Provide migration tool (like Space token on Nouns) |
+| Caniana | Clanker project (Spain) | Potential partner — Jack offering intro |
+| Kenny (Picture/poidh) | Bounty provider | Already integrated |
+
+## Clanker Ecosystem Benefits (from call)
+
+- Tokens are independent, self-sustainable, immutable after deploy
+- Protocol fees fund an ecosystem fund for projects like Gnars
+- Marketing/distribution via GM Farcaster (branded X account)
+- Custom fee structures (can take fees in paired token, USDC, or ETH)
+- Vault up to 90% supply for rewards, onboarding, airdrops
+
+## Open Questions
+
+1. What's the Clanker SDK equivalent of `@zoralabs/coins-sdk`?
+2. How does custom pairing work? (Jack promised SDK method)
+3. What's the timeline for the migration tool from Compre?
+4. How to handle the existing Zora subgraph data post-migration?
+5. Do droposals (NFT mints) need to change? (They use separate Zora NFT contracts)
+6. What happens to existing content coins paired with GNARS on Zora?
+7. How to handle the transition period (both systems live)?
+8. Pair new tokens with ETH or GNARS? (Jack suggested ETH for "cold hard cash")
+
+## Risk Assessment
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Migration tool delay (Compre) | HIGH — blocks everything | Start research in parallel; have snapshot as fallback |
+| Holders miss migration window | HIGH — community trust | Clear comms, long window (~1 week+), multiple channels |
+| Clanker SDK gaps vs Zora SDK | MEDIUM — feature regression | Research early, identify gaps before committing |
+| Content coins stranded on Zora | MEDIUM — value locked | Consider aggregation tool (trade Zora coins → GNARS) |
+| Attention split during transition | MEDIUM — price impact | Single strong launch per Jack's advice |
+
+## Next Steps (Immediate)
+
+1. **r4to:** Wait for Clanker SDK docs from Jack → research token pairing mechanics
+2. **r4to:** Complete detailed per-file audit of what changes (this doc is the start)
+3. **Vlad:** Summarize call intentions for Telegram group with Compre
+4. **Jack:** Create Telegram group, intro Compre, send SDK method
+5. **Team:** Define contribution-weighted airdrop criteria
+6. **Team:** Create Trello cards for Phase 1 tasks


### PR DESCRIPTION
## Summary
- Documents decisions from call with Jack Dishman (Clanker) on 2026-03-26
- Audits all 63 Zora-dependent files that need to change
- Defines 3-phase migration plan: pre-migration, migration, post-migration
- Lists blockers (Clanker SDK docs, Compre migration tool) and open questions

## Changes
- `docs/strategy/gnars-token-migration.md` — full migration strategy document
- `docs/INDEX.md` — added Strategy section with pointer

## Context
The GNARS creator coin is currently paired with Zora, which is underperforming. The team decided to migrate to Clanker ecosystem (new ERC20, 100B supply) using Compre's migration tool. This doc serves as the single source of truth for the migration plan and can be shared with the Telegram group (Jack Dishman, Vlad, Compre).

## Test plan
- [ ] Review strategy accuracy against call transcript
- [ ] Share with Vlad and Jack for validation
- [ ] Create Trello cards from Phase 1 tasks

Generated with [Claude Code](https://claude.com/claude-code)