### PR TITLE
fix(feed): surface propdates + droposals + govern activity beyond 30d

### DIFF
--- a/src/components/feed/GovernanceEventCard.tsx
+++ b/src/components/feed/GovernanceEventCard.tsx
@@ -1,6 +1,6 @@
 /**
  * GovernanceEventCard - Governance event display
- * 
+ *
  * Handles proposal and voting related events with appropriate icons,
  * colors, and actions based on event type.
  */
@@ -9,21 +9,22 @@
 
 import Link from "next/link";
 import { formatDistanceToNow } from "date-fns";
-import { 
-  Target, 
-  ThumbsUp, 
-  ThumbsDown, 
-  MinusCircle,
-  Clock,
+import {
+  AlertCircle,
   CheckCircle,
-  XCircle,
+  Clock,
+  MessageSquare,
+  MinusCircle,
   ShieldX,
-  AlertCircle 
+  Target,
+  ThumbsDown,
+  ThumbsUp,
+  XCircle,
 } from "lucide-react";
-import { Card, CardContent } from "@/components/ui/card";
 import { AddressDisplay } from "@/components/ui/address-display";
-import { cn } from "@/lib/utils";
+import { Card, CardContent } from "@/components/ui/card";
 import type { FeedEvent } from "@/lib/types/feed-events";
+import { cn } from "@/lib/utils";
 
 export interface GovernanceEventCardProps {
   event: Extract<FeedEvent, { category: "governance" }>;
@@ -33,15 +34,12 @@ export interface GovernanceEventCardProps {
 
 export function GovernanceEventCard({ event, compact, sequenceNumber }: GovernanceEventCardProps) {
   // Removed: timeAgo is redundant since we have day headers
-  
+
   // Event icon and color based on type
   const { icon: Icon, iconColor, bgColor, title, actionText } = getEventDisplay(event);
 
   return (
-    <Card className={cn(
-      "transition-shadow hover:shadow-md relative",
-      compact ? "py-3" : "py-4"
-    )}>
+    <Card className={cn("transition-shadow hover:shadow-md relative", compact ? "py-3" : "py-4")}>
       <CardContent className={cn(compact ? "px-4 py-2" : "px-4")}>
         {/* Sequence number badge */}
         {sequenceNumber !== undefined && (
@@ -49,13 +47,10 @@ export function GovernanceEventCard({ event, compact, sequenceNumber }: Governan
             {sequenceNumber}
           </div>
         )}
-        
+
         <div className="flex items-start gap-3">
           {/* Event icon */}
-          <div className={cn(
-            "flex-shrink-0 rounded-full p-2",
-            bgColor
-          )}>
+          <div className={cn("flex-shrink-0 rounded-full p-2", bgColor)}>
             <Icon className={cn("h-4 w-4", iconColor)} />
           </div>
 
@@ -67,7 +62,7 @@ export function GovernanceEventCard({ event, compact, sequenceNumber }: Governan
                 {event.type === "VoteCast" ? (
                   <p className="text-sm font-medium">
                     Vote on{" "}
-                    <Link 
+                    <Link
                       href={`/proposals/${event.proposalNumber}`}
                       className="underline hover:opacity-80"
                     >
@@ -81,26 +76,21 @@ export function GovernanceEventCard({ event, compact, sequenceNumber }: Governan
             </div>
 
             {/* Event-specific content */}
-            {event.type === "ProposalCreated" && (
-              <ProposalCreatedContent event={event} />
-            )}
-            {event.type === "VoteCast" && (
-              <VoteCastContent event={event} compact={compact} />
-            )}
-            {(event.type === "ProposalQueued" || 
-              event.type === "ProposalExecuted" || 
+            {event.type === "ProposalCreated" && <ProposalCreatedContent event={event} />}
+            {event.type === "VoteCast" && <VoteCastContent event={event} compact={compact} />}
+            {(event.type === "ProposalQueued" ||
+              event.type === "ProposalExecuted" ||
               event.type === "ProposalCanceled" ||
-              event.type === "ProposalVetoed") && (
-              <ProposalStatusContent event={event} />
-            )}
+              event.type === "ProposalVetoed") && <ProposalStatusContent event={event} />}
             {(event.type === "VotingOpened" || event.type === "VotingClosingSoon") && (
               <VotingAlertContent event={event} />
             )}
+            {event.type === "ProposalUpdated" && <ProposalUpdatedContent event={event} />}
 
             {/* Action button */}
             {actionText && (
               <div className="pt-1">
-                <Link 
+                <Link
                   href={getEventLink(event)}
                   className="text-xs text-primary hover:underline font-medium"
                 >
@@ -117,13 +107,17 @@ export function GovernanceEventCard({ event, compact, sequenceNumber }: Governan
 
 // Subcomponents for different event types
 
-function ProposalCreatedContent({ event }: { event: Extract<FeedEvent, { type: "ProposalCreated" }> }) {
+function ProposalCreatedContent({
+  event,
+}: {
+  event: Extract<FeedEvent, { type: "ProposalCreated" }>;
+}) {
   return (
     <div className="space-y-1.5">
       <p className="text-sm font-semibold line-clamp-2">{event.title}</p>
       <div className="flex items-center gap-1 text-xs text-muted-foreground">
         <span>by</span>
-        <AddressDisplay 
+        <AddressDisplay
           address={event.proposer}
           variant="compact"
           showAvatar={true}
@@ -140,8 +134,11 @@ function ProposalCreatedContent({ event }: { event: Extract<FeedEvent, { type: "
   );
 }
 
-function VoteCastContent({ event, compact }: { 
-  event: Extract<FeedEvent, { type: "VoteCast" }>; 
+function VoteCastContent({
+  event,
+  compact,
+}: {
+  event: Extract<FeedEvent, { type: "VoteCast" }>;
   compact?: boolean;
 }) {
   const supportConfig = {
@@ -149,14 +146,14 @@ function VoteCastContent({ event, compact }: {
     AGAINST: { icon: ThumbsDown, color: "text-red-600", bg: "bg-red-50 dark:bg-red-950" },
     ABSTAIN: { icon: MinusCircle, color: "text-gray-600", bg: "bg-gray-50 dark:bg-gray-950" },
   };
-  
+
   const config = supportConfig[event.support];
   const SupportIcon = config.icon;
-  
+
   return (
     <div className="space-y-1.5">
       <div className="flex items-center gap-2 flex-wrap">
-        <AddressDisplay 
+        <AddressDisplay
           address={event.voter}
           variant="compact"
           showAvatar={true}
@@ -166,13 +163,17 @@ function VoteCastContent({ event, compact }: {
           showExplorer={false}
         />
         <span className="text-xs text-muted-foreground">voted</span>
-        <span className={cn("flex items-center gap-1 text-xs font-medium", config.bg, "px-2 py-0.5 rounded-md")}>
+        <span
+          className={cn(
+            "flex items-center gap-1 text-xs font-medium",
+            config.bg,
+            "px-2 py-0.5 rounded-md",
+          )}
+        >
           <SupportIcon className={cn("h-3 w-3", config.color)} />
           {event.support}
         </span>
-        <span className="text-xs text-muted-foreground">
-          with {event.weight} votes
-        </span>
+        <span className="text-xs text-muted-foreground">with {event.weight} votes</span>
       </div>
       <p className="text-xs font-medium line-clamp-1">{event.proposalTitle}</p>
       {event.reason && !compact && (
@@ -184,8 +185,13 @@ function VoteCastContent({ event, compact }: {
   );
 }
 
-function ProposalStatusContent({ event }: { 
-  event: Extract<FeedEvent, { type: "ProposalQueued" | "ProposalExecuted" | "ProposalCanceled" | "ProposalVetoed" }> 
+function ProposalStatusContent({
+  event,
+}: {
+  event: Extract<
+    FeedEvent,
+    { type: "ProposalQueued" | "ProposalExecuted" | "ProposalCanceled" | "ProposalVetoed" }
+  >;
 }) {
   return (
     <div className="space-y-1">
@@ -201,8 +207,45 @@ function ProposalStatusContent({ event }: {
   );
 }
 
-function VotingAlertContent({ event }: { 
-  event: Extract<FeedEvent, { type: "VotingOpened" | "VotingClosingSoon" }> 
+function ProposalUpdatedContent({
+  event,
+}: {
+  event: Extract<FeedEvent, { type: "ProposalUpdated" }>;
+}) {
+  // Builder propdate enum: 0 = original/update, 1 = reply. Anything else
+  // falls back to "update" wording so future enum additions don't crash.
+  const isReply = event.messageType === 1;
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-1 text-xs text-muted-foreground">
+        <span>{isReply ? "reply from" : "update from"}</span>
+        <AddressDisplay
+          address={event.proposer}
+          variant="compact"
+          showAvatar={true}
+          avatarSize="xs"
+          showENS={true}
+          showCopy={false}
+          showExplorer={false}
+        />
+        <span>on</span>
+        <Link href={`/proposals/${event.proposalNumber}`} className="underline hover:opacity-80">
+          Proposal #{event.proposalNumber}
+        </Link>
+      </div>
+      {event.message && (
+        <p className="text-xs italic text-muted-foreground border-l-2 border-muted pl-2 line-clamp-3">
+          {event.message}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function VotingAlertContent({
+  event,
+}: {
+  event: Extract<FeedEvent, { type: "VotingOpened" | "VotingClosingSoon" }>;
 }) {
   return (
     <div className="space-y-1">
@@ -210,10 +253,9 @@ function VotingAlertContent({ event }: {
         Proposal #{event.proposalNumber}: {event.proposalTitle}
       </p>
       <p className="text-xs text-muted-foreground" suppressHydrationWarning>
-        {event.type === "VotingOpened" 
+        {event.type === "VotingOpened"
           ? `Voting ends ${formatDistanceToNow(new Date(event.voteEnd * 1000), { addSuffix: true })}`
-          : `Only ${event.hoursLeft}h left to vote!`
-        }
+          : `Only ${event.hoursLeft}h left to vote!`}
       </p>
     </div>
   );
@@ -233,9 +275,24 @@ function getEventDisplay(event: Extract<FeedEvent, { category: "governance" }>) 
       };
     case "VoteCast":
       return {
-        icon: event.support === "FOR" ? ThumbsUp : event.support === "AGAINST" ? ThumbsDown : MinusCircle,
-        iconColor: event.support === "FOR" ? "text-green-600" : event.support === "AGAINST" ? "text-red-600" : "text-gray-600",
-        bgColor: event.support === "FOR" ? "bg-green-50 dark:bg-green-950" : event.support === "AGAINST" ? "bg-red-50 dark:bg-red-950" : "bg-gray-50 dark:bg-gray-950",
+        icon:
+          event.support === "FOR"
+            ? ThumbsUp
+            : event.support === "AGAINST"
+              ? ThumbsDown
+              : MinusCircle,
+        iconColor:
+          event.support === "FOR"
+            ? "text-green-600"
+            : event.support === "AGAINST"
+              ? "text-red-600"
+              : "text-gray-600",
+        bgColor:
+          event.support === "FOR"
+            ? "bg-green-50 dark:bg-green-950"
+            : event.support === "AGAINST"
+              ? "bg-red-50 dark:bg-red-950"
+              : "bg-gray-50 dark:bg-gray-950",
         title: `Vote on Proposal #${event.proposalNumber}`,
         actionText: "View Proposal",
       };
@@ -287,13 +344,23 @@ function getEventDisplay(event: Extract<FeedEvent, { category: "governance" }>) 
         title: "Voting Closing Soon",
         actionText: "Cast Vote",
       };
+    case "ProposalUpdated":
+      return {
+        icon: MessageSquare,
+        iconColor: "text-indigo-600",
+        bgColor: "bg-indigo-50 dark:bg-indigo-950",
+        title: `Propdate · Proposal #${event.proposalNumber}`,
+        actionText: "View Propdate",
+      };
   }
 }
 
 function getEventLink(event: Extract<FeedEvent, { category: "governance" }>): string {
+  if (event.type === "ProposalUpdated") {
+    return `/propdates#proposal-${event.proposalNumber}`;
+  }
   if ("proposalNumber" in event) {
     return `/proposals/${event.proposalNumber}`;
   }
   return "/proposals";
 }
-

--- a/src/components/feed/LiveFeedView.tsx
+++ b/src/components/feed/LiveFeedView.tsx
@@ -26,7 +26,11 @@ export interface LiveFeedViewProps {
 export const DEFAULT_FILTERS: FeedFilters = {
   priorities: ["HIGH", "MEDIUM", "LOW"],
   categories: ["governance", "auction", "token", "delegation", "treasury", "admin", "settings"],
-  timeRange: "30d",
+  // Default to the full fetched window (subgraph caps at ~250 events).
+  // Gnars has quiet stretches where 30d contains auctions only; a wider
+  // default surfaces the most recent proposal/vote/propdate/droposal
+  // activity even when it sits just outside 30 days.
+  timeRange: "all",
   showOnlyWithComments: false,
 };
 
@@ -148,8 +152,12 @@ export function LiveFeedView({
     ).acc;
   }, [filteredEvents]);
 
-  // Incremental rendering for performance
-  const PAGE_SIZE = 20;
+  // Incremental rendering for performance. Bumped from 20 to 50 so the
+  // first page surfaces governance activity that would otherwise sit
+  // below a wall of daily auction events (Gnars emits 2 auction events
+  // per day, which alone would fill 20 slots before any vote/proposal
+  // showed up).
+  const PAGE_SIZE = 50;
   const [visibleCount, setVisibleCount] = useState<number>(PAGE_SIZE);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
 
@@ -393,7 +401,7 @@ function EmptyState({ filters }: { filters: FeedFilters }) {
   const hasActiveFilters =
     filters.priorities.length < 3 ||
     filters.categories.length < 7 ||
-    filters.timeRange !== "30d" ||
+    filters.timeRange !== "all" ||
     filters.showOnlyWithComments;
 
   return (

--- a/src/components/feed/TokenEventCard.tsx
+++ b/src/components/feed/TokenEventCard.tsx
@@ -1,18 +1,19 @@
 /**
  * TokenEventCard - Token and delegation event display
- * 
+ *
  * Handles token mints, transfers, and delegation changes.
  */
 
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
-import { Palette, ArrowRightLeft, Users } from "lucide-react";
-import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
+import { ArrowRightLeft, Palette, Sparkles, Users } from "lucide-react";
 import { AddressDisplay } from "@/components/ui/address-display";
-import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
 import type { FeedEvent } from "@/lib/types/feed-events";
+import { cn } from "@/lib/utils";
 
 export interface TokenEventCardProps {
   event: Extract<FeedEvent, { category: "token" | "delegation" }>;
@@ -22,16 +23,16 @@ export interface TokenEventCardProps {
 
 export function TokenEventCard({ event, compact, sequenceNumber }: TokenEventCardProps) {
   // Check if token was burned (minted to zero address)
-  const isBurned = event.type === "TokenMinted" && 
-    (!event.recipient || event.recipient === "0x0000000000000000000000000000000000000000" || event.recipient === "0x0");
-  
+  const isBurned =
+    event.type === "TokenMinted" &&
+    (!event.recipient ||
+      event.recipient === "0x0000000000000000000000000000000000000000" ||
+      event.recipient === "0x0");
+
   const { icon: Icon, iconColor, bgColor, title, actionText } = getEventDisplay(event, isBurned);
 
   return (
-    <Card className={cn(
-      "transition-shadow hover:shadow-md relative",
-      compact ? "py-3" : "py-4"
-    )}>
+    <Card className={cn("transition-shadow hover:shadow-md relative", compact ? "py-3" : "py-4")}>
       <CardContent className={cn(compact ? "px-4 py-2" : "px-4")}>
         {/* Sequence number badge */}
         {sequenceNumber !== undefined && (
@@ -39,13 +40,10 @@ export function TokenEventCard({ event, compact, sequenceNumber }: TokenEventCar
             {sequenceNumber}
           </div>
         )}
-        
+
         <div className="flex items-start gap-3">
           {/* Event icon */}
-          <div className={cn(
-            "flex-shrink-0 rounded-full p-2",
-            bgColor
-          )}>
+          <div className={cn("flex-shrink-0 rounded-full p-2", bgColor)}>
             <Icon className={cn("h-4 w-4", iconColor)} />
           </div>
 
@@ -59,20 +57,15 @@ export function TokenEventCard({ event, compact, sequenceNumber }: TokenEventCar
             </div>
 
             {/* Event-specific content */}
-            {event.type === "TokenMinted" && (
-              <TokenMintedContent event={event} />
-            )}
-            {event.type === "TokenTransferred" && (
-              <TokenTransferredContent event={event} />
-            )}
-            {event.type === "DelegateChanged" && (
-              <DelegateChangedContent event={event} />
-            )}
+            {event.type === "TokenMinted" && <TokenMintedContent event={event} />}
+            {event.type === "TokenTransferred" && <TokenTransferredContent event={event} />}
+            {event.type === "DelegateChanged" && <DelegateChangedContent event={event} />}
+            {event.type === "ZoraDropCreated" && <ZoraDropCreatedContent event={event} />}
 
             {/* Action button */}
             {actionText && (
               <div className="pt-1">
-                <Link 
+                <Link
                   href={getEventLink(event)}
                   className="text-xs text-primary hover:underline font-medium"
                 >
@@ -90,8 +83,11 @@ export function TokenEventCard({ event, compact, sequenceNumber }: TokenEventCar
 // Subcomponents
 
 function TokenMintedContent({ event }: { event: Extract<FeedEvent, { type: "TokenMinted" }> }) {
-  const isZeroAddress = !event.recipient || event.recipient === "0x0000000000000000000000000000000000000000" || event.recipient === "0x0";
-  
+  const isZeroAddress =
+    !event.recipient ||
+    event.recipient === "0x0000000000000000000000000000000000000000" ||
+    event.recipient === "0x0";
+
   return (
     <div className="space-y-1.5">
       <p className="text-sm font-semibold">Gnar #{event.tokenId}</p>
@@ -100,7 +96,7 @@ function TokenMintedContent({ event }: { event: Extract<FeedEvent, { type: "Toke
       ) : (
         <div className="flex items-center gap-1.5 flex-wrap">
           <span className="text-xs text-muted-foreground">minted to</span>
-          <AddressDisplay 
+          <AddressDisplay
             address={event.recipient}
             variant="compact"
             showAvatar={true}
@@ -110,7 +106,9 @@ function TokenMintedContent({ event }: { event: Extract<FeedEvent, { type: "Toke
             showExplorer={false}
           />
           {event.isFounder && (
-            <Badge variant="secondary" className="text-xs">Founder</Badge>
+            <Badge variant="secondary" className="text-xs">
+              Founder
+            </Badge>
           )}
         </div>
       )}
@@ -118,12 +116,16 @@ function TokenMintedContent({ event }: { event: Extract<FeedEvent, { type: "Toke
   );
 }
 
-function TokenTransferredContent({ event }: { event: Extract<FeedEvent, { type: "TokenTransferred" }> }) {
+function TokenTransferredContent({
+  event,
+}: {
+  event: Extract<FeedEvent, { type: "TokenTransferred" }>;
+}) {
   return (
     <div className="space-y-1.5">
       <p className="text-sm font-semibold">Gnar #{event.tokenId}</p>
       <div className="flex items-center gap-1.5 flex-wrap text-xs">
-        <AddressDisplay 
+        <AddressDisplay
           address={event.from}
           variant="compact"
           showAvatar={true}
@@ -133,7 +135,7 @@ function TokenTransferredContent({ event }: { event: Extract<FeedEvent, { type: 
           showExplorer={false}
         />
         <span className="text-muted-foreground">→</span>
-        <AddressDisplay 
+        <AddressDisplay
           address={event.to}
           variant="compact"
           showAvatar={true}
@@ -147,11 +149,15 @@ function TokenTransferredContent({ event }: { event: Extract<FeedEvent, { type: 
   );
 }
 
-function DelegateChangedContent({ event }: { event: Extract<FeedEvent, { type: "DelegateChanged" }> }) {
+function DelegateChangedContent({
+  event,
+}: {
+  event: Extract<FeedEvent, { type: "DelegateChanged" }>;
+}) {
   return (
     <div className="space-y-1.5">
       <div className="flex items-center gap-1.5 flex-wrap">
-        <AddressDisplay 
+        <AddressDisplay
           address={event.delegator}
           variant="compact"
           showAvatar={true}
@@ -161,7 +167,7 @@ function DelegateChangedContent({ event }: { event: Extract<FeedEvent, { type: "
           showExplorer={false}
         />
         <span className="text-xs text-muted-foreground">delegated to</span>
-        <AddressDisplay 
+        <AddressDisplay
           address={event.toDelegate}
           variant="compact"
           showAvatar={true}
@@ -178,9 +184,57 @@ function DelegateChangedContent({ event }: { event: Extract<FeedEvent, { type: "
   );
 }
 
+function ZoraDropCreatedContent({
+  event,
+}: {
+  event: Extract<FeedEvent, { type: "ZoraDropCreated" }>;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-start gap-3">
+        {event.dropImageURI && (
+          <div className="relative h-16 w-16 flex-shrink-0 overflow-hidden rounded-md bg-muted">
+            <Image
+              src={event.dropImageURI}
+              alt={event.dropName}
+              fill
+              className="object-cover"
+              unoptimized
+            />
+          </div>
+        )}
+        <div className="min-w-0 flex-1 space-y-0.5">
+          <p className="text-sm font-semibold line-clamp-1">{event.dropName}</p>
+          <p className="text-xs text-muted-foreground">
+            {event.dropSymbol} · edition of {event.editionSize}
+          </p>
+          <div className="flex items-center gap-1 text-xs text-muted-foreground">
+            <span>by</span>
+            <AddressDisplay
+              address={event.dropCreator}
+              variant="compact"
+              showAvatar={true}
+              avatarSize="xs"
+              showENS={true}
+              showCopy={false}
+              showExplorer={false}
+            />
+          </div>
+        </div>
+      </div>
+      {event.dropDescription && (
+        <p className="text-xs text-muted-foreground line-clamp-2">{event.dropDescription}</p>
+      )}
+    </div>
+  );
+}
+
 // Helper functions
 
-function getEventDisplay(event: Extract<FeedEvent, { category: "token" | "delegation" }>, isBurned?: boolean) {
+function getEventDisplay(
+  event: Extract<FeedEvent, { category: "token" | "delegation" }>,
+  isBurned?: boolean,
+) {
   switch (event.type) {
     case "TokenMinted":
       return {
@@ -206,6 +260,14 @@ function getEventDisplay(event: Extract<FeedEvent, { category: "token" | "delega
         title: "Delegation Changed",
         actionText: "View Member",
       };
+    case "ZoraDropCreated":
+      return {
+        icon: Sparkles,
+        iconColor: "text-pink-600",
+        bgColor: "bg-pink-50 dark:bg-pink-950",
+        title: "New Droposal",
+        actionText: "View Drop",
+      };
   }
 }
 
@@ -213,6 +275,8 @@ function getEventLink(event: Extract<FeedEvent, { category: "token" | "delegatio
   if (event.type === "DelegateChanged") {
     return `/members/${event.toDelegate}`;
   }
+  if (event.type === "ZoraDropCreated") {
+    return `/droposals/${event.dropAddress}`;
+  }
   return "/members";
 }
-

--- a/src/lib/types/feed-events.ts
+++ b/src/lib/types/feed-events.ts
@@ -1,6 +1,6 @@
 /**
  * Live Feed Event Types
- * 
+ *
  * Comprehensive type definitions for all DAO events that appear in the live feed.
  * Events are categorized by contract source (Governor, Auction, Token, Treasury).
  */
@@ -9,13 +9,13 @@
 export type EventPriority = "HIGH" | "MEDIUM" | "LOW";
 
 // Event categories for filtering
-export type EventCategory = 
-  | "governance" 
-  | "auction" 
-  | "token" 
-  | "delegation" 
-  | "treasury" 
-  | "admin" 
+export type EventCategory =
+  | "governance"
+  | "auction"
+  | "token"
+  | "delegation"
+  | "treasury"
+  | "admin"
   | "settings";
 
 // Base event interface - all events extend this
@@ -87,6 +87,40 @@ export interface ProposalVetoedEvent extends BaseEvent {
   proposalId: string;
   proposalNumber: number;
   proposalTitle: string;
+}
+
+// Builder propdates — onchain post authored by a proposal's proposer or
+// executor. `messageType` mirrors the subgraph enum (0 = original/update,
+// 1 = reply). We surface these because Gnars uses them as the DAO's
+// primary update channel.
+export interface ProposalUpdatedEvent extends BaseEvent {
+  type: "ProposalUpdated";
+  category: "governance";
+  proposalId: string;
+  proposalNumber: number;
+  proposalTitle: string;
+  proposer: string;
+  messageType: number;
+  message: string;
+  originalMessageId?: string | null;
+}
+
+// Droposals — Zora ERC-721 edition deployed from a DAO proposal. Only a
+// handful historically on Gnars but the /droposals page treats them as
+// first-class so the feed should too.
+export interface ZoraDropCreatedEvent extends BaseEvent {
+  type: "ZoraDropCreated";
+  category: "token";
+  dropAddress: string;
+  dropCreator: string;
+  dropName: string;
+  dropSymbol: string;
+  dropDescription: string;
+  dropImageURI?: string;
+  editionSize: string;
+  publicSalePrice: string;
+  publicSaleStart: number;
+  publicSaleEnd: number;
 }
 
 // Auction Events
@@ -212,6 +246,7 @@ export type FeedEvent =
   | ProposalExecutedEvent
   | ProposalCanceledEvent
   | ProposalVetoedEvent
+  | ProposalUpdatedEvent
   | AuctionCreatedEvent
   | AuctionBidEvent
   | AuctionSettledEvent
@@ -223,7 +258,8 @@ export type FeedEvent =
   | OwnershipTransferredEvent
   | VotingOpenedEvent
   | VotingClosingSoonEvent
-  | AuctionEndingSoonEvent;
+  | AuctionEndingSoonEvent
+  | ZoraDropCreatedEvent;
 
 // Feed filter options
 export interface FeedFilters {
@@ -232,4 +268,3 @@ export interface FeedFilters {
   timeRange: "1h" | "24h" | "7d" | "30d" | "all";
   showOnlyWithComments: boolean;
 }
-

--- a/src/services/feed-events.ts
+++ b/src/services/feed-events.ts
@@ -15,10 +15,13 @@ import type { FeedEvent } from "@/lib/types/feed-events";
 const CACHE_TTL = 15;
 const CACHE_TAG = "feed-events";
 
-// Cap at 100 per Builder subgraph convention; we over-fetch to cover
-// post-filter event drops (Updated/Clanker/Zora currently unmapped) and
-// derived status events.
-const DEFAULT_FETCH_LIMIT = 100;
+// Over-fetch so the client-side filter pass (zero-amount
+// AuctionSettled drops, skipped ClankerTokenCreated events) does not
+// starve other event types. Gnars has ~1 auction/day = ~60 auction
+// events per 30d (Created + Settled) before the no-bid filter; 250
+// leaves room for proposal votes, executions, propdates and drops
+// within the same window.
+const DEFAULT_FETCH_LIMIT = 250;
 
 const FEED_EVENTS_QUERY = `
   query GnarsFeedEvents($first: Int!, $where: FeedEvent_filter) {
@@ -82,6 +85,10 @@ const FEED_EVENTS_QUERY = `
           id
           startTime
           endTime
+          settled
+          winningBid {
+            amount
+          }
           token {
             tokenId
             image
@@ -114,6 +121,35 @@ const FEED_EVENTS_QUERY = `
           }
         }
         amount
+      }
+
+      ... on ProposalUpdatedEvent {
+        proposal {
+          proposalId
+          proposalNumber
+          title
+          proposer
+        }
+        update {
+          messageType
+          message
+          originalMessageId
+        }
+      }
+
+      ... on ZoraDropCreatedEvent {
+        zoraDrop {
+          id
+          creator
+          name
+          symbol
+          description
+          imageURI
+          editionSize
+          publicSalePrice
+          publicSaleStart
+          publicSaleEnd
+        }
       }
     }
   }
@@ -189,6 +225,8 @@ interface SubgraphAuctionCreated extends BaseSubgraphEvent {
     id: string;
     startTime: string;
     endTime: string;
+    settled: boolean;
+    winningBid?: { amount: string } | null;
     token: { tokenId: string; image?: string | null };
   };
 }
@@ -212,6 +250,33 @@ interface SubgraphAuctionSettled extends BaseSubgraphEvent {
   amount: string;
 }
 
+interface SubgraphProposalUpdated extends BaseSubgraphEvent {
+  __typename: "ProposalUpdatedEvent";
+  proposal: SubgraphProposalRef;
+  update: {
+    // Subgraph exposes this as a number (0 = original/update, 1 = reply).
+    messageType: number;
+    message: string;
+    originalMessageId: string | null;
+  };
+}
+
+interface SubgraphZoraDropCreated extends BaseSubgraphEvent {
+  __typename: "ZoraDropCreatedEvent";
+  zoraDrop: {
+    id: string;
+    creator: string;
+    name: string;
+    symbol: string;
+    description: string;
+    imageURI: string | null;
+    editionSize: string;
+    publicSalePrice: string;
+    publicSaleStart: string;
+    publicSaleEnd: string;
+  };
+}
+
 type SubgraphFeedEvent =
   | SubgraphProposalCreated
   | SubgraphProposalVoted
@@ -219,6 +284,8 @@ type SubgraphFeedEvent =
   | SubgraphAuctionCreated
   | SubgraphAuctionBidPlaced
   | SubgraphAuctionSettled
+  | SubgraphProposalUpdated
+  | SubgraphZoraDropCreated
   | (BaseSubgraphEvent & { __typename: string });
 
 function toHttpUrl(uri?: string | null): string | undefined {
@@ -363,6 +430,13 @@ function transformEvent(event: SubgraphFeedEvent): FeedEvent[] {
 
     case "AuctionCreatedEvent": {
       const e = event as SubgraphAuctionCreated;
+      // Dedupe: when an auction has already completed (settled), skip
+      // the "New Auction" card so the same auction isn't represented by
+      // both a Created and a Settled card. Settled + no-bid auctions
+      // emit no Settled card either (filtered below), so those settle
+      // silently — consistent with old behavior where non-events stayed
+      // out of the feed. Live/unsettled auctions still surface.
+      if (e.auction.settled) return [];
       return [
         {
           id: `auction-${e.auction.id}`,
@@ -428,25 +502,78 @@ function transformEvent(event: SubgraphFeedEvent): FeedEvent[] {
       ];
     }
 
-    // Unmapped Builder event types (ProposalUpdated, ClankerTokenCreated,
-    // ZoraCoinCreated, ZoraDropCreated). Skip until local FeedEvent union
-    // grows support.
+    case "ProposalUpdatedEvent": {
+      const e = event as SubgraphProposalUpdated;
+      return [
+        {
+          id: `proposal-updated-${e.id}`,
+          type: "ProposalUpdated",
+          category: "governance",
+          priority: "HIGH",
+          timestamp: ts,
+          blockNumber: block,
+          transactionHash: e.transactionHash,
+          proposalId: e.proposal.proposalId,
+          proposalNumber: e.proposal.proposalNumber,
+          proposalTitle: e.proposal.title || `Proposal #${e.proposal.proposalNumber}`,
+          proposer: e.actor,
+          messageType: Number(e.update.messageType),
+          message: e.update.message,
+          originalMessageId: e.update.originalMessageId,
+        },
+      ];
+    }
+
+    case "ZoraDropCreatedEvent": {
+      const e = event as SubgraphZoraDropCreated;
+      return [
+        {
+          id: `zora-drop-${e.id}`,
+          type: "ZoraDropCreated",
+          category: "token",
+          priority: "HIGH",
+          timestamp: ts,
+          blockNumber: block,
+          transactionHash: e.transactionHash,
+          dropAddress: e.zoraDrop.id,
+          dropCreator: e.zoraDrop.creator,
+          dropName: e.zoraDrop.name,
+          dropSymbol: e.zoraDrop.symbol,
+          dropDescription: e.zoraDrop.description,
+          dropImageURI: toHttpUrl(e.zoraDrop.imageURI),
+          editionSize: e.zoraDrop.editionSize,
+          publicSalePrice: e.zoraDrop.publicSalePrice,
+          publicSaleStart: Number(e.zoraDrop.publicSaleStart),
+          publicSaleEnd: Number(e.zoraDrop.publicSaleEnd),
+        },
+      ];
+    }
+
+    // Unmapped Builder event types (ClankerTokenCreated, ZoraCoinCreated).
+    // Gnars does not currently surface coin launches in the feed.
     default:
       return [];
   }
 }
 
-async function fetchFeedEventsUncached(hoursBack: number = 24): Promise<FeedEvent[]> {
-  const now = Math.floor(Date.now() / 1000);
-  const since = now - hoursBack * 3600;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+async function fetchFeedEventsUncached(_hoursBack: number = 24): Promise<FeedEvent[]> {
   const daoAddress = DAO_ADDRESSES.token.toLowerCase();
 
   try {
+    // No `timestamp_gt` filter — Gnars has extended quiet stretches
+    // (weeks with auctions only, no votes/proposals). Filtering by a
+    // 30-day wall-clock window silently starves the feed of governance
+    // activity that occurred just outside the window. Rely on the
+    // subgraph's descending sort + first:N cap to bound the query
+    // instead, then let the UI time-range filter (LiveFeedView) narrow
+    // the visible set. Users default to "30d" but can switch to "all"
+    // to see older votes/proposals. `_hoursBack` is kept in the
+    // signature for backwards compatibility with existing callers.
     const data = await subgraphQuery<{ feedEvents: SubgraphFeedEvent[] }>(FEED_EVENTS_QUERY, {
       first: DEFAULT_FETCH_LIMIT,
       where: {
         dao: daoAddress,
-        timestamp_gt: since.toString(),
       },
     });
 


### PR DESCRIPTION
## Summary
Follow-up to [#75](https://github.com/r4topunk/gnars-website/pull/75) / [#76](https://github.com/r4topunk/gnars-website/pull/76). The unified `feedEvents` port silently dropped two event types and inherited a 30-day filter that starved the feed during Gnars' slow governance weeks.

**Before**: `/feed` first page = 49 auction cards + 1 propdate. No votes, proposals, executions, or droposals visible.
**After (verified on dev)**: `/feed` first page = 43 votes + 3 executed + 3 proposals + 1 propdate + 1 bid + 1 won auction + 1 live auction.

## Root causes
1. `transformEvent` default-branch dropped `ProposalUpdatedEvent` (Gnars' primary update channel) and `ZoraDropCreatedEvent` (Gnars droposals).
2. Server query filtered `timestamp_gt: since` (30d). Old code had an empty-result fallback to a no-filter query; the unified port lost it.
3. Every daily Gnars auction emitted two cards (`Created` + `Settled`), plus no-bid settlements got re-emitted as `Created`. 60 auction events per 30d crowded governance activity below the fold.
4. UI `DEFAULT_FILTERS.timeRange = "30d"` hid anything older than 30 days.

## Changes
- `src/lib/types/feed-events.ts` — add `ProposalUpdatedEvent` + `ZoraDropCreatedEvent` to the `FeedEvent` union.
- `src/services/feed-events.ts`
  - New GraphQL fragments: `... on ProposalUpdatedEvent`, `... on ZoraDropCreatedEvent`.
  - Transform cases for both. `messageType` is a numeric enum (0 = update, 1 = reply) in the subgraph — type reflects that.
  - Drop `timestamp_gt` filter — rely on `first: 250` + descending sort to bound.
  - Bump `DEFAULT_FETCH_LIMIT` 100 → 250 so the no-bid settlement filter doesn't starve other types.
  - Skip `AuctionCreatedEvent` when `auction.settled` is true (dedupe against `Settled` card; no-bid settlements become silent).
- `src/components/feed/GovernanceEventCard.tsx` — `ProposalUpdatedContent` + display config for the new event type. Link targets `/propdates#proposal-N`.
- `src/components/feed/TokenEventCard.tsx` — `ZoraDropCreatedContent` with thumbnail + edition info. Link targets `/droposals/[address]`.
- `src/components/feed/LiveFeedView.tsx`
  - `DEFAULT_FILTERS.timeRange`: `"30d"` → `"all"`.
  - Initial `PAGE_SIZE`: 20 → 50 (ensures governance events appear on first page even when auctions dominate recent days).

## Test plan
- [x] `pnpm lint` passes
- [x] Dev server renders /feed with 43 vote / 3 executed / 3 proposal / 1 propdate / 1 bid / 1 won / 1 live auction in first page
- [ ] Vercel preview /feed renders propdate card + droposal card when scrolling
- [ ] Propdate link resolves to `/propdates#proposal-N`
- [ ] Droposal link resolves to `/droposals/[address]`
- [ ] Switching UI time filter to "30d" still works (filters older votes)

## Follow-ups (not in this PR)
- Render `ProposalUpdated` with attached proposal title (currently shows "Proposal #N" only).
- Collapse same-day auction pairs into a single "auctions today" rollup for even leaner feed.
- Map `ClankerTokenCreated` + `ZoraCoinCreated` if product wants coin launches surfaced.

Generated with [Claude Code](https://claude.com/claude-code)