### PR TITLE
fix(bounties): hide Join/Contribute on completed bounties + render Pinata media

### DIFF
--- a/src/app/api/media-type/route.ts
+++ b/src/app/api/media-type/route.ts
@@ -9,6 +9,13 @@ const ALLOWED_HOSTNAMES = new Set([
   'nftstorage.link',
 ]);
 
+const ALLOWED_HOST_SUFFIXES = ['.mypinata.cloud'];
+
+function isAllowedHost(hostname: string): boolean {
+  if (ALLOWED_HOSTNAMES.has(hostname)) return true;
+  return ALLOWED_HOST_SUFFIXES.some((suffix) => hostname.endsWith(suffix));
+}
+
 export async function GET(req: NextRequest) {
   const url = req.nextUrl.searchParams.get('url');
   if (!url) return NextResponse.json({ error: 'Missing url' }, { status: 400 });
@@ -20,7 +27,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: 'Invalid url' }, { status: 400 });
   }
 
-  if (!ALLOWED_HOSTNAMES.has(hostname)) {
+  if (!isAllowedHost(hostname)) {
     return NextResponse.json({ error: 'URL hostname not allowed' }, { status: 400 });
   }
 

--- a/src/components/bounties/BountyDetailView.tsx
+++ b/src/components/bounties/BountyDetailView.tsx
@@ -110,12 +110,14 @@ function isIpfsCid(url: string | undefined): boolean {
 const STATUS_STYLES = {
   Canceled: "bg-red-500/10 text-red-400 border-red-500/20",
   Voting: "bg-yellow-500/10 text-yellow-400 border-yellow-500/20",
+  Completed: "bg-sky-500/10 text-sky-400 border-sky-500/20",
   Open: "bg-emerald-500/10 text-emerald-400 border-emerald-500/20",
 } as const;
 
 function getStatus(bounty: PoidhBounty): keyof typeof STATUS_STYLES {
   if (bounty.isCanceled) return "Canceled";
   if (bounty.isVoting) return "Voting";
+  if (bounty.isCompleted) return "Completed";
   return "Open";
 }
 
@@ -318,7 +320,7 @@ export function BountyDetailView({ initialBounty, chainId, bountyId }: BountyDet
   const deadlineDate = bounty.deadline ? new Date(bounty.deadline * 1000) : null;
   const status = getStatus(bounty);
   const isCreator = address?.toLowerCase() === bounty.issuer.toLowerCase();
-  const isActive = !bounty.isCanceled && !bounty.isVoting;
+  const isActive = !bounty.isCanceled && !bounty.isVoting && !bounty.isCompleted;
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-5xl">
@@ -888,7 +890,7 @@ export function BountyDetailView({ initialBounty, chainId, bountyId }: BountyDet
           )}
 
           {/* Join open bounty (add funds) */}
-          {isJoinable && !bounty.isCanceled && !bounty.isVoting && (
+          {isJoinable && isActive && (
             <Card className="border-border">
               <CardHeader className="pb-3">
                 <CardTitle className="text-base">Add to the Prize Pool</CardTitle>

--- a/src/services/poidh.ts
+++ b/src/services/poidh.ts
@@ -162,6 +162,7 @@ export const fetchPoidhBounty = cache(
     return {
       ...bounty,
       isOpenBounty: bounty.isOpenBounty ?? bounty.isMultiplayer,
+      isCompleted: bounty.isCompleted ?? claims.some((c) => c.accepted),
       claims,
     };
   },


### PR DESCRIPTION
## Summary
- Completed POIDH bounties (claim accepted, prize paid out) no longer expose live **Submit Your Proof** / **Add to the Prize Pool** CTAs and now show a **Completed** status badge.
- Claim media hosted on POIDH's dedicated Pinata gateway (`*.mypinata.cloud`) now renders inline as images/videos instead of the **View media** fallback link — this was rejecting 100% of claim media on the bounty detail page.

Surfaced by Vlad ("Retirar Botão Join de Bounty pages que já foram Closed") and João ("a foto não aparece depois no submissions") on the GNARS CREW 2026 Trello board.

## Changes
- [`src/services/poidh.ts`](src/services/poidh.ts): derive `isCompleted` in `fetchPoidhBounty` from `claims.some(c => c.accepted)` since the detail-fetch tRPC endpoint doesn't return that flag.
- [`src/components/bounties/BountyDetailView.tsx`](src/components/bounties/BountyDetailView.tsx): add `Completed` to `STATUS_STYLES` (sky), return it from `getStatus`, propagate through `isActive`, and reuse `isActive` for the Add-to-the-Prize-Pool gate so closed-state CTAs hide automatically.
- [`src/app/api/media-type/route.ts`](src/app/api/media-type/route.ts): allow `*.mypinata.cloud` host suffix (POIDH and other dedicated Pinata gateways).

## Test plan
Verified live against `/community/bounties/8453/1148` (a real completed bounty, deadline May 1st):

- [x] Status badge reads **Completed** (was: Open).
- [x] No `Join` button, no `Contribute X ETH` form, no Submit Your Proof / Add to the Prize Pool cards.
- [x] All 19 claim images render inline (no `View media` fallback links remaining).
- [x] `curl /api/media-type?url=…mypinata.cloud…` returns `{ contentType: "image/jpeg", isImage: true }` instead of `{ error: "URL hostname not allowed" }`.
- [x] `pnpm lint` passes (only the pre-existing `BountiesView.tsx` `<img>` warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)