### PR TITLE
perf(feed): unified feedEvents query (5 queries → 1)

### DIFF
--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -1,12 +1,11 @@
-import { NextResponse } from "next/server";
 import { unstable_cache } from "next/cache";
+import { NextResponse } from "next/server";
 import { fetchFarcasterProfilesByAddress } from "@/services/farcaster";
 import {
   fetchActiveVotesForVoters,
   fetchAllMembers,
   fetchNonCanceledProposalsCount,
-  fetchVotesCountForVoters,
-  fetchVoteSupportForVoters,
+  fetchVoterActivity,
   type MemberListItem,
 } from "@/services/members";
 
@@ -19,24 +18,22 @@ const getCachedMembers = unstable_cache(
   async (): Promise<MemberListItem[]> => {
     const members = await fetchAllMembers();
     const owners = members.map((m) => m.owner);
-    const [
-      votesCountResult,
-      activeVotesResult,
-      nonCanceledResult,
-      voteSupportResult,
-      farcasterResult,
-    ] = await Promise.allSettled([
-      fetchVotesCountForVoters(owners),
-      fetchActiveVotesForVoters(owners),
-      fetchNonCanceledProposalsCount(),
-      fetchVoteSupportForVoters(owners),
-      fetchFarcasterProfilesByAddress(owners),
-    ]);
+    const [voterActivityResult, activeVotesResult, nonCanceledResult, farcasterResult] =
+      await Promise.allSettled([
+        fetchVoterActivity(owners),
+        fetchActiveVotesForVoters(owners),
+        fetchNonCanceledProposalsCount(),
+        fetchFarcasterProfilesByAddress(owners),
+      ]);
 
-    const votesCountMap = votesCountResult.status === "fulfilled" ? votesCountResult.value : {};
+    const voterActivity =
+      voterActivityResult.status === "fulfilled"
+        ? voterActivityResult.value
+        : { counts: {}, support: {} };
+    const votesCountMap = voterActivity.counts;
+    const voteSupportMap = voterActivity.support;
     const activeVotesMap = activeVotesResult.status === "fulfilled" ? activeVotesResult.value : {};
     const nonCanceledCount = nonCanceledResult.status === "fulfilled" ? nonCanceledResult.value : 0;
-    const voteSupportMap = voteSupportResult.status === "fulfilled" ? voteSupportResult.value : {};
     const farcasterProfiles = farcasterResult.status === "fulfilled" ? farcasterResult.value : {};
 
     return members.map((m) => {

--- a/src/app/api/proposals/per-month/route.ts
+++ b/src/app/api/proposals/per-month/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { SubgraphSDK } from "@buildeross/sdk";
-import { CHAIN, DAO_ADDRESSES } from "@/lib/config";
+import { DAO_ADDRESSES } from "@/lib/config";
+import { subgraphQuery } from "@/lib/subgraph";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 300; // 5 minutes
@@ -8,6 +8,22 @@ export const revalidate = 300; // 5 minutes
 // In-memory cache to reduce subgraph queries
 let cache: { proposals: number[]; timestamp: number } | null = null;
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+// Minimal query: only `timeCreated` — previous SDK call pulled full
+// proposal payload (description, calldatas, votes) per entry just to
+// bucket by month.
+const PROPOSAL_TIMESTAMPS_QUERY = `
+  query ProposalTimestamps($dao: String!, $first: Int!) {
+    proposals(
+      where: { dao: $dao }
+      first: $first
+      orderBy: timeCreated
+      orderDirection: desc
+    ) {
+      timeCreated
+    }
+  }
+`;
 
 export async function GET(request: NextRequest) {
   try {
@@ -22,14 +38,14 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    // Fetch from subgraph (no RPC calls)
-    const result = await SubgraphSDK.connect(CHAIN.id).proposals({
-      where: { dao: DAO_ADDRESSES.token.toLowerCase() },
+    const { proposals: rows } = await subgraphQuery<{
+      proposals: Array<{ timeCreated: string }>;
+    }>(PROPOSAL_TIMESTAMPS_QUERY, {
+      dao: DAO_ADDRESSES.token.toLowerCase(),
       first: 500,
-      skip: 0,
     });
 
-    const proposals = (result.proposals || []).map((p) => Number(p.timeCreated ?? 0));
+    const proposals = (rows || []).map((p) => Number(p.timeCreated ?? 0));
 
     // Update cache
     cache = { proposals, timestamp: now };
@@ -67,4 +83,3 @@ function groupByMonth(timestamps: number[], months: number) {
 
   return result;
 }
-

--- a/src/services/dao.ts
+++ b/src/services/dao.ts
@@ -7,54 +7,57 @@ export type DaoStats = {
   ownerCount: number;
 };
 
-type DaoQuery = {
+export type DaoOverview = DaoStats & {
+  totalAuctionSalesWei: bigint;
+};
+
+type DaoOverviewQuery = {
   dao: {
     id: string;
     totalSupply: number;
     ownerCount: number;
+    totalAuctionSales: string | null;
   } | null;
 };
 
-const DAO_GQL = /* GraphQL */ `
-  query Dao($id: ID!) {
+// Single query covering every `dao(id)` read currently scattered across
+// fetchDaoStats + fetchTotalAuctionSalesWei. React `cache()` dedupes
+// within a request so callers still see per-request memoization.
+const DAO_OVERVIEW_GQL = /* GraphQL */ `
+  query DaoOverview($id: ID!) {
     dao(id: $id) {
       id
       totalSupply
       ownerCount
-    }
-  }
-`;
-
-export const fetchDaoStats = cache(async (): Promise<DaoStats> => {
-  const id = DAO_ADDRESSES.token.toLowerCase();
-  const data = await subgraphQuery<DaoQuery>(DAO_GQL, { id });
-  return {
-    totalSupply: Number(data.dao?.totalSupply ?? 0),
-    ownerCount: Number(data.dao?.ownerCount ?? 0),
-  };
-});
-
-type DaoSalesQuery = {
-  dao: {
-    totalAuctionSales: string;
-  } | null;
-};
-
-const DAO_TOTAL_AUCTION_SALES_GQL = /* GraphQL */ `
-  query TotalAuctionSales($id: ID!) {
-    dao(id: $id) {
       totalAuctionSales
     }
   }
 `;
 
-export const fetchTotalAuctionSalesWei = cache(async (): Promise<bigint> => {
-  const id = DAO_ADDRESSES.token.toLowerCase();
-  const data = await subgraphQuery<DaoSalesQuery>(DAO_TOTAL_AUCTION_SALES_GQL, { id });
-  const wei = data.dao?.totalAuctionSales ?? "0";
+function safeBigInt(value: string | null | undefined): bigint {
   try {
-    return BigInt(wei);
+    return BigInt(value ?? "0");
   } catch {
     return BigInt(0);
   }
+}
+
+export const fetchDaoOverview = cache(async (): Promise<DaoOverview> => {
+  const id = DAO_ADDRESSES.token.toLowerCase();
+  const data = await subgraphQuery<DaoOverviewQuery>(DAO_OVERVIEW_GQL, { id });
+  return {
+    totalSupply: Number(data.dao?.totalSupply ?? 0),
+    ownerCount: Number(data.dao?.ownerCount ?? 0),
+    totalAuctionSalesWei: safeBigInt(data.dao?.totalAuctionSales),
+  };
+});
+
+export const fetchDaoStats = cache(async (): Promise<DaoStats> => {
+  const { totalSupply, ownerCount } = await fetchDaoOverview();
+  return { totalSupply, ownerCount };
+});
+
+export const fetchTotalAuctionSalesWei = cache(async (): Promise<bigint> => {
+  const { totalAuctionSalesWei } = await fetchDaoOverview();
+  return totalAuctionSalesWei;
 });

--- a/src/services/feed-events.ts
+++ b/src/services/feed-events.ts
@@ -1,8 +1,9 @@
 /**
  * Feed Events Service
- * 
- * Fetches and transforms blockchain events from The Graph subgraph.
- * Uses Next.js 15 caching for optimal performance on Vercel.
+ *
+ * Fetches DAO activity from The Graph via a single unified `feedEvents`
+ * query (Builder subgraph union interface). Replaces the previous 5-query
+ * parallel fetch-and-merge approach.
  */
 
 import { unstable_cache } from "next/cache";
@@ -11,288 +12,215 @@ import { CHAIN, DAO_ADDRESSES } from "@/lib/config";
 import { subgraphQuery } from "@/lib/subgraph";
 import type { FeedEvent } from "@/lib/types/feed-events";
 
-// Cache for 15 seconds with background revalidation
 const CACHE_TTL = 15;
 const CACHE_TAG = "feed-events";
 
-/**
- * Query for recent proposals with their votes
- */
-const PROPOSALS_QUERY = `
-  query GetRecentProposals($daoAddress: String!, $since: BigInt!) {
-    proposals(
-      where: { dao: $daoAddress, timeCreated_gt: $since }
-      orderBy: timeCreated
-      orderDirection: desc
-      first: 100
-    ) {
-      id
-      proposalId
-      proposalNumber
-      title
-      description
-      proposer
-      timeCreated
-      voteStart
-      voteEnd
-      quorumVotes
-      executed
-      canceled
-      vetoed
-      queued
-      snapshotBlockNumber
-      transactionHash
-    }
-  }
-`;
+// Cap at 100 per Builder subgraph convention; we over-fetch to cover
+// post-filter event drops (Updated/Clanker/Zora currently unmapped) and
+// derived status events.
+const DEFAULT_FETCH_LIMIT = 100;
 
-/**
- * Query for recent votes
- */
-const VOTES_QUERY = `
-  query GetRecentVotes($daoAddress: String!, $since: BigInt!) {
-    proposalVotes(
-      where: { 
-        proposal_: { dao: $daoAddress }
-        timestamp_gt: $since
-      }
+const FEED_EVENTS_QUERY = `
+  query GnarsFeedEvents($first: Int!, $where: FeedEvent_filter) {
+    feedEvents(
+      first: $first
+      where: $where
       orderBy: timestamp
       orderDirection: desc
-      first: 200
     ) {
+      __typename
       id
-      voter
-      support
-      weight
-      reason
+      type
       timestamp
+      blockNumber
       transactionHash
-      proposal {
-        proposalNumber
-        title
-      }
-    }
-  }
-`;
+      actor
 
-/**
- * Query for recent auctions
- */
-const AUCTIONS_QUERY = `
-  query GetRecentAuctions($daoAddress: String!, $since: BigInt!) {
-    auctions(
-      where: { dao: $daoAddress, startTime_gt: $since }
-      orderBy: startTime
-      orderDirection: desc
-      first: 50
-    ) {
-      id
-      startTime
-      endTime
-      settled
-      token {
-        tokenId
-        image
-      }
-    }
-  }
-`;
-
-/**
- * Query for recent auction bids
- */
-const BIDS_QUERY = `
-  query GetRecentBids($daoAddress: String!, $since: BigInt!) {
-    auctionBids(
-      where: { 
-        auction_: { dao: $daoAddress }
-        bidTime_gt: $since
-      }
-      orderBy: bidTime
-      orderDirection: desc
-      first: 200
-    ) {
-      id
-      bidder
-      amount
-      bidTime
-      transactionHash
-      auction {
-        token {
-          tokenId
-          image
+      ... on ProposalCreatedEvent {
+        proposal {
+          proposalId
+          proposalNumber
+          title
+          description
+          proposer
+          timeCreated
+          voteStart
+          voteEnd
+          quorumVotes
+          executed
+          queued
+          canceled
+          vetoed
+          snapshotBlockNumber
+          transactionHash
         }
-        endTime
+      }
+
+      ... on ProposalVotedEvent {
+        proposal {
+          proposalId
+          proposalNumber
+          title
+        }
+        vote {
+          support
+          weight
+          reason
+        }
+      }
+
+      ... on ProposalExecutedEvent {
+        proposal {
+          proposalId
+          proposalNumber
+          title
+        }
+      }
+
+      ... on AuctionCreatedEvent {
+        auction {
+          id
+          startTime
+          endTime
+          token {
+            tokenId
+            image
+          }
+        }
+      }
+
+      ... on AuctionBidPlacedEvent {
+        auction {
+          id
+          endTime
+          token {
+            tokenId
+            image
+          }
+        }
+        bid {
+          amount
+          bidder
+        }
+      }
+
+      ... on AuctionSettledEvent {
+        auction {
+          id
+          token {
+            tokenId
+            image
+            owner
+          }
+        }
+        amount
       }
     }
   }
 `;
 
-/**
- * Query for recent token mints/transfers
- */
-const TOKENS_QUERY = `
-  query GetRecentTokens($daoAddress: String!, $since: BigInt!) {
-    tokens(
-      where: { dao: $daoAddress, mintedAt_gt: $since }
-      orderBy: mintedAt
-      orderDirection: desc
-      first: 100
-    ) {
-      id
-      tokenId
-      owner
-      mintedAt
-    }
-  }
-`;
-
-/**
- * Query for delegate changes (not yet implemented)
- */
-// const DELEGATES_QUERY = `
-//   query GetRecentDelegates($daoAddress: String!, $since: BigInt!) {
-//     daoTokenOwners(
-//       where: { 
-//         dao: $daoAddress
-//         # Note: We'd need a timestamp field for filtering
-//       }
-//       orderBy: daoTokenCount
-//       orderDirection: desc
-//       first: 50
-//     ) {
-//       id
-//       owner
-//       delegate
-//       daoTokenCount
-//     }
-//   }
-// `;
-
-// Type definitions for subgraph responses
-interface SubgraphProposal {
+interface BaseSubgraphEvent {
+  __typename: string;
   id: string;
+  type: string;
+  timestamp: string;
+  blockNumber: string;
+  transactionHash: string;
+  actor: string;
+}
+
+interface SubgraphProposalRef {
   proposalId: string;
   proposalNumber: number;
   title: string | null;
-  description: string | null;
-  proposer: string;
-  timeCreated: string;
-  voteStart: string;
-  voteEnd: string;
-  quorumVotes: string;
-  executed: boolean;
-  canceled: boolean;
-  vetoed: boolean;
-  queued: boolean;
-  snapshotBlockNumber: string;
-  transactionHash: string;
+  description?: string | null;
+  proposer?: string;
+  timeCreated?: string;
+  voteStart?: string;
+  voteEnd?: string;
+  quorumVotes?: string;
+  executed?: boolean;
+  queued?: boolean;
+  canceled?: boolean;
+  vetoed?: boolean;
+  snapshotBlockNumber?: string;
+  transactionHash?: string;
 }
 
-interface SubgraphVote {
-  id: string;
-  voter: string;
-  support: string;
-  weight: string;
-  reason: string | null;
-  timestamp: string;
-  transactionHash: string;
+interface SubgraphProposalCreated extends BaseSubgraphEvent {
+  __typename: "ProposalCreatedEvent";
   proposal: {
+    proposalId: string;
     proposalNumber: number;
     title: string | null;
+    description: string | null;
+    proposer: string;
+    timeCreated: string;
+    voteStart: string;
+    voteEnd: string;
+    quorumVotes: string;
+    executed: boolean;
+    queued: boolean;
+    canceled: boolean;
+    vetoed: boolean;
+    snapshotBlockNumber: string;
+    transactionHash: string;
   };
 }
 
-interface SubgraphBid {
-  id: string;
-  bidder: string;
-  amount: string;
-  bidTime: string;
-  transactionHash: string;
+interface SubgraphProposalVoted extends BaseSubgraphEvent {
+  __typename: "ProposalVotedEvent";
+  proposal: SubgraphProposalRef;
+  vote: {
+    support: string;
+    weight: string;
+    reason: string | null;
+  };
+}
+
+interface SubgraphProposalExecuted extends BaseSubgraphEvent {
+  __typename: "ProposalExecutedEvent";
+  proposal: SubgraphProposalRef;
+}
+
+interface SubgraphAuctionCreated extends BaseSubgraphEvent {
+  __typename: "AuctionCreatedEvent";
   auction: {
-    token: {
-      tokenId: string;
-      image?: string | null;
-    };
+    id: string;
+    startTime: string;
     endTime: string;
+    token: { tokenId: string; image?: string | null };
   };
 }
 
-interface SubgraphToken {
-  id: string;
-  tokenId: string;
-  owner: string;
-  mintedAt: string;
+interface SubgraphAuctionBidPlaced extends BaseSubgraphEvent {
+  __typename: "AuctionBidPlacedEvent";
+  auction: {
+    id: string;
+    endTime: string;
+    token: { tokenId: string; image?: string | null };
+  };
+  bid: { amount: string; bidder: string };
 }
 
-interface SubgraphAuction {
-  id: string;
-  startTime: string;
-  endTime: string;
-  settled: boolean;
-  token: {
-    tokenId: string;
-    image?: string | null;
+interface SubgraphAuctionSettled extends BaseSubgraphEvent {
+  __typename: "AuctionSettledEvent";
+  auction: {
+    id: string;
+    token: { tokenId: string; image?: string | null; owner: string };
   };
+  amount: string;
 }
 
-/**
- * Transform subgraph proposal to feed event
- */
-function transformProposalToEvent(p: SubgraphProposal): FeedEvent {
-  return {
-    id: `proposal-${p.proposalId}`,
-    type: "ProposalCreated",
-    category: "governance",
-    priority: "HIGH",
-    timestamp: Number(p.timeCreated),
-    blockNumber: Number(p.snapshotBlockNumber),
-    transactionHash: p.transactionHash,
-    proposalId: p.proposalId,
-    proposalNumber: p.proposalNumber,
-    title: p.title || `Proposal #${p.proposalNumber}`,
-    description: p.description || "",
-    proposer: p.proposer,
-    voteStart: Number(p.voteStart),
-    voteEnd: Number(p.voteEnd),
-    quorumVotes: Number(p.quorumVotes),
-  };
-}
+type SubgraphFeedEvent =
+  | SubgraphProposalCreated
+  | SubgraphProposalVoted
+  | SubgraphProposalExecuted
+  | SubgraphAuctionCreated
+  | SubgraphAuctionBidPlaced
+  | SubgraphAuctionSettled
+  | (BaseSubgraphEvent & { __typename: string });
 
-/**
- * Transform subgraph vote to feed event
- */
-function transformVoteToEvent(v: SubgraphVote): FeedEvent {
-  const supportMap: Record<string, "FOR" | "AGAINST" | "ABSTAIN"> = {
-    "0": "AGAINST",
-    "1": "FOR",
-    "2": "ABSTAIN",
-    "AGAINST": "AGAINST",
-    "FOR": "FOR",
-    "ABSTAIN": "ABSTAIN",
-  };
-
-  return {
-    id: `vote-${v.id}`,
-    type: "VoteCast",
-    category: "governance",
-    priority: v.reason && v.reason.length > 0 ? "HIGH" : "MEDIUM",
-    timestamp: Number(v.timestamp),
-    blockNumber: 0, // Not available in vote data
-    transactionHash: v.transactionHash,
-    proposalId: "", // Not directly available
-    proposalNumber: v.proposal.proposalNumber,
-    proposalTitle: v.proposal.title || `Proposal #${v.proposal.proposalNumber}`,
-    voter: v.voter,
-    support: supportMap[v.support] || "ABSTAIN",
-    weight: Number(v.weight),
-    reason: v.reason || undefined,
-  };
-}
-
-/**
- * Convert IPFS URI to HTTP URL
- */
 function toHttpUrl(uri?: string | null): string | undefined {
   if (!uri) return undefined;
   if (uri.startsWith("ipfs://")) {
@@ -301,326 +229,246 @@ function toHttpUrl(uri?: string | null): string | undefined {
   return uri;
 }
 
-/**
- * Transform subgraph bid to feed event
- */
-function transformBidToEvent(b: SubgraphBid): FeedEvent {
-  return {
-    id: `bid-${b.id}`,
-    type: "AuctionBid",
-    category: "auction",
-    priority: "HIGH",
-    timestamp: Number(b.bidTime),
-    blockNumber: 0,
-    transactionHash: b.transactionHash,
-    tokenId: Number(b.auction.token.tokenId),
-    bidder: b.bidder,
-    amount: (Number(b.amount) / 1e18).toFixed(5), // Convert from wei to ETH (5 decimals)
-    extended: false, // Extended field not available in subgraph
-    endTime: Number(b.auction.endTime),
-    imageUrl: toHttpUrl(b.auction.token.image),
-  };
+const VOTE_SUPPORT: Record<string, "FOR" | "AGAINST" | "ABSTAIN"> = {
+  "0": "AGAINST",
+  "1": "FOR",
+  "2": "ABSTAIN",
+  AGAINST: "AGAINST",
+  FOR: "FOR",
+  ABSTAIN: "ABSTAIN",
+};
+
+function weiToEth(wei: string): string {
+  return (Number(wei) / 1e18).toFixed(5);
 }
 
-/**
- * Transform subgraph auction to feed event
- */
-function transformAuctionToEvent(a: SubgraphAuction): FeedEvent | null {
-  // Show all auctions (both new and settled)
-  return {
-    id: `auction-${a.id}`,
-    type: "AuctionCreated",
-    category: "auction",
-    priority: "HIGH",
-    timestamp: Number(a.startTime),
-    blockNumber: 0,
-    transactionHash: "",
-    tokenId: Number(a.token.tokenId),
-    startTime: Number(a.startTime),
-    endTime: Number(a.endTime),
-    imageUrl: toHttpUrl(a.token.image),
-  };
+function transformEvent(event: SubgraphFeedEvent): FeedEvent[] {
+  const ts = Number(event.timestamp);
+  const block = Number(event.blockNumber);
+
+  switch (event.__typename) {
+    case "ProposalCreatedEvent": {
+      const e = event as SubgraphProposalCreated;
+      const p = e.proposal;
+      const title = p.title || `Proposal #${p.proposalNumber}`;
+      const events: FeedEvent[] = [
+        {
+          id: `proposal-${p.proposalId}`,
+          type: "ProposalCreated",
+          category: "governance",
+          priority: "HIGH",
+          timestamp: Number(p.timeCreated),
+          blockNumber: Number(p.snapshotBlockNumber),
+          transactionHash: p.transactionHash,
+          proposalId: p.proposalId,
+          proposalNumber: p.proposalNumber,
+          title,
+          description: p.description || "",
+          proposer: p.proposer,
+          voteStart: Number(p.voteStart),
+          voteEnd: Number(p.voteEnd),
+          quorumVotes: Number(p.quorumVotes),
+        },
+      ];
+
+      // Builder subgraph emits ProposalExecutedEvent natively but NOT
+      // Queued/Canceled/Vetoed. Synthesize those from current proposal
+      // flags carried on the ProposalCreatedEvent relation.
+      if (p.queued) {
+        events.push({
+          id: `proposal-queued-${p.proposalId}`,
+          type: "ProposalQueued",
+          category: "governance",
+          priority: "HIGH",
+          timestamp: Number(p.voteEnd),
+          blockNumber: Number(p.snapshotBlockNumber),
+          transactionHash: p.transactionHash,
+          proposalId: p.proposalId,
+          proposalNumber: p.proposalNumber,
+          proposalTitle: title,
+          eta: Number(p.voteEnd) + 86400,
+        });
+      }
+      if (p.canceled) {
+        events.push({
+          id: `proposal-canceled-${p.proposalId}`,
+          type: "ProposalCanceled",
+          category: "governance",
+          priority: "MEDIUM",
+          timestamp: Number(p.timeCreated),
+          blockNumber: Number(p.snapshotBlockNumber),
+          transactionHash: p.transactionHash,
+          proposalId: p.proposalId,
+          proposalNumber: p.proposalNumber,
+          proposalTitle: title,
+        });
+      }
+      if (p.vetoed) {
+        events.push({
+          id: `proposal-vetoed-${p.proposalId}`,
+          type: "ProposalVetoed",
+          category: "governance",
+          priority: "HIGH",
+          timestamp: Number(p.timeCreated),
+          blockNumber: Number(p.snapshotBlockNumber),
+          transactionHash: p.transactionHash,
+          proposalId: p.proposalId,
+          proposalNumber: p.proposalNumber,
+          proposalTitle: title,
+        });
+      }
+      return events;
+    }
+
+    case "ProposalVotedEvent": {
+      const e = event as SubgraphProposalVoted;
+      const support = VOTE_SUPPORT[e.vote.support] || "ABSTAIN";
+      return [
+        {
+          id: `vote-${e.id}`,
+          type: "VoteCast",
+          category: "governance",
+          priority: e.vote.reason && e.vote.reason.length > 0 ? "HIGH" : "MEDIUM",
+          timestamp: ts,
+          blockNumber: block,
+          transactionHash: e.transactionHash,
+          proposalId: e.proposal.proposalId,
+          proposalNumber: e.proposal.proposalNumber,
+          proposalTitle: e.proposal.title || `Proposal #${e.proposal.proposalNumber}`,
+          voter: e.actor,
+          support,
+          weight: Number(e.vote.weight),
+          reason: e.vote.reason || undefined,
+        },
+      ];
+    }
+
+    case "ProposalExecutedEvent": {
+      const e = event as SubgraphProposalExecuted;
+      return [
+        {
+          id: `proposal-executed-${e.proposal.proposalId}`,
+          type: "ProposalExecuted",
+          category: "governance",
+          priority: "HIGH",
+          timestamp: ts,
+          blockNumber: block,
+          transactionHash: e.transactionHash,
+          proposalId: e.proposal.proposalId,
+          proposalNumber: e.proposal.proposalNumber,
+          proposalTitle: e.proposal.title || `Proposal #${e.proposal.proposalNumber}`,
+        },
+      ];
+    }
+
+    case "AuctionCreatedEvent": {
+      const e = event as SubgraphAuctionCreated;
+      return [
+        {
+          id: `auction-${e.auction.id}`,
+          type: "AuctionCreated",
+          category: "auction",
+          priority: "HIGH",
+          timestamp: Number(e.auction.startTime),
+          blockNumber: block,
+          transactionHash: e.transactionHash,
+          tokenId: Number(e.auction.token.tokenId),
+          startTime: Number(e.auction.startTime),
+          endTime: Number(e.auction.endTime),
+          imageUrl: toHttpUrl(e.auction.token.image),
+        },
+      ];
+    }
+
+    case "AuctionBidPlacedEvent": {
+      const e = event as SubgraphAuctionBidPlaced;
+      return [
+        {
+          id: `bid-${e.id}`,
+          type: "AuctionBid",
+          category: "auction",
+          priority: "HIGH",
+          timestamp: ts,
+          blockNumber: block,
+          transactionHash: e.transactionHash,
+          tokenId: Number(e.auction.token.tokenId),
+          bidder: e.bid.bidder,
+          amount: weiToEth(e.bid.amount),
+          extended: false,
+          endTime: Number(e.auction.endTime),
+          imageUrl: toHttpUrl(e.auction.token.image),
+        },
+      ];
+    }
+
+    case "AuctionSettledEvent": {
+      const e = event as SubgraphAuctionSettled;
+      return [
+        {
+          id: `auction-settled-${e.auction.id}`,
+          type: "AuctionSettled",
+          category: "auction",
+          priority: "HIGH",
+          timestamp: ts,
+          blockNumber: block,
+          transactionHash: e.transactionHash,
+          tokenId: Number(e.auction.token.tokenId),
+          winner: e.auction.token.owner,
+          amount: weiToEth(e.amount),
+          imageUrl: toHttpUrl(e.auction.token.image),
+        },
+      ];
+    }
+
+    // Unmapped Builder event types (ProposalUpdated, ClankerTokenCreated,
+    // ZoraCoinCreated, ZoraDropCreated). Skip until local FeedEvent union
+    // grows support.
+    default:
+      return [];
+  }
 }
 
-/**
- * Transform subgraph token to feed event
- */
-function transformTokenToEvent(t: SubgraphToken): FeedEvent {
-  return {
-    id: `token-${t.id}`,
-    type: "TokenMinted",
-    category: "token",
-    priority: "HIGH",
-    timestamp: Number(t.mintedAt),
-    blockNumber: 0,
-    transactionHash: "",
-    tokenId: Number(t.tokenId),
-    recipient: t.owner,
-    isFounder: false, // Would need to check mint schedule
-  };
-}
-
-/**
- * Fetch feed events from subgraph (uncached)
- */
 async function fetchFeedEventsUncached(hoursBack: number = 24): Promise<FeedEvent[]> {
   const now = Math.floor(Date.now() / 1000);
-  const since = now - (hoursBack * 3600);
+  const since = now - hoursBack * 3600;
   const daoAddress = DAO_ADDRESSES.token.toLowerCase();
 
-  const events: FeedEvent[] = [];
-
   try {
-    // Fetch all data in parallel
-    // Try with time filter first, then without if empty
-    const [proposalsData, votesData, bidsData, auctionsData, tokensData] = await Promise.all([
-      subgraphQuery<{ proposals: SubgraphProposal[] }>(PROPOSALS_QUERY, {
-        daoAddress,
-        since: since.toString(),
-      }).catch((e) => {
-        console.error("[feed-events] Proposals query error:", e);
-        return { proposals: [] };
-      }),
+    const data = await subgraphQuery<{ feedEvents: SubgraphFeedEvent[] }>(FEED_EVENTS_QUERY, {
+      first: DEFAULT_FETCH_LIMIT,
+      where: {
+        dao: daoAddress,
+        timestamp_gt: since.toString(),
+      },
+    });
 
-      subgraphQuery<{ proposalVotes: SubgraphVote[] }>(VOTES_QUERY, {
-        daoAddress,
-        since: since.toString(),
-      }).catch((e) => {
-        console.error("[feed-events] Votes query error:", e);
-        return { proposalVotes: [] };
-      }),
-
-      subgraphQuery<{ auctionBids: SubgraphBid[] }>(BIDS_QUERY, {
-        daoAddress,
-        since: since.toString(),
-      }).catch((e) => {
-        console.error("[feed-events] Bids query error:", e);
-        return { auctionBids: [] };
-      }),
-
-      subgraphQuery<{ auctions: SubgraphAuction[] }>(AUCTIONS_QUERY, {
-        daoAddress,
-        since: since.toString(),
-      }).catch((e) => {
-        console.error("[feed-events] Auctions query error:", e);
-        return { auctions: [] };
-      }),
-
-      subgraphQuery<{ tokens: SubgraphToken[] }>(TOKENS_QUERY, {
-        daoAddress,
-        since: since.toString(),
-      }).catch((e) => {
-        console.error("[feed-events] Tokens query error:", e);
-        return { tokens: [] };
-      }),
-    ]);
-
-    // If no data with time filter, try without it (get ALL recent data)
-    if (!proposalsData.proposals?.length && 
-        !votesData.proposalVotes?.length && 
-        !bidsData.auctionBids?.length) {
-      const allDataQuery = `
-        query GetAllRecentData($daoAddress: String!) {
-          proposals(
-            where: { dao: $daoAddress }
-            orderBy: timeCreated
-            orderDirection: desc
-            first: 50
-          ) {
-            id
-            proposalId
-            proposalNumber
-            title
-            description
-            proposer
-            timeCreated
-            voteStart
-            voteEnd
-            quorumVotes
-            executed
-            canceled
-            vetoed
-            queued
-            snapshotBlockNumber
-            transactionHash
-          }
-          proposalVotes(
-            where: { proposal_: { dao: $daoAddress } }
-            orderBy: timestamp
-            orderDirection: desc
-            first: 100
-          ) {
-            id
-            voter
-            support
-            weight
-            reason
-            timestamp
-            transactionHash
-            proposal {
-              proposalNumber
-              title
-            }
-          }
-        }
-      `;
-      
-      const allData = await subgraphQuery<{
-        proposals: SubgraphProposal[];
-        proposalVotes: SubgraphVote[];
-      }>(allDataQuery, {
-        daoAddress,
-      }).catch((e) => {
-        console.error("[feed-events] All data query error:", e);
-        return { proposals: [], proposalVotes: [] };
-      });
-      
-      if (allData.proposals) proposalsData.proposals = allData.proposals;
-      if (allData.proposalVotes) votesData.proposalVotes = allData.proposalVotes;
-    }
-
-    // Transform proposals
-    if (proposalsData.proposals && proposalsData.proposals.length > 0) {
-      events.push(...proposalsData.proposals.map(transformProposalToEvent));
-
-      // Add status events for executed/canceled/vetoed proposals
-      for (const p of proposalsData.proposals) {
-        if (p.executed) {
-          events.push({
-            id: `proposal-executed-${p.proposalId}`,
-            type: "ProposalExecuted",
-            category: "governance",
-            priority: "HIGH",
-            timestamp: Number(p.timeCreated), // Approximation
-            blockNumber: Number(p.snapshotBlockNumber),
-            transactionHash: p.transactionHash,
-            proposalId: p.proposalId,
-            proposalNumber: p.proposalNumber,
-            proposalTitle: p.title || `Proposal #${p.proposalNumber}`,
-          });
-        }
-
-        if (p.queued) {
-          events.push({
-            id: `proposal-queued-${p.proposalId}`,
-            type: "ProposalQueued",
-            category: "governance",
-            priority: "HIGH",
-            timestamp: Number(p.timeCreated),
-            blockNumber: Number(p.snapshotBlockNumber),
-            transactionHash: p.transactionHash,
-            proposalId: p.proposalId,
-            proposalNumber: p.proposalNumber,
-            proposalTitle: p.title || `Proposal #${p.proposalNumber}`,
-            eta: Number(p.voteEnd) + 86400, // Approximation
-          });
-        }
-
-        if (p.canceled) {
-          events.push({
-            id: `proposal-canceled-${p.proposalId}`,
-            type: "ProposalCanceled",
-            category: "governance",
-            priority: "MEDIUM",
-            timestamp: Number(p.timeCreated),
-            blockNumber: Number(p.snapshotBlockNumber),
-            transactionHash: p.transactionHash,
-            proposalId: p.proposalId,
-            proposalNumber: p.proposalNumber,
-            proposalTitle: p.title || `Proposal #${p.proposalNumber}`,
-          });
-        }
-
-        if (p.vetoed) {
-          events.push({
-            id: `proposal-vetoed-${p.proposalId}`,
-            type: "ProposalVetoed",
-            category: "governance",
-            priority: "HIGH",
-            timestamp: Number(p.timeCreated),
-            blockNumber: Number(p.snapshotBlockNumber),
-            transactionHash: p.transactionHash,
-            proposalId: p.proposalId,
-            proposalNumber: p.proposalNumber,
-            proposalTitle: p.title || `Proposal #${p.proposalNumber}`,
-          });
-        }
-      }
-    }
-
-    // Transform votes
-    if (votesData.proposalVotes) {
-      events.push(...votesData.proposalVotes.map(transformVoteToEvent));
-    }
-
-    // Transform bids
-    if (bidsData.auctionBids) {
-      events.push(...bidsData.auctionBids.map(transformBidToEvent));
-    }
-
-    // Transform auctions
-    if (auctionsData.auctions) {
-      const auctionEvents = auctionsData.auctions
-        .map(transformAuctionToEvent)
-        .filter((e): e is FeedEvent => e !== null);
-      events.push(...auctionEvents);
-    }
-
-    // Transform tokens (filter out TokenMinted events)
-    if (tokensData.tokens) {
-      const tokenEvents = tokensData.tokens.map(transformTokenToEvent);
-      
-      // Filter out all TokenMinted events from the feed
-      // Keep only token transfers and delegation events
-      const filteredTokenEvents = tokenEvents.filter(event => 
-        event.type !== "TokenMinted"
-      );
-      
-      events.push(...filteredTokenEvents);
-    }
-
-    // Sort by timestamp descending
+    const events = (data.feedEvents || []).flatMap(transformEvent);
     return events.sort((a, b) => b.timestamp - a.timestamp);
   } catch (error) {
-    console.error("[feed-events] Error fetching feed events:", error);
-    if (error instanceof Error) {
-      console.error("[feed-events] Error details:", {
-        message: error.message,
-        stack: error.stack,
-      });
-    }
+    console.error("[feed-events] feedEvents query error:", error);
     return [];
   }
 }
 
-/**
- * Fetch feed events with Next.js 15 caching
- * 
- * Uses unstable_cache for automatic revalidation on Vercel.
- * Cache is tagged for manual revalidation if needed.
- */
 const fetchFeedEvents = unstable_cache(
-  async (hoursBack: number = 24) => {
-    return await fetchFeedEventsUncached(hoursBack);
-  },
+  async (hoursBack: number = 24) => fetchFeedEventsUncached(hoursBack),
   ["feed-events"],
   {
     revalidate: CACHE_TTL,
     tags: [CACHE_TAG],
-  }
+  },
 );
 
 /**
- * Generate computed/time-based events
- * 
- * These events are derived from current data and time, not blockchain events.
+ * Derived time-based events (VotingOpened, VotingClosingSoon). Kept
+ * separate from the subgraph feedEvents query because these are computed
+ * against current wall-clock time, not emitted onchain events.
  */
 async function generateComputedEvents(): Promise<FeedEvent[]> {
   const events: FeedEvent[] = [];
   const now = Math.floor(Date.now() / 1000);
 
   try {
-    // Get recent proposals to check their timing
     const sdk = SubgraphSDK.connect(CHAIN.id);
     const { proposals } = await sdk.proposals({
       where: {
@@ -633,7 +481,6 @@ async function generateComputedEvents(): Promise<FeedEvent[]> {
       const voteStart = Number(p.voteStart || 0);
       const voteEnd = Number(p.voteEnd || 0);
 
-      // Voting opened (within last hour)
       if (voteStart <= now && voteStart > now - 3600) {
         events.push({
           id: `voting-open-${p.proposalId}`,
@@ -650,7 +497,6 @@ async function generateComputedEvents(): Promise<FeedEvent[]> {
         });
       }
 
-      // Voting closing soon (within next 6 hours)
       const hoursUntilEnd = (voteEnd - now) / 3600;
       if (hoursUntilEnd > 0 && hoursUntilEnd <= 6) {
         events.push({
@@ -670,22 +516,17 @@ async function generateComputedEvents(): Promise<FeedEvent[]> {
       }
     }
   } catch (error) {
-    console.error("Error generating computed events:", error);
+    console.error("[feed-events] Error generating computed events:", error);
   }
 
   return events;
 }
 
-/**
- * Get all feed events (cached blockchain + computed)
- */
 export async function getAllFeedEvents(hoursBack: number = 24): Promise<FeedEvent[]> {
   const [blockchainEvents, computedEvents] = await Promise.all([
     fetchFeedEvents(hoursBack),
     generateComputedEvents(),
   ]);
 
-  return [...blockchainEvents, ...computedEvents]
-    .sort((a, b) => b.timestamp - a.timestamp);
+  return [...blockchainEvents, ...computedEvents].sort((a, b) => b.timestamp - a.timestamp);
 }
-

--- a/src/services/members.ts
+++ b/src/services/members.ts
@@ -557,14 +557,21 @@ export async function fetchDelegatorsWithCounts(address: string): Promise<Delega
   return results;
 }
 
-type VotesCountBatchQuery = {
+type VoterActivityBatchQuery = {
   proposalVotes: Array<{
     voter: string;
+    support: "FOR" | "AGAINST" | "ABSTAIN";
+    proposal: { canceled: boolean };
   }>;
 };
 
-const VOTES_COUNT_BATCH_GQL = /* GraphQL */ `
-  query VotesCountBatch($dao: ID!, $voters: [Bytes!]!, $first: Int!, $skip: Int!) {
+// Merged payload for per-voter aggregation. Selecting `proposal.canceled`
+// alongside `voter` + `support` lets us derive both the raw vote count
+// (includes canceled proposals) and the canceled-excluded support tallies
+// in a single traversal. Prior code issued two near-identical paginated
+// sweeps differing only in the `proposal_: { canceled: false }` filter.
+const VOTER_ACTIVITY_BATCH_GQL = /* GraphQL */ `
+  query VoterActivityBatch($dao: ID!, $voters: [Bytes!]!, $first: Int!, $skip: Int!) {
     proposalVotes(
       where: { proposal_: { dao: $dao }, voter_in: $voters }
       orderBy: timestamp
@@ -573,6 +580,10 @@ const VOTES_COUNT_BATCH_GQL = /* GraphQL */ `
       skip: $skip
     ) {
       voter
+      support
+      proposal {
+        canceled
+      }
     }
   }
 `;
@@ -585,15 +596,26 @@ function chunkArray<T>(arr: T[], size: number): T[][] {
   return chunks;
 }
 
+export type VoterActivity = {
+  /** Total votes cast per voter — includes votes on canceled proposals. */
+  counts: Record<string, number>;
+  /**
+   * Per-voter FOR / total counts restricted to non-canceled proposals.
+   * Matches the prior `fetchVoteSupportForVoters` contract so `likePct`
+   * continues to exclude canceled proposals.
+   */
+  support: Record<string, { total: number; forCount: number }>;
+};
+
 /**
- * Fetch number of proposals voted per voter address (batch, chunked).
+ * Per-voter vote counts + FOR/AGAINST breakdown in one paginated sweep.
+ * Chunks `addresses` into groups of 100 for `voter_in` compatibility.
  */
-export async function fetchVotesCountForVoters(
-  addresses: string[],
-): Promise<Record<string, number>> {
-  if (addresses.length === 0) return {};
+export async function fetchVoterActivity(addresses: string[]): Promise<VoterActivity> {
+  if (addresses.length === 0) return { counts: {}, support: {} };
   const dao = DAO_ADDRESSES.token.toLowerCase();
   const counts: Record<string, number> = {};
+  const support: Record<string, { total: number; forCount: number }> = {};
   const uniqueAddresses = Array.from(new Set(addresses.map((a) => a.toLowerCase())));
   const chunks = chunkArray(uniqueAddresses, 100);
 
@@ -601,7 +623,7 @@ export async function fetchVotesCountForVoters(
     const voters = chunks[i];
     let skip = 0;
     while (true) {
-      const data = await subgraphQuery<VotesCountBatchQuery>(VOTES_COUNT_BATCH_GQL, {
+      const data = await subgraphQuery<VoterActivityBatchQuery>(VOTER_ACTIVITY_BATCH_GQL, {
         dao,
         voters,
         first: 1000,
@@ -611,6 +633,11 @@ export async function fetchVotesCountForVoters(
       for (const v of votes) {
         const key = v.voter.toLowerCase();
         counts[key] = (counts[key] || 0) + 1;
+        if (!v.proposal.canceled) {
+          const entry = (support[key] ||= { total: 0, forCount: 0 });
+          entry.total += 1;
+          if (v.support === "FOR") entry.forCount += 1;
+        }
       }
       if (votes.length < 1000) break;
       skip += 1000;
@@ -619,68 +646,7 @@ export async function fetchVotesCountForVoters(
     if (i < chunks.length - 1) await delay(100);
   }
 
-  return counts;
-}
-
-type VotesSupportBatchQuery = {
-  proposalVotes: Array<{
-    voter: string;
-    support: "FOR" | "AGAINST" | "ABSTAIN";
-  }>;
-};
-
-const VOTES_SUPPORT_BATCH_GQL = /* GraphQL */ `
-  query VotesSupportBatch($dao: ID!, $voters: [Bytes!]!, $first: Int!, $skip: Int!) {
-    proposalVotes(
-      where: { proposal_: { dao: $dao, canceled: false }, voter_in: $voters }
-      orderBy: timestamp
-      orderDirection: desc
-      first: $first
-      skip: $skip
-    ) {
-      voter
-      support
-    }
-  }
-`;
-
-/**
- * Fetch per-voter support counts (FOR vs total) excluding canceled proposals.
- */
-export async function fetchVoteSupportForVoters(
-  addresses: string[],
-): Promise<Record<string, { total: number; forCount: number }>> {
-  if (addresses.length === 0) return {};
-  const dao = DAO_ADDRESSES.token.toLowerCase();
-  const supportMap: Record<string, { total: number; forCount: number }> = {};
-  const uniqueAddresses = Array.from(new Set(addresses.map((a) => a.toLowerCase())));
-  const chunks = chunkArray(uniqueAddresses, 100);
-
-  for (let i = 0; i < chunks.length; i++) {
-    const voters = chunks[i];
-    let skip = 0;
-    while (true) {
-      const data = await subgraphQuery<VotesSupportBatchQuery>(VOTES_SUPPORT_BATCH_GQL, {
-        dao,
-        voters,
-        first: 1000,
-        skip,
-      });
-      const votes = data.proposalVotes || [];
-      for (const v of votes) {
-        const key = v.voter.toLowerCase();
-        const entry = (supportMap[key] ||= { total: 0, forCount: 0 });
-        entry.total += 1;
-        if (v.support === "FOR") entry.forCount += 1;
-      }
-      if (votes.length < 1000) break;
-      skip += 1000;
-    }
-    // Small delay between chunks to avoid rate limits
-    if (i < chunks.length - 1) await delay(100);
-  }
-
-  return supportMap;
+  return { counts, support };
 }
 
 type NonCanceledProposalsQuery = {

--- a/src/services/members.ts
+++ b/src/services/members.ts
@@ -82,45 +82,61 @@ type TokensQuery = {
   }>;
 };
 
-const MEMBER_TOKENS_GQL = /* GraphQL */ `
-  query MemberTokens($dao: ID!, $owner: Bytes!) {
-    tokens(where: { dao: $dao, owner: $owner }, orderBy: tokenId, orderDirection: asc) {
-      tokenId
-      ownerInfo {
-        owner
-        delegate
+// Reusable token fragment so single-owner and joint (EOA + SA)
+// variants render identical row shapes without duplicating field lists.
+const MEMBER_TOKEN_FIELDS = /* GraphQL */ `
+  fragment MemberTokenFields on Token {
+    tokenId
+    ownerInfo {
+      owner
+      delegate
+    }
+    image
+    mintedAt
+    auction {
+      endTime
+      settled
+      highestBid {
+        amount
+        bidder
       }
-      image
-      mintedAt
-      auction {
-        endTime
-        settled
-        highestBid {
-          amount
-          bidder
-        }
-        winningBid {
-          amount
-          bidder
-        }
+      winningBid {
+        amount
+        bidder
       }
     }
   }
 `;
 
-export async function fetchMemberOverview(address: string): Promise<MemberOverview> {
-  const dao = DAO_ADDRESSES.token.toLowerCase();
+const MEMBER_TOKENS_GQL = /* GraphQL */ `
+  query MemberTokens($dao: ID!, $owner: Bytes!) {
+    tokens(where: { dao: $dao, owner: $owner }, orderBy: tokenId, orderDirection: asc) {
+      ...MemberTokenFields
+    }
+  }
+  ${MEMBER_TOKEN_FIELDS}
+`;
 
-  // Fetch tokens held by the member
-  const tokensData = await subgraphQuery<TokensQuery>(MEMBER_TOKENS_GQL, {
-    dao,
-    owner: address.toLowerCase(),
-  });
+// Single-request fetch for a joint profile (EOA + predicted smart
+// account). GraphQL aliases partition the two owners into separate
+// result buckets; the subgraph indexer still executes one query.
+const JOINT_MEMBER_TOKENS_GQL = /* GraphQL */ `
+  query JointMemberTokens($dao: ID!, $eoa: Bytes!, $sa: Bytes!) {
+    eoaTokens: tokens(where: { dao: $dao, owner: $eoa }, orderBy: tokenId, orderDirection: asc) {
+      ...MemberTokenFields
+    }
+    saTokens: tokens(where: { dao: $dao, owner: $sa }, orderBy: tokenId, orderDirection: asc) {
+      ...MemberTokenFields
+    }
+  }
+  ${MEMBER_TOKEN_FIELDS}
+`;
 
-  const tokenIds: number[] = (tokensData.tokens || []).map((t) => Number(t.tokenId));
-  // Derive delegate from the first token's ownerInfo if available; fall back to self
-  const delegate = tokensData.tokens?.[0]?.ownerInfo?.delegate ?? address;
-  const tokens = (tokensData.tokens || []).map((t) => ({
+// Shared row → MemberToken mapper (used by both single-owner and joint flows)
+type MemberTokenRow = TokensQuery["tokens"][number];
+
+function rowToToken(t: MemberTokenRow): MemberToken {
+  return {
     id: Number(t.tokenId),
     imageUrl: t.image ?? undefined,
     mintedAt: t.mintedAt ? Number(t.mintedAt) : undefined,
@@ -128,15 +144,28 @@ export async function fetchMemberOverview(address: string): Promise<MemberOvervi
     settled: t.auction?.settled ?? undefined,
     finalBidWei: t.auction?.winningBid?.amount ?? t.auction?.highestBid?.amount ?? undefined,
     winner: t.auction?.winningBid?.bidder ?? undefined,
-  }));
+  };
+}
 
+function buildOverview(address: string, rows: MemberTokenRow[]): MemberOverview {
+  const tokenIds = rows.map((t) => Number(t.tokenId));
+  const delegate = rows[0]?.ownerInfo?.delegate ?? address;
   return {
     address,
     delegate,
     tokensHeld: tokenIds,
     tokenCount: tokenIds.length,
-    tokens,
+    tokens: rows.map(rowToToken),
   };
+}
+
+export async function fetchMemberOverview(address: string): Promise<MemberOverview> {
+  const dao = DAO_ADDRESSES.token.toLowerCase();
+  const tokensData = await subgraphQuery<TokensQuery>(MEMBER_TOKENS_GQL, {
+    dao,
+    owner: address.toLowerCase(),
+  });
+  return buildOverview(address, tokensData.tokens || []);
 }
 
 /**
@@ -186,16 +215,35 @@ export async function fetchJointMemberOverview(address: string): Promise<MemberO
     return fetchMemberOverview(address);
   }
 
-  const [eoaOverview, saOverview] = await Promise.allSettled([
-    fetchMemberOverview(address),
-    fetchMemberOverview(predictedSa),
-  ]);
-
-  if (eoaOverview.status === "rejected") {
-    throw eoaOverview.reason;
+  // Single-request joint fetch — GraphQL aliases collapse EOA + SA into
+  // one round trip. If it fails we fall back to two sequential overviews
+  // so a subgraph hiccup still returns the EOA side.
+  let eoa: MemberOverview;
+  let sa: MemberOverview | null;
+  const dao = DAO_ADDRESSES.token.toLowerCase();
+  try {
+    const joint = await subgraphQuery<{
+      eoaTokens: MemberTokenRow[];
+      saTokens: MemberTokenRow[];
+    }>(JOINT_MEMBER_TOKENS_GQL, {
+      dao,
+      eoa: address.toLowerCase(),
+      sa: predictedSa.toLowerCase(),
+    });
+    eoa = buildOverview(address, joint.eoaTokens || []);
+    sa = buildOverview(predictedSa, joint.saTokens || []);
+  } catch (err) {
+    console.warn("[members] joint tokens query failed, falling back", err);
+    const [eoaOverview, saOverview] = await Promise.allSettled([
+      fetchMemberOverview(address),
+      fetchMemberOverview(predictedSa),
+    ]);
+    if (eoaOverview.status === "rejected") {
+      throw eoaOverview.reason;
+    }
+    eoa = eoaOverview.value;
+    sa = saOverview.status === "fulfilled" ? saOverview.value : null;
   }
-  const eoa = eoaOverview.value;
-  const sa = saOverview.status === "fulfilled" ? saOverview.value : null;
 
   if (!sa || sa.tokenCount === 0) {
     return {
@@ -737,23 +785,17 @@ const VOTERS_BY_ADDRESSES_GQL = /* GraphQL */ `
  * Fetch active members: voters who voted in at least `threshold` of the last `windowSize` non-canceled proposals.
  * Returns enriched list with address, votingPower (including delegated votes), and votesInWindow.
  */
-export async function fetchActiveMembers(
-  windowSize = 10,
-  threshold = 5,
-): Promise<ActiveMember[]> {
+export async function fetchActiveMembers(windowSize = 10, threshold = 5): Promise<ActiveMember[]> {
   const dao = DAO_ADDRESSES.token.toLowerCase();
 
   // Step 1: Fetch last N non-canceled proposals
-  const proposalsData = await subgraphQuery<NonCanceledProposalsQuery>(
-    NON_CANCELED_PROPOSALS_GQL,
-    {
-      dao,
-      first: windowSize,
-      skip: 0,
-    },
-  );
+  const proposalsData = await subgraphQuery<NonCanceledProposalsQuery>(NON_CANCELED_PROPOSALS_GQL, {
+    dao,
+    first: windowSize,
+    skip: 0,
+  });
   const proposals = proposalsData.proposals || [];
-  
+
   if (proposals.length === 0) {
     return [];
   }
@@ -777,7 +819,7 @@ export async function fetchActiveMembers(
     for (const vote of votes) {
       const voter = vote.voter.toLowerCase();
       const proposalId = vote.proposal.id;
-      
+
       if (!voterProposalMap.has(voter)) {
         voterProposalMap.set(voter, new Set());
       }

--- a/src/services/proposals.ts
+++ b/src/services/proposals.ts
@@ -1,7 +1,7 @@
 import { cache } from "react";
 import {
-  SubgraphSDK,
   governorAbi,
+  SubgraphSDK,
   type Proposal_Filter,
   type Proposal as SdkProposal,
 } from "@buildeross/sdk";
@@ -23,7 +23,9 @@ async function withRetry<T>(fn: () => Promise<T>, label: string, maxAttempts = 5
       const isTransient = isRateLimit || /fetch failed|ETIMEDOUT|ECONNRESET|503|502/i.test(msg);
       if (!isTransient || attempt === maxAttempts) throw err;
       const delay = Math.min(8_000, 500 * 2 ** (attempt - 1)) + Math.random() * 250;
-      console.warn(`[${label}] attempt ${attempt} failed (${isRateLimit ? "429" : "transient"}); retry in ${Math.round(delay)}ms`);
+      console.warn(
+        `[${label}] attempt ${attempt} failed (${isRateLimit ? "429" : "transient"}); retry in ${Math.round(delay)}ms`,
+      );
       await new Promise((r) => setTimeout(r, delay));
     }
   }
@@ -31,9 +33,7 @@ async function withRetry<T>(fn: () => Promise<T>, label: string, maxAttempts = 5
 }
 
 /** Fetch vote timestamps from subgraph (the SDK fragment omits this field) */
-async function fetchVoteTimestamps(
-  proposalId: string,
-): Promise<Record<string, number>> {
+async function fetchVoteTimestamps(proposalId: string): Promise<Record<string, number>> {
   const query = `{
     proposalVotes(
       where: { proposal: "${proposalId.toLowerCase()}" }
@@ -71,10 +71,7 @@ async function fetchVoteTimestamps(
  * Fetch proposal state from the governor contract using our resilient RPC client.
  * Replaces the SDK's internal client which only uses mainnet.base.org.
  */
-async function fetchProposalState(
-  governorAddress: string,
-  proposalId: string,
-): Promise<number> {
+async function fetchProposalState(governorAddress: string, proposalId: string): Promise<number> {
   return serverPublicClient.readContract({
     address: governorAddress as `0x${string}`,
     abi: governorAbi,
@@ -173,9 +170,7 @@ export const listProposals = cache(async (limit = 200, page = 0): Promise<Propos
 
   const sdkProposals = data.proposals ?? [];
 
-  return Promise.all(
-    sdkProposals.map((raw) => formatWithState(raw).then(transformProposal)),
-  );
+  return Promise.all(sdkProposals.map((raw) => formatWithState(raw).then(transformProposal)));
 });
 
 export const getProposalByIdOrNumber = cache(
@@ -189,6 +184,16 @@ export const getProposalByIdOrNumber = cache(
           dao: DAO_ADDRESSES.token.toLowerCase(),
         };
 
+    // When we already have the canonical proposalId (hex path) we can
+    // fetch vote timestamps in parallel with the SDK proposal query,
+    // saving one round trip. For number-based lookups we do not know the
+    // id upfront so the timestamps query runs alongside formatWithState's
+    // RPC state() read instead — same parallel-waterfall trick, one
+    // level deeper.
+    const timestampsPromise = isHexId
+      ? fetchVoteTimestamps(idOrNumber)
+      : Promise.resolve<Record<string, number> | null>(null);
+
     const data = await withRetry(
       () => SubgraphSDK.connect(CHAIN.id).proposals({ where, first: 1 }),
       `getProposalByIdOrNumber(${idOrNumber})`,
@@ -200,15 +205,19 @@ export const getProposalByIdOrNumber = cache(
 
     // RPC errors will propagate (not swallowed) so callers can distinguish
     // "not found" (null) from "transient failure" (thrown error)
-    const sdkProposal = await formatWithState(data.proposals[0]);
+    const rawProposal = data.proposals[0];
+    const [sdkProposal, timestampMapResolved] = await Promise.all([
+      formatWithState(rawProposal),
+      timestampsPromise.then((m) => m ?? fetchVoteTimestamps(String(rawProposal.proposalId ?? ""))),
+    ]);
+
     const proposal = transformProposal(sdkProposal);
 
-    if (proposal.votes && proposal.votes.length > 0) {
-      const timestampMap = await fetchVoteTimestamps(proposal.proposalId);
+    if (proposal.votes && proposal.votes.length > 0 && timestampMapResolved) {
       proposal.votes = proposal.votes
         .map((v) => ({
           ...v,
-          timestamp: timestampMap[v.voter.toLowerCase()] ?? v.timestamp,
+          timestamp: timestampMapResolved[v.voter.toLowerCase()] ?? v.timestamp,
         }))
         .sort((a, b) => (b.timestamp ?? 0) - (a.timestamp ?? 0));
     }


### PR DESCRIPTION
## Summary
Phase-1 subgraph query optimizations across `services/*` and `api/*`. Six commits, each regression-safe in isolation; same public API, same output shapes throughout. Mirrors the [BuilderOSS/nouns-builder](https://github.com/BuilderOSS/nouns-builder) patterns where applicable.

## Commits

| # | Commit | Win |
|---|--------|-----|
| 1 | `perf(feed): collapse 5 subgraph queries into unified feedEvents` | `src/services/feed-events.ts` — single `feedEvents` union query replaces 5-parallel + fallback. 6 round trips → 2. |
| 2 | `perf(api/per-month): query only timeCreated, drop SDK` | `/api/proposals/per-month` used SDK that pulled full proposal (description/calldatas/votes) just to bucket by month. Raw query of `timeCreated` only. |
| 3 | `perf(dao): single dao(id) query backing all three readers` | `fetchDaoStats` + `fetchTotalAuctionSalesWei` each issued a `dao(id)` query; pages calling both paid 2 round trips for the same entity. One `fetchDaoOverview` feeds both. |
| 4 | `perf(proposals): parallelize SDK proposal + vote-timestamps fetch` | `getProposalByIdOrNumber` awaited SDK → formatWithState RPC → fetchVoteTimestamps serially. Timestamps now run concurrently with the SDK call (hex path) or the RPC state read (number path). |
| 5 | `perf(members): joint EOA+SA tokens in one aliased query` | `fetchJointMemberOverview` issued 2 parallel MEMBER_TOKENS queries. GraphQL aliases collapse both into one request; fallback to prior allSettled on query error. |
| 6 | `perf(members): one paginated sweep for voter counts + support` | `fetchVotesCountForVoters` + `fetchVoteSupportForVoters` were near-identical paginated sweeps. Merged into `fetchVoterActivity` selecting `proposal.canceled` to derive both tallies in one pass. Halves `/api/members` subgraph requests on cache miss. |

## Changes
- `src/services/feed-events.ts` (−532 / +373)
- `src/app/api/proposals/per-month/route.ts`
- `src/services/dao.ts`
- `src/services/proposals.ts`
- `src/services/members.ts`
- `src/app/api/members/route.ts`

## Not in this PR (Phase 2)
- Cursor pagination (`timestamp_lt` + `limit+1`) + `useSWRInfinite` on a new `/api/feed` route.
- Scope-aware `unstable_cache` tags (global/chain/DAO/user).
- `ProposalUpdated` / `ClankerTokenCreated` / `ZoraCoinCreated` / `ZoraDropCreated` local `FeedEvent` mappings (currently skipped in `transformEvent`).
- `fetchNonCanceledProposalsCount` reads every proposal id just for `.length` — candidate for a `dao.proposalCount`-style aggregate if schema exposes one.
- `listProposals(1000)` payload trim + shared server endpoint for `use-member-activity` / `MemberDetail`.

## Test plan
- [ ] `pnpm dev` then open `/feed`, `/members`, `/proposals`, `/proposals/[id]`, `/treasury` — verify output unchanged
- [ ] Member page with an external wallet (EOA + SA holdings) renders joint breakdown
- [ ] `/api/members` returns same `votesCount` / `attendancePct` / `likePct` for top 10 owners as before
- [ ] `/api/proposals/per-month?months=12` returns same month buckets and totals
- [ ] `pnpm lint` passes (verified locally)

Generated with [Claude Code](https://claude.com/claude-code)