### PR TITLE
fix(navbar): stop mouse click from closing hover-opened dropdown

### DIFF
--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -61,12 +61,26 @@ const navigationMenuTriggerStyle = cva(
 function NavigationMenuTrigger({
   className,
   children,
+  onClick,
   ...props
 }: React.ComponentProps<typeof NavigationMenuPrimitive.Trigger>) {
   return (
     <NavigationMenuPrimitive.Trigger
       data-slot="navigation-menu-trigger"
       className={cn(navigationMenuTriggerStyle(), "group", className)}
+      onClick={(event) => {
+        // Mouse click on a hover-opened trigger would toggle it closed. Suppress
+        // click for mouse only; keyboard (Enter/Space) and touch still toggle.
+        const native = event.nativeEvent;
+        if (
+          typeof PointerEvent !== "undefined" &&
+          native instanceof PointerEvent &&
+          native.pointerType === "mouse"
+        ) {
+          event.preventDefault();
+        }
+        onClick?.(event);
+      }}
       {...props}
     >
       {children}{" "}


### PR DESCRIPTION
## Summary
- Radix `NavigationMenu.Trigger` toggles on click. User hovers Governance/Community → menu opens → reflex click on trigger label → menu collapses before they reach a sub-item.
- Suppress click for mouse pointers only inside the shadcn `NavigationMenuTrigger` wrapper; keyboard (Enter/Space) and touch still toggle.

## Changes
- `src/components/ui/navigation-menu.tsx` — wrap `onClick` on `NavigationMenuTrigger`; `preventDefault` when `event.nativeEvent.pointerType === "mouse"`, chain any caller-provided `onClick`.

## Test plan
- [ ] Desktop: hover Governance → opens; click label → stays open; click sub-item → navigates.
- [ ] Repeat for Community.
- [ ] Keyboard: Tab to Governance, Enter → opens; Esc → closes; Enter → opens.
- [ ] Touch emulation: tap Governance → opens; tap outside → closes.
- [ ] Mobile sheet unchanged.

Generated with [Claude Code](https://claude.com/claude-code)