### PR TITLE
feat(swap): user balance + MAX button + flip preserves amount

### DIFF
--- a/src/app/swap/SwapWidget.tsx
+++ b/src/app/swap/SwapWidget.tsx
@@ -25,6 +25,7 @@ import { ensureOnChain, normalizeTxError } from "@/lib/thirdweb-tx";
 import { cn } from "@/lib/utils";
 import { getDefaultPair, NATIVE_TOKEN, type SwapToken } from "./chains";
 import { useSwapChain } from "./SwapChainContext";
+import { formatBalanceDisplay, useTokenBalance } from "./useTokenBalance";
 
 const erc20ApproveAbi = [
   {
@@ -267,6 +268,27 @@ export function SwapWidget() {
   const [isSwapping, setIsSwapping] = React.useState(false);
   const [isSwitchingChain, setIsSwitchingChain] = React.useState(false);
 
+  // Live balances for the currently-picked sell/buy tokens on the selected
+  // chain. Both honor `useUserAddress`'s SA-vs-EOA view mode automatically
+  // because we pass `address` straight through.
+  const sellBalance = useTokenBalance({
+    chain,
+    userAddress: address as Address | undefined,
+    token: sellToken,
+  });
+  const buyBalance = useTokenBalance({
+    chain,
+    userAddress: address as Address | undefined,
+    token: buyToken,
+  });
+
+  /** "Use max" — fills the sell input with the full token balance. */
+  const handleUseMax = () => {
+    const bal = sellBalance.data;
+    if (!bal || bal.value === 0n) return;
+    setSellAmount(bal.displayValue);
+  };
+
   // When the user switches chain, reset everything to that chain's defaults.
   // Tokens from a previous chain are nonsense to 0x for the new chainId.
   React.useEffect(() => {
@@ -347,7 +369,8 @@ export function SwapWidget() {
   const flip = () => {
     setSellToken(buyToken);
     setBuyToken(sellToken);
-    setSellAmount("");
+    // Preserve the typed amount across flips — the value is now interpreted
+    // as the new sell token; the debounced price effect will refetch.
     setPrice(null);
     setNeedsApproval(false);
     setApprovalTarget(null);
@@ -534,7 +557,7 @@ export function SwapWidget() {
         <div className="grid grid-cols-1 items-end gap-y-7 md:grid-cols-[1fr_auto_1fr] md:gap-y-0">
           {/* FROM */}
           <div className="md:border-r md:border-border md:pr-7">
-            <div className="mb-2.5">
+            <div className="mb-2.5 flex items-center justify-between gap-2">
               <TokenPicker
                 value={sellToken}
                 tokens={chain.tokens}
@@ -546,6 +569,20 @@ export function SwapWidget() {
                 }}
                 label="Sell token"
               />
+              {isConnected && sellBalance.data && sellBalance.data.value > 0n && (
+                <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                  <span className="font-mono">
+                    {formatBalanceDisplay(sellBalance.data.displayValue)}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={handleUseMax}
+                    className="rounded-sm px-1.5 py-0.5 text-[10px] font-semibold tracking-wider text-blue-700 transition-colors hover:bg-blue-100 dark:text-blue-300 dark:hover:bg-blue-900/30"
+                  >
+                    MAX
+                  </button>
+                </div>
+              )}
             </div>
             <div className="flex items-baseline gap-3 border-b border-border pb-2.5 transition-colors focus-within:border-foreground/40">
               <Input
@@ -587,7 +624,7 @@ export function SwapWidget() {
 
           {/* TO */}
           <div className="md:pl-7">
-            <div className="mb-2.5">
+            <div className="mb-2.5 flex items-center justify-between gap-2">
               <TokenPicker
                 value={buyToken}
                 tokens={chain.tokens}
@@ -599,6 +636,11 @@ export function SwapWidget() {
                 }}
                 label="Buy token"
               />
+              {isConnected && buyBalance.data && buyBalance.data.value > 0n && (
+                <span className="font-mono text-[11px] text-muted-foreground">
+                  {formatBalanceDisplay(buyBalance.data.displayValue)}
+                </span>
+              )}
             </div>
             <div className="flex items-baseline gap-3 border-b border-border pb-2.5">
               <span className="flex-1 truncate text-[44px] font-thin leading-none tracking-[-2px] text-foreground/90 md:text-[56px] md:tracking-[-3px]">

--- a/src/app/swap/SwapWidget.tsx
+++ b/src/app/swap/SwapWidget.tsx
@@ -511,7 +511,10 @@ export function SwapWidget() {
 
   const isLoading = isFetching || isApproving || isSwapping;
   const hasAmount = sellAmount.length > 0 && Number(sellAmount) > 0;
-  const insufficientBalance = Boolean(price?.issues?.balance);
+  // Only trust 0x's balance signal when we have a real taker. The sentinel
+  // address used pre-connection holds zero of everything, so 0x would
+  // always flag "insufficient" — misleading when no wallet is connected.
+  const insufficientBalance = isConnected && Boolean(price?.issues?.balance);
   const canSwap =
     isConnected &&
     !isWrongNetwork &&
@@ -595,6 +598,7 @@ export function SwapWidget() {
               <Input
                 type="number"
                 inputMode="decimal"
+                step="any"
                 placeholder="0"
                 value={sellAmount}
                 onChange={(e) => setSellAmount(e.target.value)}

--- a/src/app/swap/SwapWidget.tsx
+++ b/src/app/swap/SwapWidget.tsx
@@ -569,18 +569,25 @@ export function SwapWidget() {
                 }}
                 label="Sell token"
               />
-              {isConnected && sellBalance.data && sellBalance.data.value > 0n && (
+              {isConnected && (
                 <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                  <span className="text-muted-foreground/60">Balance:</span>
                   <span className="font-mono">
-                    {formatBalanceDisplay(sellBalance.data.displayValue)}
+                    {sellBalance.isLoading
+                      ? "…"
+                      : sellBalance.data
+                        ? formatBalanceDisplay(sellBalance.data.displayValue)
+                        : "—"}
                   </span>
-                  <button
-                    type="button"
-                    onClick={handleUseMax}
-                    className="rounded-sm px-1.5 py-0.5 text-[10px] font-semibold tracking-wider text-blue-700 transition-colors hover:bg-blue-100 dark:text-blue-300 dark:hover:bg-blue-900/30"
-                  >
-                    MAX
-                  </button>
+                  {sellBalance.data && sellBalance.data.value > 0n && (
+                    <button
+                      type="button"
+                      onClick={handleUseMax}
+                      className="rounded-sm px-1.5 py-0.5 text-[10px] font-semibold tracking-wider text-blue-700 transition-colors hover:bg-blue-100 dark:text-blue-300 dark:hover:bg-blue-900/30"
+                    >
+                      MAX
+                    </button>
+                  )}
                 </div>
               )}
             </div>
@@ -636,10 +643,17 @@ export function SwapWidget() {
                 }}
                 label="Buy token"
               />
-              {isConnected && buyBalance.data && buyBalance.data.value > 0n && (
-                <span className="font-mono text-[11px] text-muted-foreground">
-                  {formatBalanceDisplay(buyBalance.data.displayValue)}
-                </span>
+              {isConnected && (
+                <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                  <span className="text-muted-foreground/60">Balance:</span>
+                  <span className="font-mono">
+                    {buyBalance.isLoading
+                      ? "…"
+                      : buyBalance.data
+                        ? formatBalanceDisplay(buyBalance.data.displayValue)
+                        : "—"}
+                  </span>
+                </div>
               )}
             </div>
             <div className="flex items-baseline gap-3 border-b border-border pb-2.5">

--- a/src/app/swap/miniapp-image/route.tsx
+++ b/src/app/swap/miniapp-image/route.tsx
@@ -1,0 +1,133 @@
+import { ImageResponse } from "next/og";
+import { MINIAPP_SIZE, OG_COLORS, OG_FONTS } from "@/lib/og-utils";
+
+export const alt = "Swap on Gnars";
+export const size = MINIAPP_SIZE;
+export const contentType = "image/png";
+export const runtime = "edge";
+
+export async function GET() {
+  const logoUrl =
+    "https://wsrv.nl/?url=https%3A%2F%2Fgnars.com%2Fgnars.webp&w=180&h=180&fit=cover&output=png";
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: "100%",
+          width: "100%",
+          display: "flex",
+          flexDirection: "column",
+          backgroundColor: OG_COLORS.background,
+          fontFamily: OG_FONTS.family,
+          padding: "80px",
+          position: "relative",
+        }}
+      >
+        {/* Eyebrow */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "16px",
+            fontSize: 22,
+            fontWeight: 700,
+            letterSpacing: "0.18em",
+            textTransform: "uppercase",
+            color: OG_COLORS.muted,
+            marginBottom: "40px",
+          }}
+        >
+          <span>Swap</span>
+          <span style={{ color: OG_COLORS.cardBorder }}>·</span>
+          <span
+            style={{
+              backgroundColor: "#132044",
+              color: "#5b9cf6",
+              padding: "6px 14px",
+              borderRadius: "6px",
+              fontSize: 18,
+              letterSpacing: "0.04em",
+            }}
+          >
+            BASE
+          </span>
+        </div>
+
+        {/* Headline */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "12px",
+            marginBottom: "auto",
+          }}
+        >
+          <div
+            style={{
+              fontSize: 124,
+              fontWeight: 100,
+              color: OG_COLORS.foreground,
+              letterSpacing: "-5px",
+              lineHeight: 1,
+            }}
+          >
+            ETH → GNARS
+          </div>
+          <div
+            style={{
+              fontSize: 32,
+              color: OG_COLORS.muted,
+              maxWidth: "920px",
+              lineHeight: 1.3,
+              marginTop: "12px",
+            }}
+          >
+            Best price across 150+ DEXes. 0.5% supports the Gnars Collective Treasury.
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            paddingTop: "24px",
+            borderTop: `1px solid ${OG_COLORS.cardBorder}`,
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: "16px" }}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={logoUrl}
+              alt="Gnars"
+              width={56}
+              height={56}
+              style={{ width: 56, height: 56, objectFit: "cover" }}
+            />
+            <div
+              style={{
+                fontSize: 28,
+                fontWeight: 700,
+                color: OG_COLORS.foreground,
+              }}
+            >
+              gnars.com / swap
+            </div>
+          </div>
+          <div
+            style={{
+              fontSize: 20,
+              color: OG_COLORS.muted,
+              letterSpacing: "0.04em",
+            }}
+          >
+            Powered by 0x
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/src/app/swap/page.tsx
+++ b/src/app/swap/page.tsx
@@ -1,10 +1,14 @@
 import type { Metadata } from "next";
+import { BASE_URL } from "@/lib/config";
+import { SWAP_MINIAPP_EMBED_CONFIG } from "@/lib/miniapp-config";
 import { ChainSelector } from "./ChainSelector";
 import { SwapChainProvider } from "./SwapChainContext";
 import { SwapWidget } from "./SwapWidget";
 
 const description =
   "Swap tokens across Base, Ethereum, Optimism, and Arbitrum with best execution across 150+ DEXes via the 0x Protocol.";
+
+const miniappImage = `${BASE_URL}/swap/miniapp-image`;
 
 export const metadata: Metadata = {
   title: "Swap — Gnars DAO",
@@ -15,11 +19,21 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Swap — Gnars DAO",
     description,
+    images: [miniappImage],
+    url: `${BASE_URL}/swap`,
+    type: "website",
   },
   twitter: {
     card: "summary_large_image",
     title: "Swap — Gnars DAO",
     description,
+    images: [miniappImage],
+  },
+  // Farcaster mini app embed metadata. Overrides the root layout's
+  // `fc:miniapp` tag so casts that link to /swap render the swap-specific
+  // cover and CTA instead of the generic Gnars DAO embed.
+  other: {
+    "fc:miniapp": JSON.stringify(SWAP_MINIAPP_EMBED_CONFIG),
   },
 };
 

--- a/src/app/swap/useTokenBalance.ts
+++ b/src/app/swap/useTokenBalance.ts
@@ -1,0 +1,85 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { getWalletBalance } from "thirdweb/wallets";
+import type { Address } from "viem";
+import { getThirdwebClient } from "@/lib/thirdweb";
+import { NATIVE_TOKEN, type SwapChain, type SwapToken } from "./chains";
+
+export interface TokenBalance {
+  /** Raw balance in the smallest unit. */
+  value: bigint;
+  /** Human-formatted string (e.g. "0.5234"). */
+  displayValue: string;
+  /** Token decimals as reported by the chain. */
+  decimals: number;
+  /** Token symbol as reported by the chain. */
+  symbol: string;
+}
+
+/**
+ * Reads the user's balance for a given token on a given chain.
+ *
+ * Uses thirdweb's `getWalletBalance` so it works on any chain we configure
+ * for the swap UI without depending on the wagmi config (which currently
+ * only carries Base + Arbitrum transports). Polls every 30s while the
+ * window is focused so the figure stays roughly fresh.
+ *
+ * Returns `null` when no wallet is connected — the caller decides how to
+ * render that (we hide the balance line entirely in the swap widget).
+ *
+ * Honors `useUserAddress` view-mode semantics: pass the address straight
+ * from `useUserAddress()` and the balance reflects the SA-vs-EOA toggle
+ * the user picked in the wallet drawer.
+ */
+export function useTokenBalance({
+  chain,
+  userAddress,
+  token,
+}: {
+  chain: SwapChain;
+  userAddress: Address | undefined;
+  token: SwapToken;
+}) {
+  const client = getThirdwebClient();
+  const enabled = Boolean(client) && Boolean(userAddress);
+
+  return useQuery<TokenBalance | null>({
+    queryKey: ["swap-token-balance", chain.id, userAddress, token.address] as const,
+    enabled,
+    staleTime: 15_000,
+    refetchInterval: 30_000,
+    queryFn: async () => {
+      if (!client || !userAddress) return null;
+
+      const balance = await getWalletBalance({
+        client,
+        chain: chain.thirdwebChain,
+        address: userAddress,
+        // Native asset → omit tokenAddress; ERC-20 → pass the contract.
+        tokenAddress: token.address === NATIVE_TOKEN ? undefined : (token.address as Address),
+      });
+
+      return {
+        value: balance.value,
+        displayValue: balance.displayValue,
+        decimals: balance.decimals,
+        symbol: balance.symbol,
+      };
+    },
+  });
+}
+
+/**
+ * Best-effort friendly format for a balance string (e.g. "1234.5678" → "1,234.57").
+ */
+export function formatBalanceDisplay(displayValue: string | undefined): string {
+  if (!displayValue) return "—";
+  const num = Number(displayValue);
+  if (!Number.isFinite(num)) return displayValue;
+  if (num === 0) return "0";
+  if (num < 0.0001) return num.toExponential(2);
+  if (num < 1) return num.toFixed(4);
+  if (num < 1000) return num.toFixed(4);
+  return num.toLocaleString(undefined, { maximumFractionDigits: 2 });
+}

--- a/src/lib/miniapp-config.ts
+++ b/src/lib/miniapp-config.ts
@@ -1,4 +1,4 @@
-import { BASE_URL, DAO_DESCRIPTION, DAO_ADDRESSES } from "./config";
+import { BASE_URL, DAO_ADDRESSES, DAO_DESCRIPTION } from "./config";
 
 /**
  * Farcaster Mini App Configuration
@@ -17,9 +17,11 @@ export const MINIAPP_CONFIG = {
   // Account association - MUST be filled in after signing at base.dev/preview
   // Leave empty strings until you've signed the manifest
   accountAssociation: {
-    header: "eyJmaWQiOjUzODgzOSwidHlwZSI6ImN1c3RvZHkiLCJrZXkiOiIweDk3Yjc4ZDdCM2M2NmMyZmZiOTYxYWEwQURCNmNlNjcyQTM3MTZEOEMifQ",
+    header:
+      "eyJmaWQiOjUzODgzOSwidHlwZSI6ImN1c3RvZHkiLCJrZXkiOiIweDk3Yjc4ZDdCM2M2NmMyZmZiOTYxYWEwQURCNmNlNjcyQTM3MTZEOEMifQ",
     payload: "eyJkb21haW4iOiJnbmFycy5jb20ifQ",
-    signature: "qm+dqd4UcCOzjAYvNCDaoQOp1A4PoXAm9B6Qv6D4iJ9kzFZ4zjVpoL3s21y2UckqPC+QPO2/HkKuRzoU8GmV4xs=",
+    signature:
+      "qm+dqd4UcCOzjAYvNCDaoQOp1A4PoXAm9B6Qv6D4iJ9kzFZ4zjVpoL3s21y2UckqPC+QPO2/HkKuRzoU8GmV4xs=",
   },
 
   // Base builder configuration - add your Base account address
@@ -75,7 +77,6 @@ export const MINIAPP_EMBED_CONFIG = {
     },
   },
 };
-
 
 /**
  * TV Mini App Configuration
@@ -177,7 +178,6 @@ export const PROPOSALS_MINIAPP_EMBED_CONFIG = {
   },
 };
 
-
 /**
  * Members Embed metadata configuration for fc:miniapp meta tag
  */
@@ -269,8 +269,7 @@ export const MAP_MINIAPP_CONFIG = {
     heroImageUrl: `${BASE_URL}/map/opengraph-image`,
     tagline: "Global skate spots funded by Gnars DAO",
     ogTitle: "Gnars World Map",
-    ogDescription:
-      "Explore Gnars DAO funded skate spots, rails, and projects around the world.",
+    ogDescription: "Explore Gnars DAO funded skate spots, rails, and projects around the world.",
     ogImageUrl: `${BASE_URL}/map/opengraph-image`,
     noindex: false,
   },
@@ -288,6 +287,29 @@ export const MAP_MINIAPP_EMBED_CONFIG = {
       type: "launch_miniapp" as const,
       name: "Gnars World Map",
       url: `${BASE_URL}/map`,
+      splashImageUrl: `${BASE_URL}/gnars-splash-200.png`,
+      splashBackgroundColor: "#000000",
+    },
+  },
+};
+
+/**
+ * Swap Embed metadata configuration for fc:miniapp meta tag.
+ *
+ * Surfaces the /swap page as a launchable Farcaster mini app with a
+ * swap-specific cover image and CTA. The fee on Base swaps still routes
+ * to the DAO treasury via the 0x proxy, so opening the embed and trading
+ * directly funds the Collective.
+ */
+export const SWAP_MINIAPP_EMBED_CONFIG = {
+  version: "1",
+  imageUrl: `${BASE_URL}/swap/miniapp-image`,
+  button: {
+    title: "Swap on Gnars",
+    action: {
+      type: "launch_miniapp" as const,
+      name: "Gnars Swap",
+      url: `${BASE_URL}/swap`,
       splashImageUrl: `${BASE_URL}/gnars-splash-200.png`,
       splashBackgroundColor: "#000000",
     },


### PR DESCRIPTION
## Summary
- Live token balance next to the picker on both sides (sell/buy), plus a **MAX** button on the sell side that fills the input.
- Flip arrow now **preserves the typed amount** across the swap (was clearing it — felt like a bug).

## Implementation
- New `src/app/swap/useTokenBalance.ts` hook backed by thirdweb's `getWalletBalance`. Reads the user's balance for any chain in our \`SWAP_CHAINS\` registry without widening the wagmi config (which still only carries Base + Arbitrum transports).
- Honors `useUserAddress`'s SA-vs-EOA view mode automatically — the address passed in is the effective view, so the displayed balance matches whatever the user picked in the wallet drawer.
- Sell column: balance + MAX button next to the picker; MAX writes \`balance.displayValue\` into the sell input.
- Buy column: balance only (no MAX — users don't choose buy amounts).
- `flip()` no longer calls \`setSellAmount("")\`. The amount is intentionally re-interpreted as the new sell token's value, and the debounced price effect refetches automatically.

## Test plan
- [ ] On Base, connect a wallet that holds ETH → balance line appears next to the ETH picker on the FROM column.
- [ ] Click **MAX** → input fills with the full ETH balance.
- [ ] Switch chain to Optimism (no balance) → sell-side balance line hides.
- [ ] Type \`0.5\` ETH, click the flip arrow → input still shows \`0.5\` (now interpreted as GNARS or the new sell token).
- [ ] \`pnpm lint\` clean (1 pre-existing warning in BountiesView).
- [ ] \`pnpm build\` clean — \`/swap\` listed as a static route.

Generated with [Claude Code](https://claude.com/claude-code)