### PR TITLE
fix(useVotes): skip getPastVotes when snapshot is still in the future

### DIFF
--- a/src/hooks/useVotes.ts
+++ b/src/hooks/useVotes.ts
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Address } from "viem";
 import { useReadContract, useReadContracts } from "wagmi";
 
@@ -117,7 +118,20 @@ export const useVotes = ({
   });
 
   const effectiveSnapshot = snapshotTimestamp ?? snapshotBlock;
-  const usingSnapshotQuery = Boolean(effectiveSnapshot && !hasSubgraphVoteWeight);
+
+  // OZ Votes.getPastVotes reverts when the queried timepoint is not strictly
+  // in the past (e.g. during the voting-delay window before snapshot elapses).
+  // In that case skip the snapshot path and fall back to getVotes so the UI
+  // can preview the signer's current voting power instead of erroring.
+  // Frozen at mount — if the user sits through the snapshot crossing,
+  // a refresh will pick up the correct path.
+  const [mountTime] = useState<bigint>(() => BigInt(Math.floor(Date.now() / 1000)));
+  const snapshotInFuture = Boolean(
+    snapshotTimestamp !== undefined && snapshotTimestamp > mountTime,
+  );
+  const usingSnapshotQuery = Boolean(
+    effectiveSnapshot && !hasSubgraphVoteWeight && !snapshotInFuture,
+  );
 
   const { data, isLoading: contractsLoading, error } = useReadContracts({
     query: {


### PR DESCRIPTION
## Summary
- Viewing a proposal during its voting-delay window crashed \`useVotes\` because \`governor.proposalSnapshot(id)\` returns a timestamp that hasn't elapsed yet, and OZ \`Votes.getPastVotes\` reverts on future timepoints (\`ERC5805FutureLookup\`).
- Detect \`snapshotTimestamp > now\` at mount and skip the snapshot branch, falling back to \`getVotes(signer)\` so the UI shows the signer's current voting power as a preview until the snapshot actually passes.

## Changes
- \`src/hooks/useVotes.ts\`: freeze the mount timestamp via \`useState\` initializer (Date.now is not allowed in render by the React purity rule), compute \`snapshotInFuture\`, gate \`usingSnapshotQuery\`.

## Test plan
- [ ] Create a new proposal and open its detail page during the voting delay — the \`[useVotes] Contract call failed\` error should be gone and voting power reads should succeed.
- [ ] Open an older proposal whose snapshot has already elapsed and confirm \`getPastVotes\` is still used (nothing regressed for historical proposals).

Generated with [Claude Code](https://claude.com/claude-code)