### PR TITLE
fix(poidh): use claim.onChainId for contract calls — fixes ClaimNotFound revert

### DIFF
--- a/src/components/bounties/BountyDetailView.tsx
+++ b/src/components/bounties/BountyDetailView.tsx
@@ -566,7 +566,7 @@ export function BountyDetailView({ initialBounty, chainId, bountyId }: BountyDet
                             size="sm"
                             variant="default"
                             disabled={acceptClaimHook.isPending}
-                            onClick={() => acceptClaimHook.accept(bounty.onChainId, claim.id)}
+                            onClick={() => acceptClaimHook.accept(bounty.onChainId, claim.onChainId)}
                           >
                             {acceptClaimHook.isPending ? (
                               <>
@@ -617,7 +617,7 @@ export function BountyDetailView({ initialBounty, chainId, bountyId }: BountyDet
                             variant="outline"
                             className="w-full"
                             disabled={submitForVoteHook.isPending}
-                            onClick={() => submitForVoteHook.submit(bounty.onChainId, claim.id)}
+                            onClick={() => submitForVoteHook.submit(bounty.onChainId, claim.onChainId)}
                           >
                             {submitForVoteHook.isPending ? (
                               <>

--- a/src/services/poidh.ts
+++ b/src/services/poidh.ts
@@ -109,6 +109,7 @@ function mapClaims(rawClaims: unknown[]): PoidhClaim[] {
   return rawClaims.map((c: unknown) => {
     const claim = c as {
       id: number;
+      onChainId?: number;
       bountyId: number;
       title?: string;
       description?: string;
@@ -118,6 +119,7 @@ function mapClaims(rawClaims: unknown[]): PoidhClaim[] {
     };
     return {
       id: claim.id,
+      onChainId: claim.onChainId ?? claim.id,
       bountyId: claim.bountyId,
       name: claim.title || `Claim #${claim.id}`,
       description: claim.description || "",

--- a/src/types/poidh.ts
+++ b/src/types/poidh.ts
@@ -1,5 +1,6 @@
 export interface PoidhClaim {
   id: number;
+  onChainId: number;
   bountyId: number;
   name: string;
   description: string;


### PR DESCRIPTION
## Summary
- `submitForVote` and `acceptClaim` were passing `claim.id` (API/database ID) to the contract, but the contract expects the **on-chain claim ID** (`claim.onChainId`) — causing `ClaimNotFound()` reverts (selector `0x0455eeee`) every time
- Adds `onChainId` to `PoidhClaim` type, maps it from the POIDH API response (falls back to `id` if absent), and updates both callsites

## Changes
- `src/types/poidh.ts` — add `onChainId: number` to `PoidhClaim`
- `src/services/poidh.ts` — map `onChainId` from raw API response in `mapClaims`
- `src/components/bounties/BountyDetailView.tsx` — `acceptClaim` and `submitForVote` now pass `claim.onChainId`

## Test plan
- [ ] Submit for Vote on a claim — should no longer revert with `ClaimNotFound`
- [ ] Accept Claim (solo bounty, no contributors) — should succeed

Generated with [Claude Code](https://claude.com/claude-code)