### PR TITLE
fix(feed): skip zero-amount AuctionSettled events

### DIFF
--- a/src/services/feed-events.ts
+++ b/src/services/feed-events.ts
@@ -403,6 +403,14 @@ function transformEvent(event: SubgraphFeedEvent): FeedEvent[] {
 
     case "AuctionSettledEvent": {
       const e = event as SubgraphAuctionSettled;
+      // Skip no-bid settlements (common on low-activity DAO days).
+      // The subgraph emits `amount: "0"` + zero-address owner when an
+      // auction ends with no bidder; surfacing those as "Auction Won"
+      // cards renders "Unknown won for 0.00e+0 ETH" — noisy and
+      // misleading. Old feed never emitted settled events at all, so
+      // filtering preserves the less-spammy baseline while still
+      // showing real settled auctions with actual winners.
+      if (!e.amount || e.amount === "0") return [];
       return [
         {
           id: `auction-settled-${e.auction.id}`,


### PR DESCRIPTION
## Summary
Regression from [#75](https://github.com/r4topunk/gnars-website/pull/75). The new unified `feedEvents` query emits `AuctionSettledEvent` which the prior 5-query code never surfaced. For no-bid auction settlements the subgraph returns `amount: "0"` + zero-address owner, and the feed renders "Unknown won #N for 0.00e+0 ETH" — looks like spam from another DAO.

Filter those out.

## Confirmed against Goldsky live
- Gnars auctions #7058–#7062 all settled with `amount: "0"`, `owner: 0x0000...0000`
- They are genuinely Gnars events (DAO filter is working); they just shouldn't be surfaced as "Auction Won" cards

## Why not render a "no-bid settled" card?
Old feed never emitted any settled event. Staying silent preserves the baseline; we can add a dedicated `AuctionEndedNoBid` event type later if product wants it surfaced.

## Test plan
- [ ] `/feed` no longer shows "Unknown won for 0.00e+0 ETH" entries
- [ ] Settled auctions with real bids still appear

Generated with [Claude Code](https://claude.com/claude-code)