### PR TITLE
fix(lint): escape quotes in NogglesRailsClosingBox

### DIFF
--- a/src/components/nogglesrails/NogglesRailsClosingBox.tsx
+++ b/src/components/nogglesrails/NogglesRailsClosingBox.tsx
@@ -40,7 +40,7 @@ export function NogglesRailsClosingBox() {
         <h2 className="mb-4 text-2xl font-bold tracking-tight">Onchain-born, still alive</h2>
         <p className="text-sm leading-7 text-muted-foreground md:text-base">
           Nogglesrails or Nounstacles prove that onchain coordination can materialize into
-          "concrete", skateable infrastructure. Through cash for tricks, events, exposition, Gnars
+          &ldquo;concrete&rdquo;, skateable infrastructure. Through cash for tricks, events, exposition, Gnars
           contests, viral Instagram clips, and global replication, the project keeps the DIY spirit
           alive while spreading Noggles culture in a way no traditional brand or institution could.
           This is an onchain-born project by Gnars DAO and it’s still alive bro, still rolling, and


### PR DESCRIPTION
## Summary
- Escaped unescaped `"` characters on line 43 of `NogglesRailsClosingBox.tsx` using `&ldquo;` / `&rdquo;` to fix `react/no-unescaped-entities` lint errors that were failing CI.

## Changes
- `src/components/nogglesrails/NogglesRailsClosingBox.tsx` — `"concrete"` → `&ldquo;concrete&rdquo;`

## Test plan
- [ ] CI lint passes

Generated with [Claude Code](https://claude.com/claude-code)