### PR TITLE
feat(ui): add avatars across proposal cards, gnar cards, propdates feed and members delegate

### DIFF
--- a/src/components/auctions/GnarCard.tsx
+++ b/src/components/auctions/GnarCard.tsx
@@ -72,7 +72,8 @@ export function GnarCard({
                   <AddressDisplay
                     address={winnerAddress}
                     variant="compact"
-                    showAvatar={false}
+                    showAvatar={true}
+                    avatarSize="xs"
                     showCopy={false}
                     showExplorer={false}
                   />

--- a/src/components/members/MembersList.tsx
+++ b/src/components/members/MembersList.tsx
@@ -321,11 +321,11 @@ export function MembersList({
                         <AddressDisplay
                           address={member.delegate}
                           variant="compact"
-                          showAvatar={false}
+                          showAvatar={true}
+                          avatarSize="xs"
                           showENS={true}
                           showCopy={false}
                           showExplorer={false}
-                          avatarSize="sm"
                           onAddressClick={() => {}}
                         />
                       </Link>

--- a/src/components/propdates/PropdatesFeed.tsx
+++ b/src/components/propdates/PropdatesFeed.tsx
@@ -67,7 +67,7 @@ function ProposalUpdateCard({ entry, index }: ProposalUpdateCardProps) {
       className="animate-in fade-in-0"
       style={{ animationDelay: `${index * 40}ms`, animationFillMode: "both" }}
     >
-      <Card className="overflow-hidden transition-transform transition-shadow hover:-translate-y-0.5 hover:shadow-md">
+      <Card className="overflow-hidden transition-all hover:-translate-y-0.5 hover:shadow-md">
         {/* Card header — proposal context */}
         <CardContent className="p-4 pb-0">
           <div className="flex items-start justify-between gap-2">
@@ -89,7 +89,7 @@ function ProposalUpdateCard({ entry, index }: ProposalUpdateCardProps) {
             <AddressDisplay
               address={proposal.proposer}
               variant="compact"
-              showAvatar={false}
+              showAvatar={true}
               showCopy={false}
               showExplorer={false}
               avatarSize="xs"

--- a/src/components/proposals/ProposalCard.tsx
+++ b/src/components/proposals/ProposalCard.tsx
@@ -156,7 +156,8 @@ export function ProposalCard({
                   <AddressDisplay
                     address={proposal.proposer}
                     variant="compact"
-                    showAvatar={false}
+                    showAvatar={true}
+                    avatarSize="xs"
                     showENS={true}
                     showCopy={false}
                     showExplorer={false}


### PR DESCRIPTION
## Summary
- Adds `xs` avatars to the proposer display on **ProposalCard** and **PropdatesFeed** ("by [address]" line)
- Adds `xs` avatar to the **Winner** field on **GnarCard** (auction history)
- Adds `xs` avatar to the **Delegate** column on **MembersList** table
- Fixes `transition-transform transition-shadow` CSS conflict in PropdatesFeed → replaced with `transition-all`

## Changes
- `src/components/proposals/ProposalCard.tsx` — `showAvatar={true}` + `avatarSize="xs"`
- `src/components/auctions/GnarCard.tsx` — `showAvatar={true}` + `avatarSize="xs"`
- `src/components/propdates/PropdatesFeed.tsx` — `showAvatar={true}`, fix CSS transition conflict
- `src/components/members/MembersList.tsx` — `showAvatar={true}` + `avatarSize="xs"` on delegate column

## Test plan
- [ ] Proposals list — each card shows a tiny avatar next to the proposer name
- [ ] Auction history / Gnar cards — winner row shows avatar
- [ ] Propdates feed — "by [address]" line shows avatar
- [ ] Members table — Delegate column shows avatar (only when delegated to someone else)

Generated with [Claude Code](https://claude.com/claude-code)