### PR TITLE
feat(swap): resolve arbitrary ERC-20 addresses in token picker

### DIFF
--- a/src/app/api/wallet/token-lookup/route.ts
+++ b/src/app/api/wallet/token-lookup/route.ts
@@ -1,0 +1,118 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { getCoin, setApiKey } from "@zoralabs/coins-sdk";
+import { getAddress, isAddress } from "viem";
+
+const ALCHEMY_RPC_BASES: Record<string, string> = {
+  "8453": "https://base-mainnet.g.alchemy.com/v2",
+  "1": "https://eth-mainnet.g.alchemy.com/v2",
+  "10": "https://opt-mainnet.g.alchemy.com/v2",
+  "42161": "https://arb-mainnet.g.alchemy.com/v2",
+};
+
+const TRUSTWALLET_CHAIN_NAMES: Record<string, string> = {
+  "8453": "base",
+  "1": "ethereum",
+  "10": "optimism",
+  "42161": "arbitrum",
+};
+
+export interface LookedUpToken {
+  address: string;
+  symbol: string;
+  name: string;
+  decimals: number;
+  logoUrl: string | null;
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const address = searchParams.get("address");
+  const chainId = searchParams.get("chainId") ?? "8453";
+
+  if (!address || !isAddress(address)) {
+    return NextResponse.json({ error: "Invalid address" }, { status: 400 });
+  }
+
+  const alchemyKey = process.env.ALCHEMY_API_KEY;
+  if (!alchemyKey) {
+    return NextResponse.json({ error: "Not configured" }, { status: 500 });
+  }
+
+  const rpcBase = ALCHEMY_RPC_BASES[chainId];
+  if (!rpcBase) {
+    return NextResponse.json({ error: "Unsupported chain" }, { status: 400 });
+  }
+
+  const checksumAddr = getAddress(address);
+  const rpcUrl = `${rpcBase}/${alchemyKey}`;
+
+  // Fetch Alchemy metadata and Zora coin data in parallel.
+  // Zora is only attempted on Base where creator coins live.
+  const [metaRes, zoraToken] = await Promise.all([
+    fetch(rpcUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: 1,
+        jsonrpc: "2.0",
+        method: "alchemy_getTokenMetadata",
+        params: [checksumAddr],
+      }),
+      next: { revalidate: 3600 },
+    }),
+    chainId === "8453"
+      ? (async () => {
+          try {
+            const key = process.env.NEXT_PUBLIC_ZORA_API_KEY;
+            if (key) setApiKey(key);
+            const res = await getCoin({ address: checksumAddr, chain: 8453 });
+            return res?.data?.zora20Token ?? null;
+          } catch {
+            return null;
+          }
+        })()
+      : Promise.resolve(null),
+  ]);
+
+  if (!metaRes.ok) {
+    return NextResponse.json({ error: "Metadata request failed" }, { status: 502 });
+  }
+
+  const meta: { name: string | null; symbol: string | null; decimals: number | null; logo: string | null } =
+    (await metaRes.json())?.result ?? {};
+
+  if (!meta.symbol || !meta.name || meta.decimals == null) {
+    return NextResponse.json({ error: "Not a valid ERC-20 token" }, { status: 404 });
+  }
+
+  // Logo priority: Zora media → Alchemy logo → TrustWallet CDN.
+  let logoUrl: string | null = null;
+
+  if (zoraToken?.mediaContent?.previewImage) {
+    const preview = zoraToken.mediaContent.previewImage;
+    const raw =
+      typeof preview === "object"
+        ? (preview as Record<string, string>)?.medium ?? (preview as Record<string, string>)?.small
+        : (preview as string | undefined);
+    if (raw) {
+      logoUrl = raw.startsWith("ipfs://") ? raw.replace("ipfs://", "https://dweb.link/ipfs/") : raw;
+    }
+  }
+
+  if (!logoUrl) logoUrl = meta.logo ?? null;
+
+  if (!logoUrl) {
+    const twChain = TRUSTWALLET_CHAIN_NAMES[chainId];
+    if (twChain) {
+      logoUrl = `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/${twChain}/assets/${checksumAddr}/logo.png`;
+    }
+  }
+
+  return NextResponse.json({
+    address: checksumAddr,
+    symbol: meta.symbol,
+    name: meta.name,
+    decimals: meta.decimals,
+    logoUrl,
+  } satisfies LookedUpToken);
+}

--- a/src/app/swap/SwapWidget.tsx
+++ b/src/app/swap/SwapWidget.tsx
@@ -7,7 +7,7 @@ import { ArrowRight, Check, ChevronDown, Info, Loader2, Search } from "lucide-re
 import { toast } from "sonner";
 import { prepareContractCall, prepareTransaction, sendTransaction, waitForReceipt } from "thirdweb";
 import { useActiveWallet, useActiveWalletChain } from "thirdweb/react";
-import { formatUnits, maxUint256, parseUnits, type Address, type Hex } from "viem";
+import { formatUnits, isAddress, maxUint256, parseUnits, type Address, type Hex } from "viem";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -27,7 +27,7 @@ import { ensureOnChain, normalizeTxError } from "@/lib/thirdweb-tx";
 import { cn } from "@/lib/utils";
 import { getDefaultPair, NATIVE_TOKEN, type SwapToken } from "./chains";
 import { useSwapChain } from "./SwapChainContext";
