### PR TITLE
fix(build): resolve subgraph 429 and eslint warnings

### DIFF
--- a/src/app/api/proposals/per-month/route.ts
+++ b/src/app/api/proposals/per-month/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { SubgraphSDK } from "@buildeross/sdk";
 import { CHAIN, DAO_ADDRESSES } from "@/lib/config";
 
+export const dynamic = "force-dynamic";
 export const revalidate = 300; // 5 minutes
 
 // In-memory cache to reduce subgraph queries

--- a/src/app/api/proposals/route.ts
+++ b/src/app/api/proposals/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { listProposals } from "@/services/proposals";
 
+export const dynamic = "force-dynamic";
 export const revalidate = 60; // Revalidate every 60 seconds
 
 export async function GET(request: NextRequest) {

--- a/src/app/nogglesrails/[slug]/page.tsx
+++ b/src/app/nogglesrails/[slug]/page.tsx
@@ -1,5 +1,4 @@
 import { notFound } from "next/navigation";
-import Image from "next/image";
 import Link from "next/link";
 import type { Metadata } from "next";
 import { ArrowLeft, ExternalLink } from "lucide-react";

--- a/src/components/auction/BidHistoryModal.tsx
+++ b/src/components/auction/BidHistoryModal.tsx
@@ -49,7 +49,7 @@ function BidListContent({
 }) {
   const { bids, isLoading, error, newBidIds } = useAuctionBids(tokenId, enabled);
   const txHashes = useMemo(() => bids.map((b) => b.transactionHash), [bids]);
-  const { comments, isLoading: commentsLoading } = useBidComments(txHashes);
+  const { comments } = useBidComments(txHashes);
 
   if (isLoading) {
     return (

--- a/src/components/bounties/BountiesView.tsx
+++ b/src/components/bounties/BountiesView.tsx
@@ -46,17 +46,21 @@ export function BountiesView({ initialBounties }: BountiesViewProps) {
 
   const { ethPrice } = useEthPrice();
 
-  const filteredBounties = data?.bounties.filter((bounty) => {
-    const text = `${bounty.title} ${bounty.description}`.toLowerCase();
+  const filteredBounties = useMemo(() => {
+    return (
+      data?.bounties.filter((bounty) => {
+        const text = `${bounty.title} ${bounty.description}`.toLowerCase();
 
-    if (searchQuery.trim()) {
-      const query = searchQuery.trim().toLowerCase();
-      if (!text.includes(query)) return false;
-    }
+        if (searchQuery.trim()) {
+          const query = searchQuery.trim().toLowerCase();
+          if (!text.includes(query)) return false;
+        }
 
-    if (categoryFilter === 'all') return true;
-    return CATEGORY_KEYWORDS[categoryFilter]?.some((keyword) => text.includes(keyword));
-  }) || [];
+        if (categoryFilter === 'all') return true;
+        return CATEGORY_KEYWORDS[categoryFilter]?.some((keyword) => text.includes(keyword));
+      }) || []
+    );
+  }, [data?.bounties, searchQuery, categoryFilter]);
 
   const totalValue = useMemo(() => {
     const totalWei = filteredBounties.reduce((sum, bounty) => {

--- a/src/components/nogglesrails/NogglesRailsMap.tsx
+++ b/src/components/nogglesrails/NogglesRailsMap.tsx
@@ -106,6 +106,7 @@ export function NogglesRailsMap() {
               position={rail.position as LatLngExpression}
               iconAnchor={[rail.iconSize[0] / 2, rail.iconSize[1] / 2]}
               icon={
+                // eslint-disable-next-line @next/next/no-img-element
                 <img
                   src={rail.iconUrl}
                   alt={rail.label}

--- a/src/components/propdates/PropdatesFeed.tsx
+++ b/src/components/propdates/PropdatesFeed.tsx
@@ -11,8 +11,6 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { AddressDisplay } from "@/components/ui/address-display";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { PropdatesFeedSkeleton } from "@/components/propdates/PropdatesFeedSkeleton";
-import type { ProposalWithPropdates } from "@/services/propdates-enriched";
 import type { ProposalStatus } from "@/lib/schemas/proposals";
 
 // ---------------------------------------------------------------------------

--- a/src/components/proposals/transaction/ProposalTransactionVisualization.tsx
+++ b/src/components/proposals/transaction/ProposalTransactionVisualization.tsx
@@ -249,9 +249,7 @@ function decodeErc20Transfer(calldata: Hex): { to: Address; amount: bigint } | n
   }
 }
 
-// 4-byte selectors keep decoder routing cheap and quiet.
-const TRANSFER_FROM_SELECTOR = "0x23b872dd";
-const SAFE_TRANSFER_FROM_SELECTOR = "0x42842e0e";
+const SAFE_TRANSFER_FROM_SELECTOR = "0x42842e0e" as const;
 
 function decodeErc721Transfer(
   abi: typeof ERC721_TRANSFER_FROM_ABI | typeof ERC721_SAFE_TRANSFER_FROM_ABI,

--- a/src/components/proposals/transaction/ProposalTransactionVisualization.tsx
+++ b/src/components/proposals/transaction/ProposalTransactionVisualization.tsx
@@ -249,10 +249,18 @@ function decodeErc20Transfer(calldata: Hex): { to: Address; amount: bigint } | n
   }
 }
 
+// 4-byte selectors keep decoder routing cheap and quiet.
+const TRANSFER_FROM_SELECTOR = "0x23b872dd";
+const SAFE_TRANSFER_FROM_SELECTOR = "0x42842e0e";
+
 function decodeErc721Transfer(
   abi: typeof ERC721_TRANSFER_FROM_ABI | typeof ERC721_SAFE_TRANSFER_FROM_ABI,
   calldata: Hex,
 ): { from: Address; to: Address; tokenId: bigint } | null {
+  const selector = calldata.slice(0, 10).toLowerCase();
+  const isTransferFrom = abi === ERC721_TRANSFER_FROM_ABI;
+  const expected = isTransferFrom ? TRANSFER_FROM_SELECTOR : SAFE_TRANSFER_FROM_SELECTOR;
+  if (selector !== expected) return null;
   try {
     const { args } = decodeFunctionData({ abi, data: calldata });
     const [from, to, tokenId] = args as [Address, Address, bigint];

--- a/src/components/proposals/transaction/RecipientBundleCard.tsx
+++ b/src/components/proposals/transaction/RecipientBundleCard.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Image from "next/image";
-import { ArrowRight, Coins, FileImage, Send } from "lucide-react";
+import { Coins, FileImage, Send } from "lucide-react";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { AddressDisplay } from "@/components/ui/address-display";
 import { cn, getETHDisplayProps } from "@/lib/utils";

--- a/src/services/proposals.ts
+++ b/src/services/proposals.ts
@@ -10,6 +10,26 @@ import { CHAIN, DAO_ADDRESSES, SUBGRAPH } from "@/lib/config";
 import { serverPublicClient } from "@/lib/rpc";
 import { getProposalStatus } from "@/lib/schemas/proposals";
 
+/** Retry with exponential backoff on rate-limit / transient errors */
+async function withRetry<T>(fn: () => Promise<T>, label: string, maxAttempts = 5): Promise<T> {
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      const msg = err instanceof Error ? err.message : String(err);
+      const isRateLimit = /429|rate.?limit|too many requests/i.test(msg);
+      const isTransient = isRateLimit || /fetch failed|ETIMEDOUT|ECONNRESET|503|502/i.test(msg);
+      if (!isTransient || attempt === maxAttempts) throw err;
+      const delay = Math.min(8_000, 500 * 2 ** (attempt - 1)) + Math.random() * 250;
+      console.warn(`[${label}] attempt ${attempt} failed (${isRateLimit ? "429" : "transient"}); retry in ${Math.round(delay)}ms`);
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+  throw lastErr;
+}
+
 /** Fetch vote timestamps from subgraph (the SDK fragment omits this field) */
 async function fetchVoteTimestamps(
   proposalId: string,
@@ -26,11 +46,15 @@ async function fetchVoteTimestamps(
     }
   }`;
   try {
-    const res = await fetch(SUBGRAPH.url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ query }),
-    });
+    const res = await withRetry(async () => {
+      const r = await fetch(SUBGRAPH.url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query }),
+      });
+      if (r.status === 429) throw new Error(`GraphQL Error (Code: 429)`);
+      return r;
+    }, "fetchVoteTimestamps");
     if (!res.ok) return {};
     const data = await res.json();
     const map: Record<string, number> = {};
@@ -137,11 +161,15 @@ function transformProposal(p: SdkProposal): Proposal {
 }
 
 export const listProposals = cache(async (limit = 200, page = 0): Promise<Proposal[]> => {
-  const data = await SubgraphSDK.connect(CHAIN.id).proposals({
-    where: { dao: DAO_ADDRESSES.token.toLowerCase() },
-    first: limit,
-    skip: page * limit,
-  });
+  const data = await withRetry(
+    () =>
+      SubgraphSDK.connect(CHAIN.id).proposals({
+        where: { dao: DAO_ADDRESSES.token.toLowerCase() },
+        first: limit,
+        skip: page * limit,
+      }),
+    "listProposals",
+  );
 
   const sdkProposals = data.proposals ?? [];
 
@@ -161,10 +189,10 @@ export const getProposalByIdOrNumber = cache(
           dao: DAO_ADDRESSES.token.toLowerCase(),
         };
 
-    const data = await SubgraphSDK.connect(CHAIN.id).proposals({
-      where,
-      first: 1,
-    });
+    const data = await withRetry(
+      () => SubgraphSDK.connect(CHAIN.id).proposals({ where, first: 1 }),
+      `getProposalByIdOrNumber(${idOrNumber})`,
+    );
 
     if (!data.proposals || data.proposals.length === 0) {
       return null; // Genuinely not found


### PR DESCRIPTION
## Summary
- Unblocks Vercel build that was aborting when subgraph returned 429 during parallel prerender of proposal pages.
- Clears all ESLint warnings reported during `Linting and checking validity of types` step.
- Silences spurious ERC721 decode warnings in proposal transaction visualization.

## Changes

**Subgraph resilience** (`src/services/proposals.ts`)
- `withRetry()` helper: exponential backoff on 429 / 5xx / transient errors (5 attempts, jittered).
- Wraps `listProposals`, `getProposalByIdOrNumber`, and `fetchVoteTimestamps`.

**Dynamic API routes** (`src/app/api/proposals/route.ts`, `src/app/api/proposals/per-month/route.ts`)
- Add `export const dynamic = "force-dynamic"` — both routes read `nextUrl.searchParams` and were triggering `DYNAMIC_SERVER_USAGE` errors during static collection.

**ERC721 decoder** (`src/components/proposals/transaction/ProposalTransactionVisualization.tsx`)
- Route by 4-byte selector before attempting `decodeFunctionData`. Previously the fallback pattern (`safeTransferFrom || transferFrom`) logged a warning on every first-attempt miss.

**ESLint warnings cleared**
- `src/app/nogglesrails/[slug]/page.tsx` — drop unused `Image` import.
- `src/components/auction/BidHistoryModal.tsx` — drop unused `commentsLoading`.
- `src/components/bounties/BountiesView.tsx` — wrap `filteredBounties` in `useMemo` (exhaustive-deps).
- `src/components/nogglesrails/NogglesRailsMap.tsx` — `eslint-disable-next-line` for the Leaflet marker `<img>` (Leaflet icon prop needs a raw DOM element, `next/image` is incompatible).
- `src/components/propdates/PropdatesFeed.tsx` — drop unused `PropdatesFeedSkeleton`, `ProposalWithPropdates` imports.
- `src/components/proposals/transaction/RecipientBundleCard.tsx` — drop unused `ArrowRight` import.

## Known follow-up
Retry is a pragmatic fix, not root-cause — the 20 parallel prerenders still hammer the free Goldsky endpoint. Tracking as a separate PR: reduce build-time subgraph load via static snapshots / single prefetch / lower `generateStaticParams` count.

## Test plan
- [ ] Vercel build completes (no `GraphQL Error (Code: 429)` abort).
- [ ] `pnpm lint --dir src` clean.
- [ ] Proposal page renders with transaction decoding intact.
- [ ] `/api/proposals` and `/api/proposals/per-month` serve data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)