### PR TITLE
fix(poidh): complete V3 implementation — fix broken vote/resolve, add vote dashboard and withdrawal banner

### DIFF
--- a/docs/superpowers/plans/2026-04-24-poidh-v3-completion.md
+++ b/docs/superpowers/plans/2026-04-24-poidh-v3-completion.md
@@ -1,0 +1,1423 @@
+# POIDH V3 Completion Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix all V3 ABI mismatches, add vote dashboard, pending withdrawal banner, and a full integration test script.
+
+**Architecture:** Fix the ABI layer first so all downstream consumers are correct, then update hooks, build two new UI components (VoteDashboard, PendingWithdrawalBanner), wire them into the existing views, and finally write the integration test script.
+
+**Tech Stack:** Next.js 15, thirdweb v5, wagmi v2, viem, Tailwind CSS v4, shadcn/ui
+
+---
+
+## File Map
+
+| File | Action | What changes |
+|---|---|---|
+| `src/lib/poidh/abi.ts` | Modify | Fix `voteClaim`/`resolveVote`, remove `getBounty`, fix `bounties` getter, add 6 new entries |
+| `src/hooks/usePoidhContract.ts` | Modify | Fix vote/resolve params, add `usePoidhClaimRefund`, `usePoidhResetVotingPeriod`, `usePoidhWithdraw` |
+| `src/components/bounties/VoteDashboard.tsx` | Create | Live yes/no tallies + vote deadline countdown |
+| `src/components/bounties/PendingWithdrawalBanner.tsx` | Create | Per-chain claimable ETH notification + withdraw button |
+| `src/components/bounties/BountyDetailView.tsx` | Modify | Remove dead `getBounty`, add `everHadExternalContributor` gate, fix canceled-bounty withdraw, add VoteDashboard + resetVotingPeriod |
+| `src/components/bounties/BountiesView.tsx` | Modify | Add PendingWithdrawalBanner at top |
+| `scripts/test-poidh.ts` | Create | Full integration test script with thirdweb wallets |
+
+---
+
+## Task 1: Fix ABI
+
+**Files:**
+- Modify: `src/lib/poidh/abi.ts` (replace entirely)
+
+Three bugs + six missing entries.
+
+**Bug fixes:**
+- `voteClaim`: V2 had `(bountyId, claimId, accept)`, V3 is `(bountyId, vote: bool)` — drop `claimId`
+- `resolveVote`: V2 had `(bountyId, claimId)`, V3 is `(bountyId)` — drop `claimId`
+- `getBounty`: does not exist on V3 — remove entirely
+- `bounties` storage getter: remove phantom fields `deadline`, `status`, `isOpenBounty`
+
+**New entries to add:**
+- `claimRefundFromCancelledOpenBounty(bountyId)` — contributor pull-refund after issuer cancels open bounty
+- `resetVotingPeriod(bountyId)` — recovery after a failed vote (reverts if vote would have passed)
+- `withdrawTo(to: address)` — variant of `withdraw()` for contract wallets
+- `bountyVotingTracker(bountyId)` → `(yes: uint256, no: uint256, deadline: uint256)`
+- `bountyCurrentVotingClaim(bountyId)` → `uint256` (claim ID in active vote)
+- `everHadExternalContributor(bountyId)` → `bool`
+
+- [ ] **Step 1: Replace `src/lib/poidh/abi.ts` with the corrected V3 ABI**
+
+```typescript
+export const POIDH_ABI = [
+  // ── Write functions ──────────────────────────────────────────────────────
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "bountyId", "type": "uint256" },
+      { "internalType": "string",  "name": "name",        "type": "string" },
+      { "internalType": "string",  "name": "description", "type": "string" },
+      { "internalType": "string",  "name": "imageUri",    "type": "string" }
+    ],
+    "name": "createClaim",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "string", "name": "name",        "type": "string" },
+      { "internalType": "string", "name": "description", "type": "string" }
+    ],
+    "name": "createSoloBounty",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "string", "name": "name",        "type": "string" },
+      { "internalType": "string", "name": "description", "type": "string" }
+    ],
+    "name": "createOpenBounty",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "bountyId", "type": "uint256" }],
+    "name": "joinOpenBounty",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "bountyId", "type": "uint256" },
+      { "internalType": "uint256", "name": "claimId",  "type": "uint256" }
+    ],
+    "name": "acceptClaim",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "bountyId", "type": "uint256" },
+      { "internalType": "uint256", "name": "claimId",  "type": "uint256" }
+    ],
+    "name": "submitClaimForVote",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "bountyId", "type": "uint256" },
+      { "internalType": "bool",    "name": "vote",     "type": "bool" }
+    ],
+    "name": "voteClaim",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "bountyId", "type": "uint256" }],
+    "name": "resolveVote",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "bountyId", "type": "uint256" }],
+    "name": "cancelSoloBounty",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "bountyId", "type": "uint256" }],
+    "name": "cancelOpenBounty",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "bountyId", "type": "uint256" }],
+    "name": "withdrawFromOpenBounty",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "bountyId", "type": "uint256" }],
+    "name": "claimRefundFromCancelledOpenBounty",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "bountyId", "type": "uint256" }],
+    "name": "resetVotingPeriod",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "withdraw",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "to", "type": "address" }],
+    "name": "withdrawTo",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  // ── Read functions ───────────────────────────────────────────────────────
+  {
+    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "name": "bounties",
+    "outputs": [
+      { "internalType": "string",  "name": "name",        "type": "string" },
+      { "internalType": "string",  "name": "description", "type": "string" },
+      { "internalType": "uint256", "name": "amount",      "type": "uint256" },
+      { "internalType": "address", "name": "issuer",      "type": "address" },
+      { "internalType": "address", "name": "claimer",     "type": "address" },
+      { "internalType": "uint256", "name": "createdAt",   "type": "uint256" },
+      { "internalType": "uint256", "name": "claimId",     "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "bountyId", "type": "uint256" }],
+    "name": "getParticipants",
+    "outputs": [
+      { "internalType": "address[]", "name": "", "type": "address[]" },
+      { "internalType": "uint256[]", "name": "", "type": "uint256[]" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "bountyId", "type": "uint256" }],
+    "name": "bountyVotingTracker",
+    "outputs": [
+      { "internalType": "uint256", "name": "yes",      "type": "uint256" },
+      { "internalType": "uint256", "name": "no",       "type": "uint256" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "bountyId", "type": "uint256" }],
+    "name": "bountyCurrentVotingClaim",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "bountyId", "type": "uint256" }],
+    "name": "everHadExternalContributor",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "pendingWithdrawals",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  }
+] as const;
+```
+
+- [ ] **Step 2: Verify TypeScript compiles with the new ABI**
+
+```bash
+cd /Users/web3warrior/Code/gnars/gnars-website && npx tsc --noEmit 2>&1 | head -40
+```
+
+Expected: no errors referencing `getBounty`, `claimId` in `voteClaim`/`resolveVote`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/poidh/abi.ts
+git commit -m "fix(poidh): update ABI to V3 — fix voteClaim/resolveVote, add missing functions"
+```
+
+---
+
+## Task 2: Fix & Extend Contract Hooks
+
+**Files:**
+- Modify: `src/hooks/usePoidhContract.ts`
+
+Three changes to existing hooks + three new hooks.
+
+### 2a: Fix `usePoidhVoteClaim` — remove `claimId` param
+
+- [ ] **Step 1: Update the `usePoidhVoteClaim` hook**
+
+Replace the existing `usePoidhVoteClaim` function (lines 300–319) with:
+
+```typescript
+export function usePoidhVoteClaim(bountyChainId: number) {
+  const ctx = usePoidhContext(bountyChainId);
+  const state = usePoidhWriteState();
+
+  const vote = useCallback(
+    async (onChainBountyId: number, accept: boolean) => {
+      const { client, contractAddress, twChain, writer } = await assertPoidhReady(ctx, bountyChainId);
+      const contract = getContract({ client, chain: twChain, address: contractAddress, abi: POIDH_ABI });
+      const tx = prepareContractCall({
+        contract,
+        method: "voteClaim",
+        params: [BigInt(onChainBountyId), accept],
+      });
+      await sendAndConfirm(state, client, twChain, writer, tx);
+    },
+    [ctx, bountyChainId, state],
+  );
+
+  return { vote, ...buildPoidhReturn(state) };
+}
+```
+
+### 2b: Fix `usePoidhResolveVote` — remove `claimId` param
+
+- [ ] **Step 2: Update the `usePoidhResolveVote` hook**
+
+Replace the existing `usePoidhResolveVote` function (lines 323–342) with:
+
+```typescript
+export function usePoidhResolveVote(bountyChainId: number) {
+  const ctx = usePoidhContext(bountyChainId);
+  const state = usePoidhWriteState();
+
+  const resolve = useCallback(
+    async (onChainBountyId: number) => {
+      const { client, contractAddress, twChain, writer } = await assertPoidhReady(ctx, bountyChainId);
+      const contract = getContract({ client, chain: twChain, address: contractAddress, abi: POIDH_ABI });
+      const tx = prepareContractCall({
+        contract,
+        method: "resolveVote",
+        params: [BigInt(onChainBountyId)],
+      });
+      await sendAndConfirm(state, client, twChain, writer, tx);
+    },
+    [ctx, bountyChainId, state],
+  );
+
+  return { resolve, ...buildPoidhReturn(state) };
+}
+```
+
+### 2c: Add three new hooks
+
+- [ ] **Step 3: Append the three new hooks to the end of `src/hooks/usePoidhContract.ts`**
+
+```typescript
+// ─── Claim Refund from Cancelled Open Bounty (contributor pull-payment) ───────
+
+export function usePoidhClaimRefundFromCancelledBounty(bountyChainId: number) {
+  const ctx = usePoidhContext(bountyChainId);
+  const state = usePoidhWriteState();
+
+  const claimRefund = useCallback(
+    async (onChainBountyId: number) => {
+      const { client, contractAddress, twChain, writer } = await assertPoidhReady(ctx, bountyChainId);
+      const contract = getContract({ client, chain: twChain, address: contractAddress, abi: POIDH_ABI });
+      const tx = prepareContractCall({
+        contract,
+        method: "claimRefundFromCancelledOpenBounty",
+        params: [BigInt(onChainBountyId)],
+      });
+      await sendAndConfirm(state, client, twChain, writer, tx);
+    },
+    [ctx, bountyChainId, state],
+  );
+
+  return { claimRefund, ...buildPoidhReturn(state) };
+}
+
+// ─── Reset Voting Period (recovery after failed vote) ─────────────────────────
+
+export function usePoidhResetVotingPeriod(bountyChainId: number) {
+  const ctx = usePoidhContext(bountyChainId);
+  const state = usePoidhWriteState();
+
+  const reset = useCallback(
+    async (onChainBountyId: number) => {
+      const { client, contractAddress, twChain, writer } = await assertPoidhReady(ctx, bountyChainId);
+      const contract = getContract({ client, chain: twChain, address: contractAddress, abi: POIDH_ABI });
+      const tx = prepareContractCall({
+        contract,
+        method: "resetVotingPeriod",
+        params: [BigInt(onChainBountyId)],
+      });
+      await sendAndConfirm(state, client, twChain, writer, tx);
+    },
+    [ctx, bountyChainId, state],
+  );
+
+  return { reset, ...buildPoidhReturn(state) };
+}
+
+// ─── Withdraw pending balance (bounty winners, cancelled-bounty refunds) ─────
+
+export function usePoidhWithdraw(bountyChainId: number) {
+  const ctx = usePoidhContext(bountyChainId);
+  const state = usePoidhWriteState();
+
+  const withdraw = useCallback(
+    async () => {
+      const { client, contractAddress, twChain, writer } = await assertPoidhReady(ctx, bountyChainId);
+      const contract = getContract({ client, chain: twChain, address: contractAddress, abi: POIDH_ABI });
+      const tx = prepareContractCall({
+        contract,
+        method: "withdraw",
+        params: [],
+      });
+      await sendAndConfirm(state, client, twChain, writer, tx);
+    },
+    [ctx, bountyChainId, state],
+  );
+
+  return { withdraw, ...buildPoidhReturn(state) };
+}
+```
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit 2>&1 | head -30
+```
+
+Expected: no errors in `usePoidhContract.ts`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/usePoidhContract.ts
+git commit -m "fix(poidh): fix voteClaim/resolveVote params, add claimRefund/resetVoting/withdraw hooks"
+```
+
+---
+
+## Task 3: VoteDashboard Component
+
+**Files:**
+- Create: `src/components/bounties/VoteDashboard.tsx`
+
+Reads `bountyVotingTracker` on-chain every 15s. Shows yes/no ETH weights as a progress bar and the vote deadline as a live countdown.
+
+Note: vote weights (`yes`/`no`) are ETH amounts in wei — participants' contribution snapshots — not simple vote counts. Display as ETH.
+
+- [ ] **Step 1: Create `src/components/bounties/VoteDashboard.tsx`**
+
+```typescript
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useReadContract } from 'wagmi';
+import { formatEther } from 'viem';
+import { Clock } from 'lucide-react';
+import { POIDH_ABI } from '@/lib/poidh/abi';
+import { POIDH_CONTRACTS } from '@/lib/poidh/config';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+function useDeadlineCountdown(deadlineSeconds: number): string {
+  const calc = () => {
+    if (!deadlineSeconds) return '';
+    const diff = deadlineSeconds * 1000 - Date.now();
+    if (diff <= 0) return 'Expired';
+    const hours = Math.floor(diff / 3_600_000);
+    const minutes = Math.floor((diff % 3_600_000) / 60_000);
+    if (hours > 0) return `${hours}h ${minutes}m`;
+    return `${minutes}m`;
+  };
+  const [label, setLabel] = useState(calc);
+  useEffect(() => {
+    if (!deadlineSeconds) return;
+    const id = setInterval(() => setLabel(calc()), 30_000);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deadlineSeconds]);
+  return label;
+}
+
+interface VoteDashboardProps {
+  chainId: number;
+  onChainBountyId: number;
+}
+
+export function VoteDashboard({ chainId, onChainBountyId }: VoteDashboardProps) {
+  const contractAddress = POIDH_CONTRACTS[chainId];
+
+  const { data: tracker } = useReadContract({
+    address: contractAddress,
+    abi: POIDH_ABI,
+    functionName: 'bountyVotingTracker',
+    args: [BigInt(onChainBountyId)],
+    chainId,
+    query: {
+      enabled: !!contractAddress && onChainBountyId > 0,
+      refetchInterval: 15_000,
+    },
+  });
+
+  const deadline = useDeadlineCountdown(tracker ? Number(tracker[2]) : 0);
+
+  if (!tracker) return null;
+
+  const yesWei = tracker[0];
+  const noWei  = tracker[1];
+  const deadlineSec = Number(tracker[2]);
+
+  if (deadlineSec === 0) return null; // no active vote
+
+  const yesEth = parseFloat(formatEther(yesWei));
+  const noEth  = parseFloat(formatEther(noWei));
+  const total  = yesEth + noEth;
+  const yesPercent = total > 0 ? Math.round((yesEth / total) * 100) : 50;
+  const isExpired  = deadlineSec * 1000 < Date.now();
+
+  return (
+    <Card className="border-yellow-500/20 bg-yellow-500/5">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base text-yellow-400">Live Vote</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {/* Yes / No labels */}
+        <div className="flex justify-between text-xs font-medium">
+          <span className="text-emerald-400">{yesEth.toFixed(4)} ETH Yes</span>
+          <span className="text-red-400">{noEth.toFixed(4)} ETH No</span>
+        </div>
+
+        {/* Progress bar */}
+        <div className="h-2 rounded-full bg-muted overflow-hidden">
+          <div
+            className="h-full bg-emerald-500 rounded-full transition-all duration-500"
+            style={{ width: `${yesPercent}%` }}
+          />
+        </div>
+
+        {/* Vote weight note */}
+        <p className="text-xs text-muted-foreground">
+          Weighted by ETH contribution — {total.toFixed(4)} ETH total
+        </p>
+
+        {/* Deadline */}
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground pt-1 border-t border-border/50">
+          <Clock className="w-3 h-3" />
+          {isExpired
+            ? 'Vote period ended — resolve when ready'
+            : `Vote closes in ${deadline}`}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit 2>&1 | grep VoteDashboard
+```
+
+Expected: no output (no errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/bounties/VoteDashboard.tsx
+git commit -m "feat(poidh): add VoteDashboard with live vote tallies and deadline countdown"
+```
+
+---
+
+## Task 4: PendingWithdrawalBanner Component
+
+**Files:**
+- Create: `src/components/bounties/PendingWithdrawalBanner.tsx`
+
+Reads `pendingWithdrawals(userAddress)` for each supported chain. Shows a banner per chain where balance > 0. Calls `withdraw()` via `usePoidhWithdraw`.
+
+- [ ] **Step 1: Create `src/components/bounties/PendingWithdrawalBanner.tsx`**
+
+```typescript
+'use client';
+
+import { useReadContract } from 'wagmi';
+import { formatEther } from 'viem';
+import { Wallet, Loader2, CheckCircle2, ExternalLink, AlertCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { POIDH_ABI } from '@/lib/poidh/abi';
+import { POIDH_CONTRACTS, CHAIN_NAMES, getTxUrl, SUPPORTED_CHAINS } from '@/lib/poidh/config';
+import { usePoidhWithdraw } from '@/hooks/usePoidhContract';
+import { useUserAddress } from '@/hooks/use-user-address';
+
+interface ChainBannerProps {
+  chainId: number;
+  userAddress: `0x${string}`;
+}
+
+function ChainWithdrawalBanner({ chainId, userAddress }: ChainBannerProps) {
+  const contractAddress = POIDH_CONTRACTS[chainId];
+  const chainName = CHAIN_NAMES[chainId as keyof typeof CHAIN_NAMES];
+  const { withdraw, isPending, isSuccess, hash, error } = usePoidhWithdraw(chainId);
+
+  const { data: pending, refetch } = useReadContract({
+    address: contractAddress,
+    abi: POIDH_ABI,
+    functionName: 'pendingWithdrawals',
+    args: [userAddress],
+    chainId,
+    query: { enabled: !!contractAddress, refetchInterval: 30_000 },
+  });
+
+  // Re-fetch after successful withdrawal
+  if (isSuccess) void refetch();
+
+  if (!pending || pending === 0n) return null;
+
+  const ethAmount = parseFloat(formatEther(pending)).toFixed(6);
+
+  return (
+    <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3 p-3 rounded-md border border-amber-500/30 bg-amber-500/10 text-sm">
+      <Wallet className="w-4 h-4 text-amber-400 shrink-0 mt-0.5 sm:mt-0" />
+      <div className="flex-1">
+        <span className="font-medium text-amber-300">
+          {ethAmount} ETH claimable on {chainName}
+        </span>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          From bounty winnings or a cancelled open bounty.
+        </p>
+      </div>
+
+      {isSuccess ? (
+        <div className="flex items-center gap-1.5 text-emerald-400 text-xs shrink-0">
+          <CheckCircle2 className="w-4 h-4" />
+          <span>Withdrawn!</span>
+          {hash && (
+            <a href={getTxUrl(chainId, hash)} target="_blank" rel="noopener noreferrer"
+               className="flex items-center gap-0.5 hover:underline ml-1">
+              Tx <ExternalLink className="w-3 h-3" />
+            </a>
+          )}
+        </div>
+      ) : (
+        <div className="flex flex-col items-end gap-1 shrink-0">
+          <Button
+            size="sm"
+            variant="outline"
+            className="border-amber-500/40 text-amber-300 hover:bg-amber-500/10 whitespace-nowrap"
+            disabled={isPending}
+            onClick={() => withdraw()}
+          >
+            {isPending ? (
+              <><Loader2 className="w-3 h-3 mr-1.5 animate-spin" />Withdrawing…</>
+            ) : (
+              'Withdraw'
+            )}
+          </Button>
+          {error && (
+            <div className="flex items-start gap-1 text-destructive text-xs max-w-48">
+              <AlertCircle className="w-3 h-3 shrink-0 mt-0.5" />
+              <span>{error.message.split('\n')[0]}</span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function PendingWithdrawalBanner() {
+  const { address, isConnected } = useUserAddress();
+
+  if (!isConnected || !address) return null;
+
+  return (
+    <div className="space-y-2 mb-4">
+      {Object.values(SUPPORTED_CHAINS).map((chainId) => (
+        <ChainWithdrawalBanner
+          key={chainId}
+          chainId={chainId}
+          userAddress={address as `0x${string}`}
+        />
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit 2>&1 | grep PendingWithdrawal
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/bounties/PendingWithdrawalBanner.tsx
+git commit -m "feat(poidh): add PendingWithdrawalBanner for claimable ETH across chains"
+```
+
+---
+
+## Task 5: Update BountyDetailView
+
+**Files:**
+- Modify: `src/components/bounties/BountyDetailView.tsx`
+
+Four independent changes:
+1. Remove dead `getBounty` call, simplify `isJoinable`
+2. Add `everHadExternalContributor` read to gate the Accept Claim button
+3. Fix canceled-bounty withdraw to use `claimRefundFromCancelledOpenBounty`
+4. Add `VoteDashboard` in sidebar + `resetVotingPeriod` button in voting section
+
+### 5a — Remove dead getBounty, fix isJoinable
+
+- [ ] **Step 1: Remove the `getBounty` useReadContract block and simplify isJoinable**
+
+Replace this block (lines 178–187):
+```typescript
+  // Read the authoritative on-chain isOpenBounty flag (overrides API field which can be null on V2)
+  const { data: onChainBountyData } = useReadContract({
+    address: POIDH_CONTRACTS[chainId],
+    abi: POIDH_ABI,
+    functionName: 'getBounty',
+    args: [BigInt(bounty?.onChainId ?? 0)],
+    chainId,
+    query: { enabled: !!(bounty?.onChainId) },
+  });
+  const isJoinable = onChainBountyData ? onChainBountyData.isOpenBounty : (bounty?.isOpenBounty || bounty?.isMultiplayer);
+```
+
+With:
+```typescript
+  const isJoinable = bounty?.isOpenBounty || bounty?.isMultiplayer;
+```
+
+### 5b — Add everHadExternalContributor read
+
+- [ ] **Step 2: Add the read after the `participantsData` block (after line 199)**
+
+```typescript
+  const { data: hadExternalContributor } = useReadContract({
+    address: POIDH_CONTRACTS[chainId],
+    abi: POIDH_ABI,
+    functionName: 'everHadExternalContributor',
+    args: [BigInt(bounty?.onChainId ?? 0)],
+    chainId,
+    query: { enabled: !!(bounty?.onChainId) },
+  });
+```
+
+- [ ] **Step 3: Update imports — add the three new hooks and VoteDashboard**
+
+In the imports at the top of BountyDetailView.tsx, update the hook import line:
+```typescript
+import { usePoidhCancelBounty, usePoidhJoinBounty, usePoidhWithdrawFromBounty, usePoidhAcceptClaim, usePoidhSubmitClaimForVote, usePoidhVoteClaim, usePoidhResolveVote, usePoidhClaimRefundFromCancelledBounty, usePoidhResetVotingPeriod } from '@/hooks/usePoidhContract';
+```
+
+Add VoteDashboard import:
+```typescript
+import { VoteDashboard } from '@/components/bounties/VoteDashboard';
+```
+
+- [ ] **Step 4: Instantiate the new hooks** — add after line 173 (after `resolveVoteHook`):
+
+```typescript
+  const claimRefundHook = usePoidhClaimRefundFromCancelledBounty(chainId);
+  const resetVotingHook = usePoidhResetVotingPeriod(chainId);
+```
+
+### 5c — Gate Accept Claim with everHadExternalContributor
+
+- [ ] **Step 5: Update the Accept Claim button condition**
+
+Find (line ~451):
+```typescript
+{isCreator && !claim.accepted && !bounty.isCanceled && (
+```
+
+Replace with:
+```typescript
+{isCreator && !claim.accepted && !bounty.isCanceled && !hadExternalContributor && (
+```
+
+Also add a note for when `hadExternalContributor` is true — insert directly after the Accept button block:
+```typescript
+{isCreator && !claim.accepted && !bounty.isCanceled && hadExternalContributor && !bounty.isVoting && (
+  <p className="text-xs text-muted-foreground pt-1">
+    This open bounty had contributors — use <strong>Submit for Vote</strong> to accept a claim.
+  </p>
+)}
+```
+
+### 5d — Fix canceled-bounty withdraw section
+
+- [ ] **Step 6: Replace `withdrawHook` with `claimRefundHook` in the canceled-bounty section**
+
+Find the entire "Withdraw Your Contribution" Card (lines ~699–732) and replace the `withdrawHook` references:
+
+```typescript
+{/* Withdraw from canceled bounty (participant) */}
+{bounty.isCanceled && isJoinable && !isCreator && (
+  <Card className="border-border">
+    <CardHeader className="pb-3">
+      <CardTitle className="text-base">Withdraw Your Contribution</CardTitle>
+      <CardDescription>This bounty was canceled. Recover your contribution.</CardDescription>
+    </CardHeader>
+    <CardContent className="space-y-3">
+      {claimRefundHook.isSuccess ? (
+        <div className="flex flex-col items-center gap-2 py-2 text-center">
+          <CheckCircle2 className="w-8 h-8 text-emerald-500" />
+          <p className="text-sm font-medium">Withdrawal confirmed!</p>
+          {claimRefundHook.hash && (
+            <a href={getTxUrl(chainId, claimRefundHook.hash)} target="_blank" rel="noopener noreferrer"
+               className="flex items-center gap-1 text-xs text-primary hover:underline">
+              View tx <ExternalLink className="w-3 h-3" />
+            </a>
+          )}
+        </div>
+      ) : (
+        <>
+          {claimRefundHook.error && (
+            <div className="flex items-start gap-2 rounded-md bg-destructive/10 border border-destructive/20 px-3 py-2 text-sm text-destructive">
+              <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" />
+              <span>{claimRefundHook.error.message.split('\n')[0]}</span>
+            </div>
+          )}
+          <Button variant="outline" className="w-full" disabled={claimRefundHook.isPending}
+                  onClick={() => claimRefundHook.claimRefund(bounty.onChainId)}>
+            {claimRefundHook.isPending
+              ? <><Loader2 className="w-4 h-4 mr-2 animate-spin" />{claimRefundHook.hash ? 'Confirming…' : 'Confirm in wallet…'}</>
+              : 'Withdraw Funds'
+            }
+          </Button>
+        </>
+      )}
+    </CardContent>
+  </Card>
+)}
+```
+
+### 5e — Wire VoteDashboard + resetVotingPeriod button
+
+- [ ] **Step 7: Add VoteDashboard card in the sidebar, before the Bounty Details card**
+
+Find the comment `{/* Bounty Details */}` card in the sidebar and insert before it:
+
+```typescript
+{/* Vote Dashboard — only when bounty is in voting state */}
+{bounty.isVoting && bounty.onChainId > 0 && (
+  <VoteDashboard chainId={chainId} onChainBountyId={bounty.onChainId} />
+)}
+```
+
+- [ ] **Step 8: Add resetVotingPeriod button in the voting controls section**
+
+Inside the `{bounty.isVoting && isConnected && (` block, after the Resolve Vote button and its success/error state (after the last `resolveVoteHook` block), add:
+
+```typescript
+{/* Reset voting period — shown after vote deadline, allows retry if vote failed */}
+<Button
+  size="sm"
+  variant="ghost"
+  className="w-full text-xs text-muted-foreground"
+  disabled={resetVotingHook.isPending}
+  onClick={() => resetVotingHook.reset(bounty.onChainId)}
+>
+  {resetVotingHook.isPending
+    ? <><Loader2 className="w-3 h-3 mr-1 animate-spin" />Resetting…</>
+    : 'Reset voting period (if vote failed)'
+  }
+</Button>
+{resetVotingHook.error && (
+  <div className="flex items-start gap-2 rounded-md bg-destructive/10 border border-destructive/20 px-2 py-1.5 text-xs text-destructive">
+    <AlertCircle className="w-3 h-3 shrink-0 mt-0.5" />
+    <span>{resetVotingHook.error.message.split('\n')[0]}</span>
+  </div>
+)}
+{resetVotingHook.isSuccess && resetVotingHook.hash && (
+  <div className="flex items-center gap-2 py-1.5 px-2 rounded-md bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 text-xs">
+    <CheckCircle2 className="w-3 h-3 shrink-0" />
+    <span>Voting period reset — new claims can be submitted for vote.</span>
+    <a href={getTxUrl(chainId, resetVotingHook.hash)} target="_blank" rel="noopener noreferrer"
+       className="ml-auto flex items-center gap-1 hover:underline">
+      View tx <ExternalLink className="w-3 h-3" />
+    </a>
+  </div>
+)}
+```
+
+- [ ] **Step 9: Also update vote/resolve call sites** — the vote and resolve hooks no longer accept `claimId`
+
+Find in the voting controls section:
+```typescript
+onClick={() => voteClaimHook.vote(bounty.onChainId, claim.id, true)}
+```
+Replace with:
+```typescript
+onClick={() => voteClaimHook.vote(bounty.onChainId, true)}
+```
+
+Find:
+```typescript
+onClick={() => voteClaimHook.vote(bounty.onChainId, claim.id, false)}
+```
+Replace with:
+```typescript
+onClick={() => voteClaimHook.vote(bounty.onChainId, false)}
+```
+
+Find:
+```typescript
+onClick={() => resolveVoteHook.resolve(bounty.onChainId, claim.id)}
+```
+Replace with:
+```typescript
+onClick={() => resolveVoteHook.resolve(bounty.onChainId)}
+```
+
+- [ ] **Step 10: Verify TypeScript compiles cleanly**
+
+```bash
+npx tsc --noEmit 2>&1 | head -40
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/components/bounties/BountyDetailView.tsx
+git commit -m "fix(poidh): fix vote/resolve calls, add VoteDashboard, claimRefund, everHadExternalContributor gate"
+```
+
+---
+
+## Task 6: Wire PendingWithdrawalBanner into BountiesView
+
+**Files:**
+- Modify: `src/components/bounties/BountiesView.tsx`
+
+Add import + render at top of the view, before the tabs/filters.
+
+- [ ] **Step 1: Add import to BountiesView.tsx**
+
+```typescript
+import { PendingWithdrawalBanner } from '@/components/bounties/PendingWithdrawalBanner';
+```
+
+- [ ] **Step 2: Render the banner at the top of the returned JSX**
+
+Find the opening of the return statement in `BountiesView` — it likely starts with a wrapper `<div>` containing the header + tab row. Insert before the first non-wrapper element:
+
+```typescript
+<PendingWithdrawalBanner />
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit 2>&1 | head -20
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/bounties/BountiesView.tsx
+git commit -m "feat(poidh): show pending withdrawal banner on bounties list page"
+```
+
+---
+
+## Task 7: Integration Test Script
+
+**Files:**
+- Create: `scripts/test-poidh.ts`
+
+Tests the full V3 contract flow using two thirdweb private-key wallets against a local Anvil fork of Base mainnet. Covers the golden path (solo bounty, open bounty, claim, vote) and edge cases (AA wallet blocked, non-issuer accept blocked, non-participant vote blocked, cancel refund flow).
+
+**Prerequisites:**
+```bash
+# 1. Install anvil (part of foundry)
+curl -L https://foundry.paradigm.xyz | bash && foundryup
+
+# 2. Start Anvil with Base mainnet fork
+anvil --fork-url https://mainnet.base.org --chain-id 8453
+
+# 3. Set env vars
+export THIRDWEB_SECRET_KEY="your-key"
+export POIDH_RPC_URL="http://127.0.0.1:8545"   # anvil default
+```
+
+**Running the script:**
+```bash
+npx tsx scripts/test-poidh.ts
+```
+
+- [ ] **Step 1: Create `scripts/test-poidh.ts`**
+
+```typescript
+import {
+  createThirdwebClient,
+  getContract,
+  prepareContractCall,
+  sendTransaction,
+  waitForReceipt,
+  readContract,
+  toWei,
+} from "thirdweb";
+import { privateKeyToAccount } from "thirdweb/wallets";
+import { defineChain } from "thirdweb/chains";
+import { createWalletClient, http, parseEther, formatEther } from "viem";
+import { privateKeyToAccount as viemPrivKey } from "viem/accounts";
+
+// ─── Config ──────────────────────────────────────────────────────────────────
+
+const RPC_URL = process.env.POIDH_RPC_URL ?? "http://127.0.0.1:8545";
+const SECRET_KEY = process.env.THIRDWEB_SECRET_KEY ?? "";
+const POIDH_CONTRACT_ADDR = "0x5555fa783936c260f77385b4e153b9725fef1719" as const;
+
+// Anvil default funded accounts (deterministic from default mnemonic)
+const ANVIL_KEY_A = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" as `0x${string}`;
+const ANVIL_KEY_B = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d" as `0x${string}`;
+
+// ─── Setup ───────────────────────────────────────────────────────────────────
+
+const baseFork = defineChain({ id: 8453, rpc: RPC_URL });
+
+const client = createThirdwebClient(
+  SECRET_KEY ? { secretKey: SECRET_KEY } : { clientId: "test" }
+);
+
+const accountA = privateKeyToAccount({ client, privateKey: ANVIL_KEY_A });
+const accountB = privateKeyToAccount({ client, privateKey: ANVIL_KEY_B });
+
+const contract = getContract({
+  client,
+  chain: baseFork,
+  address: POIDH_CONTRACT_ADDR,
+  abi: POIDH_ABI,
+});
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+let passed = 0;
+let failed = 0;
+
+async function send(account: typeof accountA, tx: ReturnType<typeof prepareContractCall>) {
+  const result = await sendTransaction({ account, transaction: tx });
+  await waitForReceipt({ client, chain: baseFork, transactionHash: result.transactionHash });
+  return result.transactionHash;
+}
+
+async function expectRevert(fn: () => Promise<unknown>, label: string) {
+  try {
+    await fn();
+    console.log(`  ❌ FAIL [${label}] — expected revert but tx succeeded`);
+    failed++;
+  } catch {
+    console.log(`  ✅ PASS [${label}] — reverted as expected`);
+    passed++;
+  }
+}
+
+async function expect<T>(actual: T, check: (v: T) => boolean, label: string) {
+  if (check(actual)) {
+    console.log(`  ✅ PASS [${label}]`);
+    passed++;
+  } else {
+    console.log(`  ❌ FAIL [${label}] — got ${String(actual)}`);
+    failed++;
+  }
+}
+
+// ─── ABI (inline for script independence) ────────────────────────────────────
+
+const POIDH_ABI = [
+  { inputs: [{ name: "name", type: "string" }, { name: "description", type: "string" }], name: "createSoloBounty", outputs: [], stateMutability: "payable", type: "function" },
+  { inputs: [{ name: "name", type: "string" }, { name: "description", type: "string" }], name: "createOpenBounty", outputs: [], stateMutability: "payable", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }], name: "joinOpenBounty", outputs: [], stateMutability: "payable", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }, { name: "name", type: "string" }, { name: "description", type: "string" }, { name: "imageUri", type: "string" }], name: "createClaim", outputs: [], stateMutability: "nonpayable", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }, { name: "claimId", type: "uint256" }], name: "acceptClaim", outputs: [], stateMutability: "nonpayable", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }, { name: "claimId", type: "uint256" }], name: "submitClaimForVote", outputs: [], stateMutability: "nonpayable", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }, { name: "vote", type: "bool" }], name: "voteClaim", outputs: [], stateMutability: "nonpayable", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }], name: "resolveVote", outputs: [], stateMutability: "nonpayable", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }], name: "cancelSoloBounty", outputs: [], stateMutability: "nonpayable", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }], name: "cancelOpenBounty", outputs: [], stateMutability: "nonpayable", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }], name: "withdrawFromOpenBounty", outputs: [], stateMutability: "nonpayable", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }], name: "claimRefundFromCancelledOpenBounty", outputs: [], stateMutability: "nonpayable", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }], name: "resetVotingPeriod", outputs: [], stateMutability: "nonpayable", type: "function" },
+  { inputs: [], name: "withdraw", outputs: [], stateMutability: "nonpayable", type: "function" },
+  // Read
+  { inputs: [], name: "getBountiesLength", outputs: [{ name: "", type: "uint256" }], stateMutability: "view", type: "function" },
+  { inputs: [], name: "MIN_BOUNTY_AMOUNT", outputs: [{ name: "", type: "uint256" }], stateMutability: "view", type: "function" },
+  { inputs: [], name: "MIN_CONTRIBUTION", outputs: [{ name: "", type: "uint256" }], stateMutability: "view", type: "function" },
+  { inputs: [], name: "FEE_BPS", outputs: [{ name: "", type: "uint256" }], stateMutability: "view", type: "function" },
+  { inputs: [], name: "votingPeriod", outputs: [{ name: "", type: "uint256" }], stateMutability: "view", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }], name: "everHadExternalContributor", outputs: [{ name: "", type: "bool" }], stateMutability: "view", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }], name: "bountyVotingTracker", outputs: [{ name: "yes", type: "uint256" }, { name: "no", type: "uint256" }, { name: "deadline", type: "uint256" }], stateMutability: "view", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }], name: "bountyCurrentVotingClaim", outputs: [{ name: "", type: "uint256" }], stateMutability: "view", type: "function" },
+  { inputs: [{ name: "", type: "address" }], name: "pendingWithdrawals", outputs: [{ name: "", type: "uint256" }], stateMutability: "view", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }], name: "getParticipants", outputs: [{ name: "", type: "address[]" }, { name: "", type: "uint256[]" }], stateMutability: "view", type: "function" },
+] as const;
+
+// ─── Test: read contract constants ───────────────────────────────────────────
+
+async function testContractConstants() {
+  console.log("\n📋 Contract Constants");
+
+  const [minBounty, minContrib, feeBps, votePeriod] = await Promise.all([
+    readContract({ contract, method: "MIN_BOUNTY_AMOUNT" }),
+    readContract({ contract, method: "MIN_CONTRIBUTION" }),
+    readContract({ contract, method: "FEE_BPS" }),
+    readContract({ contract, method: "votingPeriod" }),
+  ]);
+
+  await expect(feeBps, (v) => v === 250n, `FEE_BPS is 250 (2.5%)`);
+  await expect(votePeriod, (v) => v === 172800n, `votingPeriod is 48h (172800s)`);
+  console.log(`  ℹ️  MIN_BOUNTY_AMOUNT: ${formatEther(minBounty)} ETH`);
+  console.log(`  ℹ️  MIN_CONTRIBUTION:  ${formatEther(minContrib)} ETH`);
+}
+
+// ─── Test: Solo bounty create → claim → accept ───────────────────────────────
+
+async function testSoloBountyFlow() {
+  console.log("\n🪙 Solo Bounty Flow");
+
+  const lengthBefore = await readContract({ contract, method: "getBountiesLength" });
+
+  // Create solo bounty (account A)
+  await send(accountA, prepareContractCall({
+    contract,
+    method: "createSoloBounty",
+    params: ["Test Solo Bounty", "Integration test — gnars website"],
+    value: parseEther("0.001"),
+  }));
+
+  const bountyId = lengthBefore; // new bounty ID = previous length (0-indexed)
+  await expect(
+    await readContract({ contract, method: "getBountiesLength" }),
+    (v) => v === lengthBefore + 1n,
+    "Solo bounty created — length increased"
+  );
+
+  // Verify no external contributors yet
+  await expect(
+    await readContract({ contract, method: "everHadExternalContributor", args: [bountyId] }),
+    (v) => v === false,
+    "everHadExternalContributor = false (solo)"
+  );
+
+  // Create claim (account B)
+  await send(accountB, prepareContractCall({
+    contract,
+    method: "createClaim",
+    params: [bountyId, "My proof", "I did it!", ""],
+  }));
+  console.log(`  ✅ PASS [claim created by wallet B]`); passed++;
+
+  // Accept claim directly (solo bounty, no contributors → acceptClaim works)
+  await send(accountA, prepareContractCall({
+    contract,
+    method: "acceptClaim",
+    params: [bountyId, 0n],
+  }));
+  console.log(`  ✅ PASS [claim accepted by issuer]`); passed++;
+
+  // Winner (B) should have pending withdrawal balance
+  const pending = await readContract({ contract, method: "pendingWithdrawals", args: [accountB.address as `0x${string}`] });
+  await expect(pending, (v) => v > 0n, `Winner has pending withdrawal (${formatEther(pending)} ETH after fee)`);
+
+  // Withdraw the winnings
+  await send(accountB, prepareContractCall({ contract, method: "withdraw", params: [] }));
+  const pendingAfter = await readContract({ contract, method: "pendingWithdrawals", args: [accountB.address as `0x${string}`] });
+  await expect(pendingAfter, (v) => v === 0n, "Pending balance cleared after withdraw");
+}
+
+// ─── Test: Open bounty create → join → submit for vote → vote → resolve ──────
+
+async function testOpenBountyVoteFlow() {
+  console.log("\n🗳️  Open Bounty Vote Flow");
+
+  const lengthBefore = await readContract({ contract, method: "getBountiesLength" });
+
+  // Create open bounty (account A)
+  await send(accountA, prepareContractCall({
+    contract,
+    method: "createOpenBounty",
+    params: ["Open Gnars Challenge", "Multiplayer test"],
+    value: parseEther("0.001"),
+  }));
+  const bountyId = lengthBefore;
+  console.log(`  ✅ PASS [open bounty created — id ${bountyId}]`); passed++;
+
+  // Account B joins
+  await send(accountB, prepareContractCall({
+    contract,
+    method: "joinOpenBounty",
+    params: [bountyId],
+    value: parseEther("0.001"),
+  }));
+  console.log(`  ✅ PASS [wallet B joined open bounty]`); passed++;
+
+  // Now everHadExternalContributor should be true
+  await expect(
+    await readContract({ contract, method: "everHadExternalContributor", args: [bountyId] }),
+    (v) => v === true,
+    "everHadExternalContributor = true after B joined"
+  );
+
+  // Account A creates a claim
+  await send(accountA, prepareContractCall({
+    contract,
+    method: "createClaim",
+    params: [bountyId, "A's proof", "Gnars proof by A", ""],
+  }));
+  const claimId = 0n;
+
+  // acceptClaim should now REVERT because everHadExternalContributor = true
+  await expectRevert(
+    () => send(accountA, prepareContractCall({
+      contract,
+      method: "acceptClaim",
+      params: [bountyId, claimId],
+    })),
+    "acceptClaim reverts when open bounty had contributors"
+  );
+
+  // Submit claim for vote (A submits their own claim)
+  await send(accountA, prepareContractCall({
+    contract,
+    method: "submitClaimForVote",
+    params: [bountyId, claimId],
+  }));
+  console.log(`  ✅ PASS [claim submitted for vote]`); passed++;
+
+  // Check vote tracker has a deadline
+  const tracker = await readContract({ contract, method: "bountyVotingTracker", args: [bountyId] });
+  await expect(tracker[2], (v) => v > 0n, "Vote deadline set after submitClaimForVote");
+
+  // Vote YES (account A), Vote NO (account B)
+  await send(accountA, prepareContractCall({ contract, method: "voteClaim", params: [bountyId, true] }));
+  await send(accountB, prepareContractCall({ contract, method: "voteClaim", params: [bountyId, false] }));
+  console.log(`  ✅ PASS [A voted yes, B voted no]`); passed++;
+
+  const trackerAfter = await readContract({ contract, method: "bountyVotingTracker", args: [bountyId] });
+  await expect(trackerAfter[0], (v) => v > 0n, "Yes weight > 0 after A voted");
+  await expect(trackerAfter[1], (v) => v > 0n, "No weight > 0 after B voted");
+
+  // Advance Anvil time past 48h voting period
+  await advanceAnvilTime(48 * 3600 + 60);
+
+  // Resolve vote
+  await send(accountA, prepareContractCall({ contract, method: "resolveVote", params: [bountyId] }));
+  console.log(`  ✅ PASS [vote resolved]`); passed++;
+}
+
+// ─── Test: Cancel open bounty → contributors claim refund ────────────────────
+
+async function testCancelAndRefundFlow() {
+  console.log("\n❌ Cancel + Refund Flow");
+
+  const lengthBefore = await readContract({ contract, method: "getBountiesLength" });
+
+  await send(accountA, prepareContractCall({
+    contract,
+    method: "createOpenBounty",
+    params: ["Refund Test Bounty", "Will be cancelled"],
+    value: parseEther("0.001"),
+  }));
+  const bountyId = lengthBefore;
+
+  await send(accountB, prepareContractCall({
+    contract,
+    method: "joinOpenBounty",
+    params: [bountyId],
+    value: parseEther("0.001"),
+  }));
+
+  // Issuer cancels
+  await send(accountA, prepareContractCall({
+    contract,
+    method: "cancelOpenBounty",
+    params: [bountyId],
+  }));
+  console.log(`  ✅ PASS [open bounty cancelled by issuer]`); passed++;
+
+  // withdrawFromOpenBounty should REVERT on a cancelled bounty
+  await expectRevert(
+    () => send(accountB, prepareContractCall({
+      contract,
+      method: "withdrawFromOpenBounty",
+      params: [bountyId],
+    })),
+    "withdrawFromOpenBounty reverts on cancelled bounty"
+  );
+
+  // claimRefundFromCancelledOpenBounty should succeed
+  await send(accountB, prepareContractCall({
+    contract,
+    method: "claimRefundFromCancelledOpenBounty",
+    params: [bountyId],
+  }));
+  console.log(`  ✅ PASS [contributor claimed refund via claimRefundFromCancelledOpenBounty]`); passed++;
+}
+
+// ─── Test: Edge cases ─────────────────────────────────────────────────────────
+
+async function testEdgeCases() {
+  console.log("\n⚠️  Edge Cases");
+
+  const lengthBefore = await readContract({ contract, method: "getBountiesLength" });
+  await send(accountA, prepareContractCall({
+    contract,
+    method: "createSoloBounty",
+    params: ["Edge Case Bounty", "For edge case tests"],
+    value: parseEther("0.001"),
+  }));
+  const bountyId = lengthBefore;
+
+  // Non-creator cannot accept a claim on behalf of creator
+  await send(accountB, prepareContractCall({
+    contract,
+    method: "createClaim",
+    params: [bountyId, "B's claim", "B tries to accept their own claim", ""],
+  }));
+  await expectRevert(
+    () => send(accountB, prepareContractCall({
+      contract,
+      method: "acceptClaim",
+      params: [bountyId, 0n],
+    })),
+    "Non-issuer cannot accept claim"
+  );
+
+  // Non-participant cannot vote
+  await send(accountA, prepareContractCall({
+    contract,
+    method: "createOpenBounty",
+    params: ["Vote Edge Case", "Only participants vote"],
+    value: parseEther("0.001"),
+  }));
+  const openBountyId = lengthBefore + 1n;
+  await send(accountB, prepareContractCall({ contract, method: "joinOpenBounty", params: [openBountyId], value: parseEther("0.001") }));
+  await send(accountA, prepareContractCall({ contract, method: "createClaim", params: [openBountyId, "Claim", "Proof", ""] }));
+  await send(accountA, prepareContractCall({ contract, method: "submitClaimForVote", params: [openBountyId, 0n] }));
+
+  // Create a third account (no contribution) and try to vote — should revert
+  const accountC = privateKeyToAccount({ client, privateKey: "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a" });
+  await expectRevert(
+    () => send(accountC, prepareContractCall({ contract, method: "voteClaim", params: [openBountyId, true] })),
+    "Non-participant cannot vote"
+  );
+
+  // AA wallet edge case — V3 requires msg.sender == tx.origin (EOA only)
+  // We cannot deploy a test contract here, but document the behavior:
+  console.log("  ℹ️  AA/Contract wallet note: V3 requires msg.sender == tx.origin for bounty creation.");
+  console.log("      Smart contract wallets (Gnosis Safe, AA) will be blocked at the contract level.");
+  console.log("      This is enforced on-chain — no UI mitigation needed beyond showing a clear error.");
+}
+
+// ─── Anvil time helpers ───────────────────────────────────────────────────────
+
+async function advanceAnvilTime(seconds: number) {
+  try {
+    await fetch(RPC_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "evm_increaseTime", params: [seconds], id: 1 }),
+    });
+    await fetch(RPC_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "evm_mine", params: [], id: 2 }),
+    });
+    console.log(`  ℹ️  Anvil time advanced by ${seconds}s`);
+  } catch {
+    console.log(`  ⚠️  Could not advance time (not running against Anvil?) — skipping time-dependent test`);
+  }
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log("🔵 POIDH V3 Integration Tests");
+  console.log(`   RPC:      ${RPC_URL}`);
+  console.log(`   Contract: ${POIDH_CONTRACT_ADDR}`);
+  console.log(`   Wallet A: ${accountA.address}`);
+  console.log(`   Wallet B: ${accountB.address}`);
+
+  try {
+    await testContractConstants();
+    await testSoloBountyFlow();
+    await testOpenBountyVoteFlow();
+    await testCancelAndRefundFlow();
+    await testEdgeCases();
+  } catch (err) {
+    console.error("\n💥 Unexpected error:", err);
+    failed++;
+  }
+
+  console.log(`\n─────────────────────────────────`);
+  console.log(`✅ ${passed} passed   ❌ ${failed} failed`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main();
+```
+
+- [ ] **Step 2: Verify the script parses without TypeScript errors**
+
+```bash
+npx tsc --noEmit --allowImportingTsExtensions scripts/test-poidh.ts 2>&1 | head -30
+```
+
+If tsx is not installed:
+```bash
+pnpm add -D tsx
+```
+
+- [ ] **Step 3: Run against Anvil fork (requires Anvil running)**
+
+```bash
+# In a separate terminal first:
+# anvil --fork-url https://mainnet.base.org --chain-id 8453
+
+npx tsx scripts/test-poidh.ts
+```
+
+Expected output: all tests pass (✅), exit code 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/test-poidh.ts
+git commit -m "test(poidh): add full integration test script with thirdweb wallets and edge cases"
+```
+
+---
+
+## Self-Review Checklist
+
+- [x] **Spec coverage:** All P0 (voteClaim, resolveVote), P1 (claimRefund, getBounty), P2 (everHadExternalContributor, VoteDashboard), P3 (pendingWithdrawals, resetVotingPeriod) items covered.
+- [x] **No placeholders:** All steps contain exact code or commands.
+- [x] **Type consistency:** `usePoidhVoteClaim.vote(bountyId, accept)` — two params throughout. `usePoidhResolveVote.resolve(bountyId)` — one param throughout. `claimRefundHook.claimRefund(bountyId)` consistent across Task 2 and Task 5.
+- [x] **ABI matches call sites:** `voteClaim` → `[BigInt(id), accept]`; `resolveVote` → `[BigInt(id)]` everywhere.
+- [x] **No new dependencies introduced** (VoteDashboard uses wagmi + existing UI primitives; test script uses thirdweb v5 which is already in the project).

--- a/scripts/test-poidh.ts
+++ b/scripts/test-poidh.ts
@@ -1,0 +1,539 @@
+/**
+ * POIDH V3 Integration Test Script
+ *
+ * Tests the full contract flow using two thirdweb private-key wallets.
+ * Designed to run against a local Anvil fork of Base mainnet so no real ETH is spent.
+ *
+ * Prerequisites:
+ *   1. Install Foundry:  curl -L https://foundry.paradigm.xyz | bash && foundryup
+ *   2. Start Anvil:      anvil --fork-url https://mainnet.base.org --chain-id 8453
+ *   3. Run this script:  npx tsx scripts/test-poidh.ts
+ *
+ * Env vars (all optional — defaults use Anvil's deterministic funded accounts):
+ *   POIDH_RPC_URL         RPC endpoint (default: http://127.0.0.1:8545)
+ *   THIRDWEB_SECRET_KEY   Thirdweb secret key (optional, uses clientId mode if omitted)
+ *   POIDH_KEY_A           Private key for wallet A / issuer  (default: Anvil account 0)
+ *   POIDH_KEY_B           Private key for wallet B / claimer (default: Anvil account 1)
+ *   POIDH_KEY_C           Private key for wallet C / non-participant edge case (default: Anvil account 2)
+ */
+
+import {
+  createThirdwebClient,
+  getContract,
+  prepareContractCall,
+  sendTransaction,
+  waitForReceipt,
+  readContract,
+} from "thirdweb";
+import { privateKeyToAccount } from "thirdweb/wallets";
+import { defineChain } from "thirdweb/chains";
+import { formatEther, parseEther } from "viem";
+
+// ─── Config ──────────────────────────────────────────────────────────────────
+
+const RPC_URL = process.env.POIDH_RPC_URL ?? "http://127.0.0.1:8545";
+const POIDH_CONTRACT_ADDR = "0x5555fa783936c260f77385b4e153b9725fef1719" as `0x${string}`;
+
+// Anvil deterministic funded accounts (from default mnemonic "test test test ... junk")
+const DEFAULT_KEY_A = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" as `0x${string}`;
+const DEFAULT_KEY_B = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d" as `0x${string}`;
+const DEFAULT_KEY_C = "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a" as `0x${string}`;
+
+const KEY_A = (process.env.POIDH_KEY_A ?? DEFAULT_KEY_A) as `0x${string}`;
+const KEY_B = (process.env.POIDH_KEY_B ?? DEFAULT_KEY_B) as `0x${string}`;
+const KEY_C = (process.env.POIDH_KEY_C ?? DEFAULT_KEY_C) as `0x${string}`;
+
+// ─── ABI (self-contained for script independence) ─────────────────────────────
+
+const POIDH_ABI = [
+  // Write
+  { inputs: [{ name: "name", type: "string" }, { name: "description", type: "string" }], name: "createSoloBounty", outputs: [], stateMutability: "payable", type: "function" },
+  { inputs: [{ name: "name", type: "string" }, { name: "description", type: "string" }], name: "createOpenBounty", outputs: [], stateMutability: "payable", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }], name: "joinOpenBounty", outputs: [], stateMutability: "payable", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }, { name: "name", type: "string" }, { name: "description", type: "string" }, { name: "imageUri", type: "string" }], name: "createClaim", outputs: [], stateMutability: "nonpayable", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }, { name: "claimId", type: "uint256" }], name: "acceptClaim", outputs: [], stateMutability: "nonpayable", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }, { name: "claimId", type: "uint256" }], name: "submitClaimForVote", outputs: [], stateMutability: "nonpayable", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }, { name: "vote", type: "bool" }], name: "voteClaim", outputs: [], stateMutability: "nonpayable", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }], name: "resolveVote", outputs: [], stateMutability: "nonpayable", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }], name: "cancelSoloBounty", outputs: [], stateMutability: "nonpayable", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }], name: "cancelOpenBounty", outputs: [], stateMutability: "nonpayable", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }], name: "withdrawFromOpenBounty", outputs: [], stateMutability: "nonpayable", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }], name: "claimRefundFromCancelledOpenBounty", outputs: [], stateMutability: "nonpayable", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }], name: "resetVotingPeriod", outputs: [], stateMutability: "nonpayable", type: "function" },
+  { inputs: [], name: "withdraw", outputs: [], stateMutability: "nonpayable", type: "function" },
+  // Read
+  { inputs: [], name: "getBountiesLength", outputs: [{ name: "", type: "uint256" }], stateMutability: "view", type: "function" },
+  { inputs: [], name: "MIN_BOUNTY_AMOUNT", outputs: [{ name: "", type: "uint256" }], stateMutability: "view", type: "function" },
+  { inputs: [], name: "MIN_CONTRIBUTION", outputs: [{ name: "", type: "uint256" }], stateMutability: "view", type: "function" },
+  { inputs: [], name: "FEE_BPS", outputs: [{ name: "", type: "uint256" }], stateMutability: "view", type: "function" },
+  { inputs: [], name: "votingPeriod", outputs: [{ name: "", type: "uint256" }], stateMutability: "view", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }], name: "everHadExternalContributor", outputs: [{ name: "", type: "bool" }], stateMutability: "view", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }], name: "bountyVotingTracker", outputs: [{ name: "yes", type: "uint256" }, { name: "no", type: "uint256" }, { name: "deadline", type: "uint256" }], stateMutability: "view", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }], name: "bountyCurrentVotingClaim", outputs: [{ name: "", type: "uint256" }], stateMutability: "view", type: "function" },
+  { inputs: [{ name: "", type: "address" }], name: "pendingWithdrawals", outputs: [{ name: "", type: "uint256" }], stateMutability: "view", type: "function" },
+  { inputs: [{ name: "bountyId", type: "uint256" }], name: "getParticipants", outputs: [{ name: "", type: "address[]" }, { name: "", type: "uint256[]" }], stateMutability: "view", type: "function" },
+] as const;
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+const baseFork = defineChain({ id: 8453, rpc: RPC_URL });
+const client = createThirdwebClient(
+  process.env.THIRDWEB_SECRET_KEY
+    ? { secretKey: process.env.THIRDWEB_SECRET_KEY }
+    : { clientId: "test-poidh-script" }
+);
+
+const accountA = privateKeyToAccount({ client, privateKey: KEY_A });
+const accountB = privateKeyToAccount({ client, privateKey: KEY_B });
+const accountC = privateKeyToAccount({ client, privateKey: KEY_C });
+
+const contract = getContract({ client, chain: baseFork, address: POIDH_CONTRACT_ADDR, abi: POIDH_ABI });
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+let passed = 0;
+let failed = 0;
+
+function pass(label: string) {
+  console.log(`  ✅ PASS [${label}]`);
+  passed++;
+}
+
+function fail(label: string, detail?: string) {
+  console.log(`  ❌ FAIL [${label}]${detail ? ` — ${detail}` : ''}`);
+  failed++;
+}
+
+function info(msg: string) {
+  console.log(`  ℹ️  ${msg}`);
+}
+
+async function send(account: typeof accountA, tx: ReturnType<typeof prepareContractCall>) {
+  const result = await sendTransaction({ account, transaction: tx });
+  await waitForReceipt({ client, chain: baseFork, transactionHash: result.transactionHash });
+  return result.transactionHash;
+}
+
+async function expectOk(fn: () => Promise<unknown>, label: string) {
+  try {
+    await fn();
+    pass(label);
+  } catch (err) {
+    fail(label, String(err).split('\n')[0]);
+  }
+}
+
+async function expectRevert(fn: () => Promise<unknown>, label: string) {
+  try {
+    await fn();
+    fail(label, "expected revert but tx succeeded");
+  } catch {
+    pass(label);
+  }
+}
+
+async function check<T>(actual: T, predicate: (v: T) => boolean, label: string, detail?: string) {
+  if (predicate(actual)) {
+    pass(label);
+  } else {
+    fail(label, detail ?? `got ${String(actual)}`);
+  }
+}
+
+// ─── Anvil time control ───────────────────────────────────────────────────────
+
+let anvilAvailable = false;
+
+async function advanceAnvilTime(seconds: number): Promise<boolean> {
+  try {
+    const r1 = await fetch(RPC_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "evm_increaseTime", params: [seconds], id: 1 }),
+    });
+    const j1 = await r1.json() as { error?: unknown };
+    if (j1.error) return false;
+    await fetch(RPC_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "evm_mine", params: [], id: 2 }),
+    });
+    info(`Time advanced +${seconds}s`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function detectAnvil() {
+  anvilAvailable = await advanceAnvilTime(1);
+  if (!anvilAvailable) {
+    info("evm_increaseTime not supported — time-dependent tests (vote resolution) will be skipped.");
+  }
+}
+
+// ─── Suite 1: Contract constants ─────────────────────────────────────────────
+
+async function testConstants() {
+  console.log("\n📋  Contract Constants");
+
+  const [minBounty, minContrib, feeBps, votePeriod] = await Promise.all([
+    readContract({ contract, method: "MIN_BOUNTY_AMOUNT" }),
+    readContract({ contract, method: "MIN_CONTRIBUTION" }),
+    readContract({ contract, method: "FEE_BPS" }),
+    readContract({ contract, method: "votingPeriod" }),
+  ]);
+
+  await check(feeBps, (v) => v === 250n, "FEE_BPS == 250 (2.5%)");
+  await check(votePeriod, (v) => v === 172800n, "votingPeriod == 172800s (48h)");
+  info(`MIN_BOUNTY_AMOUNT: ${formatEther(minBounty)} ETH`);
+  info(`MIN_CONTRIBUTION:  ${formatEther(minContrib)} ETH`);
+}
+
+// ─── Suite 2: Solo bounty — create → claim → direct accept → withdraw ─────────
+
+async function testSoloBountyFlow() {
+  console.log("\n🪙  Solo Bounty: create → claim → accept → withdraw");
+
+  const lengthBefore = await readContract({ contract, method: "getBountiesLength" });
+  const bountyId = lengthBefore;
+
+  // Create solo bounty (A is issuer)
+  await expectOk(
+    () => send(accountA, prepareContractCall({
+      contract, method: "createSoloBounty",
+      params: ["Gnars Test Solo", "Integration test"],
+      value: parseEther("0.001"),
+    })),
+    "createSoloBounty"
+  );
+  await check(
+    await readContract({ contract, method: "getBountiesLength" }),
+    (v) => v === lengthBefore + 1n,
+    "Bounty count incremented"
+  );
+
+  // No external contributors on a fresh solo bounty
+  await check(
+    await readContract({ contract, method: "everHadExternalContributor", args: [bountyId] }),
+    (v) => v === false,
+    "everHadExternalContributor == false (solo, no joiners)"
+  );
+
+  // B submits a claim
+  await expectOk(
+    () => send(accountB, prepareContractCall({
+      contract, method: "createClaim",
+      params: [bountyId, "B's proof", "Gnars solo test claim", ""],
+    })),
+    "createClaim (B)"
+  );
+
+  // A accepts directly (solo bounty, no contributors)
+  await expectOk(
+    () => send(accountA, prepareContractCall({
+      contract, method: "acceptClaim",
+      params: [bountyId, 0n],
+    })),
+    "acceptClaim (A accepts B's claim)"
+  );
+
+  // B should have a pending withdrawal (bounty amount minus 2.5% fee)
+  const pending = await readContract({ contract, method: "pendingWithdrawals", args: [accountB.address as `0x${string}`] });
+  await check(pending, (v) => v > 0n, `Winner has pending balance (${formatEther(pending)} ETH)`);
+
+  // B withdraws
+  await expectOk(
+    () => send(accountB, prepareContractCall({ contract, method: "withdraw", params: [] })),
+    "withdraw (B claims winnings)"
+  );
+  const pendingAfter = await readContract({ contract, method: "pendingWithdrawals", args: [accountB.address as `0x${string}`] });
+  await check(pendingAfter, (v) => v === 0n, "Pending balance == 0 after withdraw");
+}
+
+// ─── Suite 3: Open bounty — join → submit for vote → vote → resolve ───────────
+
+async function testOpenBountyVoteFlow() {
+  console.log("\n🗳️   Open Bounty: create → join → claim → vote → resolve");
+
+  const lengthBefore = await readContract({ contract, method: "getBountiesLength" });
+  const bountyId = lengthBefore;
+
+  // A creates open bounty
+  await expectOk(
+    () => send(accountA, prepareContractCall({
+      contract, method: "createOpenBounty",
+      params: ["Gnars Open Challenge", "Multiplayer integration test"],
+      value: parseEther("0.001"),
+    })),
+    "createOpenBounty (A)"
+  );
+
+  // B joins
+  await expectOk(
+    () => send(accountB, prepareContractCall({
+      contract, method: "joinOpenBounty",
+      params: [bountyId],
+      value: parseEther("0.001"),
+    })),
+    "joinOpenBounty (B)"
+  );
+
+  await check(
+    await readContract({ contract, method: "everHadExternalContributor", args: [bountyId] }),
+    (v) => v === true,
+    "everHadExternalContributor == true after B joined"
+  );
+
+  // A creates a claim
+  await expectOk(
+    () => send(accountA, prepareContractCall({
+      contract, method: "createClaim",
+      params: [bountyId, "A's skate proof", "Landed the kickflip", ""],
+    })),
+    "createClaim (A)"
+  );
+  const claimId = 0n;
+
+  // acceptClaim must revert when everHadExternalContributor is true
+  await expectRevert(
+    () => send(accountA, prepareContractCall({
+      contract, method: "acceptClaim",
+      params: [bountyId, claimId],
+    })),
+    "acceptClaim reverts — open bounty with contributor must use vote flow"
+  );
+
+  // Submit claim for vote
+  await expectOk(
+    () => send(accountA, prepareContractCall({
+      contract, method: "submitClaimForVote",
+      params: [bountyId, claimId],
+    })),
+    "submitClaimForVote (A)"
+  );
+
+  // Verify vote deadline is set
+  const tracker = await readContract({ contract, method: "bountyVotingTracker", args: [bountyId] });
+  await check(tracker[2], (v) => v > 0n, "Vote deadline set (bountyVotingTracker.deadline > 0)");
+  info(`Vote deadline: ${new Date(Number(tracker[2]) * 1000).toISOString()}`);
+
+  // Both A and B vote
+  await expectOk(
+    () => send(accountA, prepareContractCall({ contract, method: "voteClaim", params: [bountyId, true] })),
+    "voteClaim YES (A)"
+  );
+  await expectOk(
+    () => send(accountB, prepareContractCall({ contract, method: "voteClaim", params: [bountyId, false] })),
+    "voteClaim NO (B)"
+  );
+
+  const trackerAfter = await readContract({ contract, method: "bountyVotingTracker", args: [bountyId] });
+  await check(trackerAfter[0], (v) => v > 0n, "Yes weight > 0 after A voted");
+  await check(trackerAfter[1], (v) => v > 0n, "No weight > 0 after B voted");
+  info(`Votes — Yes: ${formatEther(trackerAfter[0])} ETH  No: ${formatEther(trackerAfter[1])} ETH`);
+
+  if (!anvilAvailable) {
+    info("Skipping resolveVote — requires Anvil time advance past 48h voting period.");
+    return;
+  }
+
+  // Advance time past 48h voting period
+  await advanceAnvilTime(48 * 3600 + 60);
+
+  await expectOk(
+    () => send(accountA, prepareContractCall({ contract, method: "resolveVote", params: [bountyId] })),
+    "resolveVote (after 48h)"
+  );
+
+  // If yes > no, the claim is accepted and A has pending winnings
+  const pendingA = await readContract({ contract, method: "pendingWithdrawals", args: [accountA.address as `0x${string}`] });
+  info(`Pending for A after resolve: ${formatEther(pendingA)} ETH`);
+}
+
+// ─── Suite 4: Cancel open bounty → contributor claims refund ──────────────────
+
+async function testCancelRefundFlow() {
+  console.log("\n❌  Cancel Open Bounty + Refund");
+
+  const lengthBefore = await readContract({ contract, method: "getBountiesLength" });
+  const bountyId = lengthBefore;
+
+  await expectOk(
+    () => send(accountA, prepareContractCall({
+      contract, method: "createOpenBounty",
+      params: ["Cancellable Bounty", "Will be cancelled"],
+      value: parseEther("0.001"),
+    })),
+    "createOpenBounty (to cancel)"
+  );
+
+  await expectOk(
+    () => send(accountB, prepareContractCall({
+      contract, method: "joinOpenBounty", params: [bountyId], value: parseEther("0.001"),
+    })),
+    "joinOpenBounty (B)"
+  );
+
+  // Issuer cancels
+  await expectOk(
+    () => send(accountA, prepareContractCall({ contract, method: "cancelOpenBounty", params: [bountyId] })),
+    "cancelOpenBounty (A)"
+  );
+
+  // withdrawFromOpenBounty must revert on a cancelled bounty
+  await expectRevert(
+    () => send(accountB, prepareContractCall({ contract, method: "withdrawFromOpenBounty", params: [bountyId] })),
+    "withdrawFromOpenBounty reverts on cancelled bounty"
+  );
+
+  // claimRefundFromCancelledOpenBounty is the correct call
+  await expectOk(
+    () => send(accountB, prepareContractCall({ contract, method: "claimRefundFromCancelledOpenBounty", params: [bountyId] })),
+    "claimRefundFromCancelledOpenBounty (B recovers funds)"
+  );
+
+  // Double-refund must revert
+  await expectRevert(
+    () => send(accountB, prepareContractCall({ contract, method: "claimRefundFromCancelledOpenBounty", params: [bountyId] })),
+    "Double claimRefund reverts"
+  );
+}
+
+// ─── Suite 5: resetVotingPeriod ───────────────────────────────────────────────
+
+async function testResetVotingPeriod() {
+  console.log("\n🔄  Reset Voting Period");
+
+  if (!anvilAvailable) {
+    info("Skipping — requires Anvil time advance.");
+    return;
+  }
+
+  const bountyId = await readContract({ contract, method: "getBountiesLength" });
+
+  // Create open bounty with B as contributor so vote flow is mandatory
+  await send(accountA, prepareContractCall({
+    contract, method: "createOpenBounty",
+    params: ["Reset Vote Test", "Vote period reset test"],
+    value: parseEther("0.001"),
+  }));
+  await send(accountB, prepareContractCall({ contract, method: "joinOpenBounty", params: [bountyId], value: parseEther("0.001") }));
+  await send(accountA, prepareContractCall({ contract, method: "createClaim", params: [bountyId, "Claim", "Proof", ""] }));
+  await send(accountA, prepareContractCall({ contract, method: "submitClaimForVote", params: [bountyId, 0n] }));
+
+  // Both vote NO → claim loses
+  await send(accountA, prepareContractCall({ contract, method: "voteClaim", params: [bountyId, false] }));
+  await send(accountB, prepareContractCall({ contract, method: "voteClaim", params: [bountyId, false] }));
+
+  await advanceAnvilTime(48 * 3600 + 60);
+
+  // resolveVote with all-no should revert or mark as not accepted and allow reset
+  // resetVotingPeriod reverts if the vote WOULD have passed — here it should succeed
+  await expectOk(
+    () => send(accountA, prepareContractCall({ contract, method: "resetVotingPeriod", params: [bountyId] })),
+    "resetVotingPeriod succeeds after failed vote"
+  );
+
+  // Verify vote tracker is cleared
+  const tracker = await readContract({ contract, method: "bountyVotingTracker", args: [bountyId] });
+  await check(tracker[2], (v) => v === 0n, "Vote deadline cleared after reset");
+}
+
+// ─── Suite 6: Edge cases ──────────────────────────────────────────────────────
+
+async function testEdgeCases() {
+  console.log("\n⚠️   Edge Cases");
+
+  const bountyId = await readContract({ contract, method: "getBountiesLength" });
+
+  await send(accountA, prepareContractCall({
+    contract, method: "createSoloBounty",
+    params: ["Edge Case Bounty", "For edge case tests"],
+    value: parseEther("0.001"),
+  }));
+  await send(accountB, prepareContractCall({
+    contract, method: "createClaim",
+    params: [bountyId, "B's edge case claim", "Testing access control", ""],
+  }));
+
+  // Non-creator cannot accept claim
+  await expectRevert(
+    () => send(accountB, prepareContractCall({ contract, method: "acceptClaim", params: [bountyId, 0n] })),
+    "Non-issuer cannot acceptClaim"
+  );
+
+  // Non-creator cannot cancel solo bounty
+  await expectRevert(
+    () => send(accountB, prepareContractCall({ contract, method: "cancelSoloBounty", params: [bountyId] })),
+    "Non-issuer cannot cancelSoloBounty"
+  );
+
+  // Non-participant cannot vote
+  const openBountyId = await readContract({ contract, method: "getBountiesLength" });
+  await send(accountA, prepareContractCall({
+    contract, method: "createOpenBounty",
+    params: ["Vote Access Test", "Only participants vote"],
+    value: parseEther("0.001"),
+  }));
+  await send(accountB, prepareContractCall({ contract, method: "joinOpenBounty", params: [openBountyId], value: parseEther("0.001") }));
+  await send(accountA, prepareContractCall({ contract, method: "createClaim", params: [openBountyId, "Claim", "Proof", ""] }));
+  await send(accountA, prepareContractCall({ contract, method: "submitClaimForVote", params: [openBountyId, 0n] }));
+
+  await expectRevert(
+    () => send(accountC, prepareContractCall({ contract, method: "voteClaim", params: [openBountyId, true] })),
+    "Non-participant cannot voteClaim"
+  );
+
+  // Cannot resolve vote before deadline
+  await expectRevert(
+    () => send(accountA, prepareContractCall({ contract, method: "resolveVote", params: [openBountyId] })),
+    "resolveVote reverts before voting deadline"
+  );
+
+  // Joining a cancelled bounty should revert
+  await send(accountA, prepareContractCall({ contract, method: "cancelOpenBounty", params: [openBountyId] }));
+  await expectRevert(
+    () => send(accountB, prepareContractCall({ contract, method: "joinOpenBounty", params: [openBountyId], value: parseEther("0.001") })),
+    "joinOpenBounty reverts on cancelled bounty"
+  );
+
+  // AA / contract wallet note
+  info("AA wallets: V3 enforces msg.sender == tx.origin for createSoloBounty/createOpenBounty.");
+  info("           Smart contract wallets (Gnosis Safe, ERC-4337 AA) will be rejected at the contract.");
+  info("           The UI should surface this error clearly — the hook error message will contain 'origin'.");
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log("=".repeat(60));
+  console.log("  POIDH V3 Integration Tests");
+  console.log("=".repeat(60));
+  console.log(`  RPC:      ${RPC_URL}`);
+  console.log(`  Contract: ${POIDH_CONTRACT_ADDR}`);
+  console.log(`  Wallet A (issuer):      ${accountA.address}`);
+  console.log(`  Wallet B (contributor): ${accountB.address}`);
+  console.log(`  Wallet C (outsider):    ${accountC.address}`);
+
+  await detectAnvil();
+
+  try {
+    await testConstants();
+    await testSoloBountyFlow();
+    await testOpenBountyVoteFlow();
+    await testCancelRefundFlow();
+    await testResetVotingPeriod();
+    await testEdgeCases();
+  } catch (err) {
+    console.error("\n💥 Unexpected error:", err);
+    failed++;
+  }
+
+  console.log("\n" + "=".repeat(60));
+  console.log(`  Results: ✅ ${passed} passed   ❌ ${failed} failed`);
+  console.log("=".repeat(60));
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main();

--- a/src/components/bounties/BountiesView.tsx
+++ b/src/components/bounties/BountiesView.tsx
@@ -11,6 +11,7 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { formatEther } from 'viem';
 import { useEthPrice, formatEthToUsd } from '@/hooks/use-eth-price';
 import type { PoidhBounty } from '@/types/poidh';
+import { PendingWithdrawalBanner } from '@/components/bounties/PendingWithdrawalBanner';
 
 const CATEGORIES = [
   { key: 'all', label: 'All' },
@@ -76,6 +77,7 @@ export function BountiesView({ initialBounties }: BountiesViewProps) {
   return (
     <div className="container mx-auto px-4 py-8 max-w-7xl">
       <div className="space-y-6">
+        <PendingWithdrawalBanner />
         {/* Header */}
         <div className="flex items-start justify-between gap-4">
           <div>

--- a/src/components/bounties/BountyDetailView.tsx
+++ b/src/components/bounties/BountyDetailView.tsx
@@ -32,7 +32,17 @@ import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog';
 import { ClaimBountyModal } from '@/components/bounties/ClaimBountyModal';
 import { MediaEmbed } from '@/components/bounties/MediaEmbed';
 import { AddressDisplay } from '@/components/ui/address-display';
-import { usePoidhCancelBounty, usePoidhJoinBounty, usePoidhWithdrawFromBounty, usePoidhAcceptClaim, usePoidhSubmitClaimForVote, usePoidhVoteClaim, usePoidhResolveVote } from '@/hooks/usePoidhContract';
+import {
+  usePoidhCancelBounty,
+  usePoidhJoinBounty,
+  usePoidhClaimRefundFromCancelledBounty,
+  usePoidhAcceptClaim,
+  usePoidhSubmitClaimForVote,
+  usePoidhVoteClaim,
+  usePoidhResolveVote,
+  usePoidhResetVotingPeriod,
+} from '@/hooks/usePoidhContract';
+import { VoteDashboard } from '@/components/bounties/VoteDashboard';
 import { POIDH_ABI } from '@/lib/poidh/abi';
 import { useEthPrice, formatEthToUsd } from '@/hooks/use-eth-price';
 import { useUserAddress } from '@/hooks/use-user-address';
@@ -166,25 +176,17 @@ export function BountyDetailView({ initialBounty, chainId, bountyId }: BountyDet
 
   const cancelHook = usePoidhCancelBounty(chainId);
   const joinHook = usePoidhJoinBounty(chainId);
-  const withdrawHook = usePoidhWithdrawFromBounty(chainId);
+  const claimRefundHook = usePoidhClaimRefundFromCancelledBounty(chainId);
   const acceptClaimHook = usePoidhAcceptClaim(chainId);
   const submitForVoteHook = usePoidhSubmitClaimForVote(chainId);
   const voteClaimHook = usePoidhVoteClaim(chainId);
   const resolveVoteHook = usePoidhResolveVote(chainId);
+  const resetVotingHook = usePoidhResetVotingPeriod(chainId);
 
   const deadlineTimestamp = bounty?.deadline ?? null;
   const countdown = useCountdown(deadlineTimestamp);
 
-  // Read the authoritative on-chain isOpenBounty flag (overrides API field which can be null on V2)
-  const { data: onChainBountyData } = useReadContract({
-    address: POIDH_CONTRACTS[chainId],
-    abi: POIDH_ABI,
-    functionName: 'getBounty',
-    args: [BigInt(bounty?.onChainId ?? 0)],
-    chainId,
-    query: { enabled: !!(bounty?.onChainId) },
-  });
-  const isJoinable = onChainBountyData ? onChainBountyData.isOpenBounty : (bounty?.isOpenBounty || bounty?.isMultiplayer);
+  const isJoinable = bounty?.isOpenBounty || bounty?.isMultiplayer;
 
 
   const { data: participantsData } = useReadContract({
@@ -197,6 +199,15 @@ export function BountyDetailView({ initialBounty, chainId, bountyId }: BountyDet
   });
   const participants = participantsData?.[0] as `0x${string}`[] | undefined;
   const participantAmounts = participantsData?.[1] as bigint[] | undefined;
+
+  const { data: hadExternalContributor } = useReadContract({
+    address: POIDH_CONTRACTS[chainId],
+    abi: POIDH_ABI,
+    functionName: 'everHadExternalContributor',
+    args: [BigInt(bounty?.onChainId ?? 0)],
+    chainId,
+    query: { enabled: !!(bounty?.onChainId) },
+  });
 
   if (!bounty) return null;
 
@@ -447,8 +458,8 @@ export function BountyDetailView({ initialBounty, chainId, bountyId }: BountyDet
                           </>
                         )}
                       </div>
-                      {/* Accept button (creator only, if not already accepted) */}
-                      {isCreator && !claim.accepted && !bounty.isCanceled && (
+                      {/* Accept button (creator only, solo bounties or open bounties with no contributors) */}
+                      {isCreator && !claim.accepted && !bounty.isCanceled && !hadExternalContributor && (
                         <Button
                           size="sm"
                           variant="default"
@@ -464,6 +475,12 @@ export function BountyDetailView({ initialBounty, chainId, bountyId }: BountyDet
                             'Accept Claim'
                           )}
                         </Button>
+                      )}
+                      {/* Guide issuer to use vote flow when open bounty had contributors */}
+                      {isCreator && !claim.accepted && !bounty.isCanceled && hadExternalContributor && !bounty.isVoting && (
+                        <p className="text-xs text-muted-foreground">
+                          Use <strong>Submit for Vote</strong> — contributors must vote to accept.
+                        </p>
                       )}
                     </div>
                     {/* Accept success message */}
@@ -519,7 +536,7 @@ export function BountyDetailView({ initialBounty, chainId, bountyId }: BountyDet
                             variant="outline"
                             className="flex-1 border-emerald-500/30 text-emerald-500 hover:bg-emerald-500/10"
                             disabled={voteClaimHook.isPending}
-                            onClick={() => voteClaimHook.vote(bounty.onChainId, claim.id, true)}
+                            onClick={() => voteClaimHook.vote(bounty.onChainId, true)}
                           >
                             {voteClaimHook.isPending ? (
                               <Loader2 className="w-3 h-3 animate-spin" />
@@ -532,7 +549,7 @@ export function BountyDetailView({ initialBounty, chainId, bountyId }: BountyDet
                             variant="outline"
                             className="flex-1 border-red-500/30 text-red-500 hover:bg-red-500/10"
                             disabled={voteClaimHook.isPending}
-                            onClick={() => voteClaimHook.vote(bounty.onChainId, claim.id, false)}
+                            onClick={() => voteClaimHook.vote(bounty.onChainId, false)}
                           >
                             {voteClaimHook.isPending ? (
                               <Loader2 className="w-3 h-3 animate-spin" />
@@ -562,7 +579,7 @@ export function BountyDetailView({ initialBounty, chainId, bountyId }: BountyDet
                           variant="outline"
                           className="w-full"
                           disabled={resolveVoteHook.isPending}
-                          onClick={() => resolveVoteHook.resolve(bounty.onChainId, claim.id)}
+                          onClick={() => resolveVoteHook.resolve(bounty.onChainId)}
                         >
                           {resolveVoteHook.isPending ? (
                             <><Loader2 className="w-3 h-3 mr-1 animate-spin" />{resolveVoteHook.hash ? 'Confirming…' : 'Confirm in wallet…'}</>
@@ -583,6 +600,34 @@ export function BountyDetailView({ initialBounty, chainId, bountyId }: BountyDet
                             <CheckCircle2 className="w-3 h-3 shrink-0" />
                             <span>Vote resolved!</span>
                             <a href={getTxUrl(chainId, resolveVoteHook.hash)} target="_blank" rel="noopener noreferrer" className="ml-auto flex items-center gap-1 hover:underline">
+                              View tx <ExternalLink className="w-3 h-3" />
+                            </a>
+                          </div>
+                        )}
+                        {/* Reset voting period — recovery if vote failed (contract reverts if vote would have passed) */}
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          className="w-full text-xs text-muted-foreground"
+                          disabled={resetVotingHook.isPending}
+                          onClick={() => resetVotingHook.resetVoting(bounty.onChainId)}
+                        >
+                          {resetVotingHook.isPending
+                            ? <><Loader2 className="w-3 h-3 mr-1 animate-spin" />Resetting…</>
+                            : 'Reset voting period (if vote failed)'
+                          }
+                        </Button>
+                        {resetVotingHook.error && (
+                          <div className="flex items-start gap-2 rounded-md bg-destructive/10 border border-destructive/20 px-2 py-1.5 text-xs text-destructive">
+                            <AlertCircle className="w-3 h-3 shrink-0 mt-0.5" />
+                            <span>{resetVotingHook.error.message.split('\n')[0]}</span>
+                          </div>
+                        )}
+                        {resetVotingHook.isSuccess && resetVotingHook.hash && (
+                          <div className="flex items-center gap-2 py-1.5 px-2 rounded-md bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 text-xs">
+                            <CheckCircle2 className="w-3 h-3 shrink-0" />
+                            <span>Voting period reset.</span>
+                            <a href={getTxUrl(chainId, resetVotingHook.hash)} target="_blank" rel="noopener noreferrer" className="ml-auto flex items-center gap-1 hover:underline">
                               View tx <ExternalLink className="w-3 h-3" />
                             </a>
                           </div>
@@ -696,7 +741,7 @@ joinHook.join(bounty.onChainId, joinAmount);
             </Card>
           )}
 
-          {/* Withdraw from canceled bounty (participant) */}
+          {/* Withdraw from canceled bounty (contributor pull-payment) */}
           {bounty.isCanceled && isJoinable && !isCreator && (
             <Card className="border-border">
               <CardHeader className="pb-3">
@@ -704,26 +749,30 @@ joinHook.join(bounty.onChainId, joinAmount);
                 <CardDescription>This bounty was canceled. Recover your contribution.</CardDescription>
               </CardHeader>
               <CardContent className="space-y-3">
-                {withdrawHook.isSuccess ? (
+                {claimRefundHook.isSuccess ? (
                   <div className="flex flex-col items-center gap-2 py-2 text-center">
                     <CheckCircle2 className="w-8 h-8 text-emerald-500" />
                     <p className="text-sm font-medium">Withdrawal confirmed!</p>
-                    {withdrawHook.hash && (
-                      <a href={getTxUrl(chainId, withdrawHook.hash)} target="_blank" rel="noopener noreferrer" className="flex items-center gap-1 text-xs text-primary hover:underline">
+                    {claimRefundHook.hash && (
+                      <a href={getTxUrl(chainId, claimRefundHook.hash)} target="_blank" rel="noopener noreferrer" className="flex items-center gap-1 text-xs text-primary hover:underline">
                         View tx <ExternalLink className="w-3 h-3" />
                       </a>
                     )}
                   </div>
                 ) : (
                   <>
-                    {withdrawHook.error && (
+                    {claimRefundHook.error && (
                       <div className="flex items-start gap-2 rounded-md bg-destructive/10 border border-destructive/20 px-3 py-2 text-sm text-destructive">
                         <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" />
-                        <span>{withdrawHook.error.message.split('\n')[0]}</span>
+                        <span>{claimRefundHook.error.message.split('\n')[0]}</span>
                       </div>
                     )}
-                    <Button variant="outline" className="w-full" disabled={withdrawHook.isPending} onClick={() => withdrawHook.withdraw(bounty.onChainId)}>
-                      {withdrawHook.isPending ? <><Loader2 className="w-4 h-4 mr-2 animate-spin" />{withdrawHook.hash ? 'Confirming…' : 'Confirm in wallet…'}</> : 'Withdraw Funds'}
+                    <Button variant="outline" className="w-full" disabled={claimRefundHook.isPending}
+                            onClick={() => claimRefundHook.claimRefund(bounty.onChainId)}>
+                      {claimRefundHook.isPending
+                        ? <><Loader2 className="w-4 h-4 mr-2 animate-spin" />{claimRefundHook.hash ? 'Confirming…' : 'Confirm in wallet…'}</>
+                        : 'Withdraw Funds'
+                      }
                     </Button>
                   </>
                 )}
@@ -775,6 +824,11 @@ joinHook.join(bounty.onChainId, joinAmount);
             </Card>
           )}
 
+
+          {/* Vote Dashboard — live yes/no tallies and deadline */}
+          {bounty.isVoting && bounty.onChainId > 0 && (
+            <VoteDashboard chainId={chainId} onChainBountyId={bounty.onChainId} />
+          )}
 
           {/* Bounty Details */}
           <Card>

--- a/src/components/bounties/PendingWithdrawalBanner.tsx
+++ b/src/components/bounties/PendingWithdrawalBanner.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useReadContract } from 'wagmi';
+import { formatEther } from 'viem';
+import { Wallet, Loader2, CheckCircle2, ExternalLink, AlertCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { POIDH_ABI } from '@/lib/poidh/abi';
+import { POIDH_CONTRACTS, CHAIN_NAMES, getTxUrl, SUPPORTED_CHAINS } from '@/lib/poidh/config';
+import { usePoidhWithdraw } from '@/hooks/usePoidhContract';
+import { useUserAddress } from '@/hooks/use-user-address';
+
+interface ChainBannerProps {
+  chainId: number;
+  userAddress: `0x${string}`;
+}
+
+function ChainWithdrawalBanner({ chainId, userAddress }: ChainBannerProps) {
+  const contractAddress = POIDH_CONTRACTS[chainId];
+  const chainName = CHAIN_NAMES[chainId as keyof typeof CHAIN_NAMES];
+  const { withdraw, isPending, isSuccess, hash, error } = usePoidhWithdraw(chainId);
+
+  const { data: pending, refetch } = useReadContract({
+    address: contractAddress,
+    abi: POIDH_ABI,
+    functionName: 'pendingWithdrawals',
+    args: [userAddress],
+    chainId,
+    query: { enabled: !!contractAddress, refetchInterval: 30_000 },
+  });
+
+  if (isSuccess) void refetch();
+
+  if (!pending || pending === 0n) return null;
+
+  const ethAmount = parseFloat(formatEther(pending)).toFixed(6);
+
+  return (
+    <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3 p-3 rounded-md border border-amber-500/30 bg-amber-500/10 text-sm">
+      <Wallet className="w-4 h-4 text-amber-400 shrink-0 mt-0.5 sm:mt-0" />
+      <div className="flex-1 min-w-0">
+        <span className="font-medium text-amber-300">
+          {ethAmount} ETH claimable on {chainName}
+        </span>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          From bounty winnings or a cancelled open bounty.
+        </p>
+      </div>
+
+      {isSuccess ? (
+        <div className="flex items-center gap-1.5 text-emerald-400 text-xs shrink-0">
+          <CheckCircle2 className="w-4 h-4" />
+          <span>Withdrawn!</span>
+          {hash && (
+            <a
+              href={getTxUrl(chainId, hash)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-0.5 hover:underline ml-1"
+            >
+              Tx <ExternalLink className="w-3 h-3" />
+            </a>
+          )}
+        </div>
+      ) : (
+        <div className="flex flex-col items-end gap-1 shrink-0">
+          <Button
+            size="sm"
+            variant="outline"
+            className="border-amber-500/40 text-amber-300 hover:bg-amber-500/10 whitespace-nowrap"
+            disabled={isPending}
+            onClick={() => withdraw()}
+          >
+            {isPending ? (
+              <><Loader2 className="w-3 h-3 mr-1.5 animate-spin" />Withdrawing…</>
+            ) : (
+              'Withdraw'
+            )}
+          </Button>
+          {error && (
+            <div className="flex items-start gap-1 text-destructive text-xs max-w-[12rem]">
+              <AlertCircle className="w-3 h-3 shrink-0 mt-0.5" />
+              <span className="break-words">{error.message.split('\n')[0]}</span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function PendingWithdrawalBanner() {
+  const { address, isConnected } = useUserAddress();
+
+  if (!isConnected || !address) return null;
+
+  return (
+    <div className="space-y-2 mb-4">
+      {Object.values(SUPPORTED_CHAINS).map((chainId) => (
+        <ChainWithdrawalBanner
+          key={chainId}
+          chainId={chainId}
+          userAddress={address as `0x${string}`}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/bounties/VoteDashboard.tsx
+++ b/src/components/bounties/VoteDashboard.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useReadContract } from 'wagmi';
+import { formatEther } from 'viem';
+import { Clock } from 'lucide-react';
+import { POIDH_ABI } from '@/lib/poidh/abi';
+import { POIDH_CONTRACTS } from '@/lib/poidh/config';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+function useDeadlineCountdown(deadlineSeconds: number): string {
+  const calc = () => {
+    if (!deadlineSeconds) return '';
+    const diff = deadlineSeconds * 1000 - Date.now();
+    if (diff <= 0) return 'Expired';
+    const hours = Math.floor(diff / 3_600_000);
+    const minutes = Math.floor((diff % 3_600_000) / 60_000);
+    if (hours > 0) return `${hours}h ${minutes}m`;
+    return `${minutes}m`;
+  };
+
+  const [label, setLabel] = useState(calc);
+
+  useEffect(() => {
+    if (!deadlineSeconds) return;
+    const id = setInterval(() => setLabel(calc()), 30_000);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deadlineSeconds]);
+
+  return label;
+}
+
+interface VoteDashboardProps {
+  chainId: number;
+  onChainBountyId: number;
+}
+
+export function VoteDashboard({ chainId, onChainBountyId }: VoteDashboardProps) {
+  const contractAddress = POIDH_CONTRACTS[chainId];
+
+  const { data: tracker } = useReadContract({
+    address: contractAddress,
+    abi: POIDH_ABI,
+    functionName: 'bountyVotingTracker',
+    args: [BigInt(onChainBountyId)],
+    chainId,
+    query: {
+      enabled: !!contractAddress && onChainBountyId > 0,
+      refetchInterval: 15_000,
+    },
+  });
+
+  const deadlineSec = tracker ? Number(tracker[2]) : 0;
+  const deadline = useDeadlineCountdown(deadlineSec);
+
+  if (!tracker || deadlineSec === 0) return null;
+
+  const yesWei = tracker[0];
+  const noWei  = tracker[1];
+  const yesEth = parseFloat(formatEther(yesWei));
+  const noEth  = parseFloat(formatEther(noWei));
+  const total  = yesEth + noEth;
+  const yesPercent = total > 0 ? Math.round((yesEth / total) * 100) : 50;
+  const isExpired  = deadlineSec * 1000 < Date.now();
+
+  return (
+    <Card className="border-yellow-500/20 bg-yellow-500/5">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base text-yellow-400">Live Vote</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {/* Yes / No labels */}
+        <div className="flex justify-between text-xs font-medium">
+          <span className="text-emerald-400">{yesEth.toFixed(4)} ETH Yes</span>
+          <span className="text-red-400">{noEth.toFixed(4)} ETH No</span>
+        </div>
+
+        {/* Progress bar */}
+        <div className="h-2 rounded-full bg-muted overflow-hidden">
+          <div
+            className="h-full bg-emerald-500 rounded-full transition-all duration-500"
+            style={{ width: `${yesPercent}%` }}
+          />
+        </div>
+
+        {/* Vote weight note */}
+        <p className="text-xs text-muted-foreground">
+          Weighted by ETH contribution — {total.toFixed(4)} ETH total
+        </p>
+
+        {/* Deadline */}
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground pt-1 border-t border-border/50">
+          <Clock className="w-3 h-3 shrink-0" />
+          <span>
+            {isExpired
+              ? 'Vote period ended — resolve when ready'
+              : `Vote closes in ${deadline}`}
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/usePoidhContract.ts
+++ b/src/hooks/usePoidhContract.ts
@@ -302,13 +302,13 @@ export function usePoidhVoteClaim(bountyChainId: number) {
   const state = usePoidhWriteState();
 
   const vote = useCallback(
-    async (onChainBountyId: number, claimId: number, accept: boolean) => {
+    async (onChainBountyId: number, accept: boolean) => {
       const { client, contractAddress, twChain, writer } = await assertPoidhReady(ctx, bountyChainId);
       const contract = getContract({ client, chain: twChain, address: contractAddress, abi: POIDH_ABI });
       const tx = prepareContractCall({
         contract,
         method: "voteClaim",
-        params: [BigInt(onChainBountyId), BigInt(claimId), accept],
+        params: [BigInt(onChainBountyId), accept],
       });
       await sendAndConfirm(state, client, twChain, writer, tx);
     },
@@ -325,13 +325,13 @@ export function usePoidhResolveVote(bountyChainId: number) {
   const state = usePoidhWriteState();
 
   const resolve = useCallback(
-    async (onChainBountyId: number, claimId: number) => {
+    async (onChainBountyId: number) => {
       const { client, contractAddress, twChain, writer } = await assertPoidhReady(ctx, bountyChainId);
       const contract = getContract({ client, chain: twChain, address: contractAddress, abi: POIDH_ABI });
       const tx = prepareContractCall({
         contract,
         method: "resolveVote",
-        params: [BigInt(onChainBountyId), BigInt(claimId)],
+        params: [BigInt(onChainBountyId)],
       });
       await sendAndConfirm(state, client, twChain, writer, tx);
     },
@@ -362,4 +362,73 @@ export function usePoidhAcceptClaim(bountyChainId: number) {
   );
 
   return { accept, ...buildPoidhReturn(state) };
+}
+
+// ─── Claim Refund from Cancelled Open Bounty (contributor pull-payment) ───────
+
+export function usePoidhClaimRefundFromCancelledBounty(bountyChainId: number) {
+  const ctx = usePoidhContext(bountyChainId);
+  const state = usePoidhWriteState();
+
+  const claimRefund = useCallback(
+    async (onChainBountyId: number) => {
+      const { client, contractAddress, twChain, writer } = await assertPoidhReady(ctx, bountyChainId);
+      const contract = getContract({ client, chain: twChain, address: contractAddress, abi: POIDH_ABI });
+      const tx = prepareContractCall({
+        contract,
+        method: "claimRefundFromCancelledOpenBounty",
+        params: [BigInt(onChainBountyId)],
+      });
+      await sendAndConfirm(state, client, twChain, writer, tx);
+    },
+    [ctx, bountyChainId, state],
+  );
+
+  return { claimRefund, ...buildPoidhReturn(state) };
+}
+
+// ─── Reset Voting Period (recovery after failed vote) ─────────────────────────
+
+export function usePoidhResetVotingPeriod(bountyChainId: number) {
+  const ctx = usePoidhContext(bountyChainId);
+  const state = usePoidhWriteState();
+
+  const resetVoting = useCallback(
+    async (onChainBountyId: number) => {
+      const { client, contractAddress, twChain, writer } = await assertPoidhReady(ctx, bountyChainId);
+      const contract = getContract({ client, chain: twChain, address: contractAddress, abi: POIDH_ABI });
+      const tx = prepareContractCall({
+        contract,
+        method: "resetVotingPeriod",
+        params: [BigInt(onChainBountyId)],
+      });
+      await sendAndConfirm(state, client, twChain, writer, tx);
+    },
+    [ctx, bountyChainId, state],
+  );
+
+  return { resetVoting, ...buildPoidhReturn(state) };
+}
+
+// ─── Withdraw pending balance (bounty winners, cancelled-bounty refunds) ──────
+
+export function usePoidhWithdraw(bountyChainId: number) {
+  const ctx = usePoidhContext(bountyChainId);
+  const state = usePoidhWriteState();
+
+  const withdraw = useCallback(
+    async () => {
+      const { client, contractAddress, twChain, writer } = await assertPoidhReady(ctx, bountyChainId);
+      const contract = getContract({ client, chain: twChain, address: contractAddress, abi: POIDH_ABI });
+      const tx = prepareContractCall({
+        contract,
+        method: "withdraw",
+        params: [],
+      });
+      await sendAndConfirm(state, client, twChain, writer, tx);
+    },
+    [ctx, bountyChainId, state],
+  );
+
+  return { withdraw, ...buildPoidhReturn(state) };
 }

--- a/src/lib/poidh/abi.ts
+++ b/src/lib/poidh/abi.ts
@@ -1,26 +1,11 @@
 export const POIDH_ABI = [
+  // ── Write functions ──────────────────────────────────────────────────────
   {
     "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "bountyId",
-        "type": "uint256"
-      },
-      {
-        "internalType": "string",
-        "name": "name",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "description",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "imageUri",
-        "type": "string"
-      }
+      { "internalType": "uint256", "name": "bountyId",    "type": "uint256" },
+      { "internalType": "string",  "name": "name",        "type": "string"  },
+      { "internalType": "string",  "name": "description", "type": "string"  },
+      { "internalType": "string",  "name": "imageUri",    "type": "string"  }
     ],
     "name": "createClaim",
     "outputs": [],
@@ -29,16 +14,8 @@ export const POIDH_ABI = [
   },
   {
     "inputs": [
-      {
-        "internalType": "string",
-        "name": "name",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "description",
-        "type": "string"
-      }
+      { "internalType": "string", "name": "name",        "type": "string" },
+      { "internalType": "string", "name": "description", "type": "string" }
     ],
     "name": "createSoloBounty",
     "outputs": [],
@@ -47,16 +24,8 @@ export const POIDH_ABI = [
   },
   {
     "inputs": [
-      {
-        "internalType": "string",
-        "name": "name",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "description",
-        "type": "string"
-      }
+      { "internalType": "string", "name": "name",        "type": "string" },
+      { "internalType": "string", "name": "description", "type": "string" }
     ],
     "name": "createOpenBounty",
     "outputs": [],
@@ -64,13 +33,7 @@ export const POIDH_ABI = [
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "bountyId",
-        "type": "uint256"
-      }
-    ],
+    "inputs": [{ "internalType": "uint256", "name": "bountyId", "type": "uint256" }],
     "name": "joinOpenBounty",
     "outputs": [],
     "stateMutability": "payable",
@@ -78,16 +41,8 @@ export const POIDH_ABI = [
   },
   {
     "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "bountyId",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "claimId",
-        "type": "uint256"
-      }
+      { "internalType": "uint256", "name": "bountyId", "type": "uint256" },
+      { "internalType": "uint256", "name": "claimId",  "type": "uint256" }
     ],
     "name": "acceptClaim",
     "outputs": [],
@@ -96,16 +51,8 @@ export const POIDH_ABI = [
   },
   {
     "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "bountyId",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "claimId",
-        "type": "uint256"
-      }
+      { "internalType": "uint256", "name": "bountyId", "type": "uint256" },
+      { "internalType": "uint256", "name": "claimId",  "type": "uint256" }
     ],
     "name": "submitClaimForVote",
     "outputs": [],
@@ -114,21 +61,8 @@ export const POIDH_ABI = [
   },
   {
     "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "bountyId",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "claimId",
-        "type": "uint256"
-      },
-      {
-        "internalType": "bool",
-        "name": "accept",
-        "type": "bool"
-      }
+      { "internalType": "uint256", "name": "bountyId", "type": "uint256" },
+      { "internalType": "bool",    "name": "vote",     "type": "bool"    }
     ],
     "name": "voteClaim",
     "outputs": [],
@@ -136,58 +70,43 @@ export const POIDH_ABI = [
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "bountyId",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "claimId",
-        "type": "uint256"
-      }
-    ],
+    "inputs": [{ "internalType": "uint256", "name": "bountyId", "type": "uint256" }],
     "name": "resolveVote",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "bountyId",
-        "type": "uint256"
-      }
-    ],
+    "inputs": [{ "internalType": "uint256", "name": "bountyId", "type": "uint256" }],
     "name": "cancelSoloBounty",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "bountyId",
-        "type": "uint256"
-      }
-    ],
+    "inputs": [{ "internalType": "uint256", "name": "bountyId", "type": "uint256" }],
     "name": "cancelOpenBounty",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "bountyId",
-        "type": "uint256"
-      }
-    ],
+    "inputs": [{ "internalType": "uint256", "name": "bountyId", "type": "uint256" }],
     "name": "withdrawFromOpenBounty",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "bountyId", "type": "uint256" }],
+    "name": "claimRefundFromCancelledOpenBounty",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "bountyId", "type": "uint256" }],
+    "name": "resetVotingPeriod",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -200,170 +119,67 @@ export const POIDH_ABI = [
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "inputs": [{ "internalType": "address", "name": "to", "type": "address" }],
+    "name": "withdrawTo",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  // ── Read functions ───────────────────────────────────────────────────────
+  {
+    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "name": "bounties",
     "outputs": [
-      {
-        "internalType": "string",
-        "name": "name",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "description",
-        "type": "string"
-      },
-      {
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      },
-      {
-        "internalType": "address",
-        "name": "issuer",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "claimer",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "createdAt",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "deadline",
-        "type": "uint256"
-      },
-      {
-        "internalType": "enum PoidhV3.BountyStatus",
-        "name": "status",
-        "type": "uint8"
-      },
-      {
-        "internalType": "bool",
-        "name": "isOpenBounty",
-        "type": "bool"
-      }
+      { "internalType": "string",  "name": "name",        "type": "string"  },
+      { "internalType": "string",  "name": "description", "type": "string"  },
+      { "internalType": "uint256", "name": "amount",      "type": "uint256" },
+      { "internalType": "address", "name": "issuer",      "type": "address" },
+      { "internalType": "address", "name": "claimer",     "type": "address" },
+      { "internalType": "uint256", "name": "createdAt",   "type": "uint256" },
+      { "internalType": "uint256", "name": "claimId",     "type": "uint256" }
     ],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "bountyId",
-        "type": "uint256"
-      }
-    ],
-    "name": "getBounty",
-    "outputs": [
-      {
-        "components": [
-          {
-            "internalType": "string",
-            "name": "name",
-            "type": "string"
-          },
-          {
-            "internalType": "string",
-            "name": "description",
-            "type": "string"
-          },
-          {
-            "internalType": "uint256",
-            "name": "amount",
-            "type": "uint256"
-          },
-          {
-            "internalType": "address",
-            "name": "issuer",
-            "type": "address"
-          },
-          {
-            "internalType": "address",
-            "name": "claimer",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "createdAt",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "deadline",
-            "type": "uint256"
-          },
-          {
-            "internalType": "enum PoidhV3.BountyStatus",
-            "name": "status",
-            "type": "uint8"
-          },
-          {
-            "internalType": "bool",
-            "name": "isOpenBounty",
-            "type": "bool"
-          }
-        ],
-        "internalType": "struct PoidhV3.Bounty",
-        "name": "",
-        "type": "tuple"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "bountyId",
-        "type": "uint256"
-      }
-    ],
+    "inputs": [{ "internalType": "uint256", "name": "bountyId", "type": "uint256" }],
     "name": "getParticipants",
     "outputs": [
-      {
-        "internalType": "address[]",
-        "name": "",
-        "type": "address[]"
-      },
-      {
-        "internalType": "uint256[]",
-        "name": "",
-        "type": "uint256[]"
-      }
+      { "internalType": "address[]", "name": "", "type": "address[]" },
+      { "internalType": "uint256[]", "name": "", "type": "uint256[]" }
     ],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "name": "pendingWithdrawals",
+    "inputs": [{ "internalType": "uint256", "name": "bountyId", "type": "uint256" }],
+    "name": "bountyVotingTracker",
     "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
+      { "internalType": "uint256", "name": "yes",      "type": "uint256" },
+      { "internalType": "uint256", "name": "no",       "type": "uint256" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" }
     ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "bountyId", "type": "uint256" }],
+    "name": "bountyCurrentVotingClaim",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "bountyId", "type": "uint256" }],
+    "name": "everHadExternalContributor",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "pendingWithdrawals",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "stateMutability": "view",
     "type": "function"
   }


### PR DESCRIPTION
## Summary
- **P0 fixes:** `voteClaim` and `resolveVote` ABI signatures were V2-era (wrong number of params) — all vote and resolve transactions were reverting silently. Fixed.
- **P1 fix:** Cancelled open-bounty contributors were calling `withdrawFromOpenBounty` (active-only) instead of `claimRefundFromCancelledOpenBounty` — ETH was unrecoverable through the UI. Fixed.
- **P1 fix:** Removed dead `getBounty` call (function doesn't exist on V3) that was silently failing for `isJoinable` detection. Now uses API data directly.
- **P2 feature:** `everHadExternalContributor` gate added to Accept Claim button — open bounties with contributors can no longer trigger a direct accept (which would revert); users are guided to the vote flow instead.
- **P2 feature:** Live vote dashboard (`VoteDashboard`) shows yes/no ETH weights and vote deadline countdown, refreshes every 15s.
- **P3 feature:** `PendingWithdrawalBanner` reads `pendingWithdrawals` per chain and shows a withdraw action for bounty winners or cancelled-bounty refunds.
- **P3 feature:** `resetVotingPeriod` hook and button added for recovery after a failed vote.
- **Test script:** `scripts/test-poidh.ts` — full integration test covering solo bounty flow, open bounty vote flow, cancel+refund flow, resetVotingPeriod, and edge cases (non-issuer accept, non-participant vote, double refund, resolve-before-deadline). Runs against local Anvil fork.

## Changes
- `src/lib/poidh/abi.ts` — V3 ABI rewrite: fix voteClaim/resolveVote, remove getBounty, fix bounties getter, add 6 new entries
- `src/hooks/usePoidhContract.ts` — fix vote/resolve hooks, add claimRefund/resetVoting/withdraw hooks
- `src/components/bounties/VoteDashboard.tsx` — new component, live vote stats
- `src/components/bounties/PendingWithdrawalBanner.tsx` — new component, per-chain claimable ETH
- `src/components/bounties/BountyDetailView.tsx` — wire everything: VoteDashboard, claimRefund, everHadExternalContributor gate, fixed vote/resolve calls
- `src/components/bounties/BountiesView.tsx` — add PendingWithdrawalBanner
- `scripts/test-poidh.ts` — integration test script

## Test plan
- [ ] Start Anvil: `anvil --fork-url https://mainnet.base.org --chain-id 8453`
- [ ] Run: `npx tsx scripts/test-poidh.ts` — all suites should pass
- [ ] Navigate to a bounty in Voting state — VoteDashboard card should appear in sidebar with yes/no ETH bars
- [ ] Connect wallet that has won a bounty — PendingWithdrawalBanner should appear on `/community/bounties`
- [ ] On an open bounty where you contributed, verify Accept Claim button is hidden and "Submit for Vote" guidance appears

Generated with [Claude Code](https://claude.com/claude-code)