-import { useWalletTokens } from "./useWalletTokens";
+import { useTokenLookup, useWalletTokens } from "./useWalletTokens";
 import {
   formatBalanceDisplay,
   useAllTokenBalances,
@@ -192,6 +192,11 @@ function TokenPicker({
     tokens,
   });
 
+  // When the query looks like a contract address and nothing in the list
+  // matches, resolve it via Alchemy metadata + Zora (on Base).
+  const queryTrimmed = query.trim();
+  const lookup = useTokenLookup({ address: queryTrimmed, chainId: chain.id });
+
   // Show the first 4 tokens of the chain as the "popular" row — chain
   // registries are ordered to put the staples first.
   const popular = React.useMemo(() => tokens.slice(0, 4), [tokens]);
@@ -295,9 +300,7 @@ function TokenPicker({
           )}
 
           <div className="-mx-6 max-h-80 overflow-y-auto border-t">
-            {filtered.length === 0 ? (
-              <p className="py-8 text-center text-sm text-muted-foreground">No tokens found</p>
-            ) : (
+            {filtered.length > 0 ? (
               filtered.map((t) => {
                 const isSelected = t.address === value.address;
                 const isExcluded = t.address === exclude;
@@ -335,6 +338,43 @@ function TokenPicker({
                   </button>
                 );
               })
+            ) : isAddress(queryTrimmed) ? (
+              // Address pasted but not in token list — resolve it on-the-fly.
+              lookup.isLoading ? (
+                <p className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Resolving token…
+                </p>
+              ) : lookup.data ? (
+                <button
+                  type="button"
+                  disabled={lookup.data.address === exclude}
+                  onClick={() => choose(lookup.data!)}
+                  className={cn(
+                    "flex w-full items-center gap-3 px-6 py-2.5 text-left transition-colors",
+                    lookup.data.address === exclude
+                      ? "cursor-not-allowed opacity-40"
+                      : "hover:bg-accent",
+                  )}
+                >
+                  <TokenLogo token={lookup.data} size={32} chainId={chain.id} />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-baseline gap-2">
+                      <span className="text-sm font-semibold">{lookup.data.symbol}</span>
+                      <span className="truncate text-xs text-muted-foreground">{lookup.data.name}</span>
+                    </div>
+                    <p className="truncate font-mono text-[10px] text-muted-foreground">
+                      {`${lookup.data.address.slice(0, 6)}…${lookup.data.address.slice(-4)}`}
+                    </p>
+                  </div>
+                </button>
+              ) : (
+                <p className="py-8 text-center text-sm text-muted-foreground">
+                  No ERC-20 token found at this address
+                </p>
+              )
+            ) : (
+              <p className="py-8 text-center text-sm text-muted-foreground">No tokens found</p>
             )}
           </div>
         </div>

--- a/src/app/swap/useWalletTokens.ts
+++ b/src/app/swap/useWalletTokens.ts
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { type Address } from "viem";
+import { isAddress, type Address } from "viem";
 import { type SwapChain, type SwapToken, type WalletToken, NATIVE_TOKEN } from "./chains";
 
 /**
@@ -90,4 +90,41 @@ export function useWalletTokens({
   }, [query.data]);
 
   return { tokens: mergedTokens, usdValues, isLoading: query.isLoading };
+}
+
+/**
+ * Resolves an arbitrary ERC-20 address to a SwapToken by calling
+ * /api/wallet/token-lookup (Alchemy metadata + Zora image on Base).
+ *
+ * Only fires when `address` is a valid 0x address. Results are cached
+ * for 24 h — token metadata is stable.
+ */
+export function useTokenLookup({
+  address,
+  chainId,
+}: {
+  address: string;
+  chainId: number;
+}) {
+  return useQuery<SwapToken | null>({
+    queryKey: ["token-lookup", chainId, address.toLowerCase()],
+    enabled: isAddress(address),
+    staleTime: 24 * 60 * 60 * 1000,
+    retry: false,
+    queryFn: async () => {
+      const res = await fetch(
+        `/api/wallet/token-lookup?address=${address}&chainId=${chainId}`,
+      );
+      if (!res.ok) return null;
+      const data = await res.json();
+      if (!data?.symbol) return null;
+      return {
+        address: data.address as `0x${string}`,
+        symbol: data.symbol,
+        name: data.name,
+        decimals: data.decimals,
+        logo: data.logoUrl ?? undefined,
+      };
+    },
+  });
 }


### PR DESCRIPTION
## Summary
- Pasting a contract address into the token picker now resolves it on-the-fly instead of showing "No tokens found"
- Alchemy (`alchemy_getTokenMetadata`) handles any ERC-20 on all 4 chains; Zora SDK runs in parallel on Base for creator coin images

## Changes
- **`/api/wallet/token-lookup`** (new) — `alchemy_getTokenMetadata` + `getCoin` (Zora) in parallel; TrustWallet CDN fallback for logo
- **`useTokenLookup`** — React Query hook, fires only when query `isAddress()`, 24h cache
- **`TokenPicker`** — detects address query, shows spinner → resolved token row → "not found" error

## Test plan
- [ ] Paste a known ERC-20 address not in the list → resolves with name/symbol/logo
- [ ] Paste a Zora creator coin address on Base → shows Zora image
- [ ] Paste a garbage string → no spinner, "No tokens found"
- [ ] Paste a valid address that isn't an ERC-20 → "No ERC-20 token found at this address"
- [ ] Select the resolved token → swap proceeds normally with 0x

Generated with [Claude Code](https://claude.com/claude-code)