### PR TITLE
fix(a11y,perf): lift nested skeleton component, add prefers-reduced-motion

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -132,7 +132,9 @@
     @apply !bg-transparent !border-none;
     @apply !bg-transparent !border-none;
   }
-  .leaflet-popup-content-wrapper, .leaflet-popup-content, .leaflet-popup-content p {
+  .leaflet-popup-content-wrapper,
+  .leaflet-popup-content,
+  .leaflet-popup-content p {
     @apply ![all:unset];
     @apply ![all:unset];
   }
@@ -144,7 +146,8 @@
     @apply ring-offset-background focus:ring-ring bg-secondary rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:outline-hidden;
     @apply ring-offset-background focus:ring-ring bg-secondary rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:outline-hidden;
   }
-  .leaflet-tooltip, .leaflet-draw-tooltip {
+  .leaflet-tooltip,
+  .leaflet-draw-tooltip {
     @apply !bg-foreground !text-background !animate-none !rounded-md !border-none !p-0 !px-3 !py-1.5 !shadow-none;
     @apply !bg-foreground !text-background !animate-none !rounded-md !border-none !p-0 !px-3 !py-1.5 !shadow-none;
   }
@@ -164,7 +167,11 @@
     @apply !text-background;
     @apply !text-background;
   }
-  .leaflet-popup-tip-container, .leaflet-tooltip-top:before, .leaflet-tooltip-bottom:before, .leaflet-tooltip-left:before, .leaflet-tooltip-right:before {
+  .leaflet-popup-tip-container,
+  .leaflet-tooltip-top:before,
+  .leaflet-tooltip-bottom:before,
+  .leaflet-tooltip-left:before,
+  .leaflet-tooltip-right:before {
     @apply hidden;
     @apply hidden;
   }
@@ -213,4 +220,18 @@
   aspect-ratio: 16 / 9;
   border-radius: 0.375rem;
   margin: 0.75rem 0;
+}
+
+/* WCAG 2.3.3 — honor user's reduced-motion preference for CSS animations
+   and transitions. JS-driven motion (Framer Motion, GSAP, Three.js) should
+   additionally consult `useReducedMotion()` or `matchMedia` when needed. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/src/components/skeletons/loading-grid-skeleton.tsx
+++ b/src/components/skeletons/loading-grid-skeleton.tsx
@@ -8,47 +8,51 @@ interface LoadingGridSkeletonProps {
   containerClassName?: string;
 }
 
+function SkeletonItem({
+  withCard,
+  aspectClassName,
+}: {
+  withCard: boolean;
+  aspectClassName: string;
+}) {
+  const content = (
+    <div className="p-4">
+      <Skeleton className={`${aspectClassName} w-full mb-5 rounded-md`} />
+      <div className="flex items-center justify-between mb-3">
+        <Skeleton className="h-4 w-24" />
+        <Skeleton className="h-5 w-20" />
+      </div>
+      <Skeleton className="h-4 w-3/4 mb-1" />
+      <Skeleton className="h-3 w-1/2 mb-4" />
+      <div className="space-y-3">
+        <Skeleton className="h-1.5 w-full" />
+        <div className="flex justify-between text-xs">
+          <Skeleton className="h-3 w-16" />
+          <Skeleton className="h-3 w-16" />
+          <Skeleton className="h-3 w-16" />
+        </div>
+      </div>
+    </div>
+  );
+  return withCard ? (
+    <Card className="py-2">
+      <CardContent className="p-0">{content}</CardContent>
+    </Card>
+  ) : (
+    <div className="p-0">{content}</div>
+  );
+}
+
 export function LoadingGridSkeleton({
   items = 8,
   withCard = true,
   aspectClassName = "aspect-square",
   containerClassName = "grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4",
 }: LoadingGridSkeletonProps) {
-  const Item = ({ index }: { index: number }) => {
-    const content = (
-      <div className="p-4">
-        <Skeleton className={`${aspectClassName} w-full mb-5 rounded-md`} />
-        <div className="flex items-center justify-between mb-3">
-          <Skeleton className="h-4 w-24" />
-          <Skeleton className="h-5 w-20" />
-        </div>
-        <Skeleton className="h-4 w-3/4 mb-1" />
-        <Skeleton className="h-3 w-1/2 mb-4" />
-        <div className="space-y-3">
-          <Skeleton className="h-1.5 w-full" />
-          <div className="flex justify-between text-xs">
-            <Skeleton className="h-3 w-16" />
-            <Skeleton className="h-3 w-16" />
-            <Skeleton className="h-3 w-16" />
-          </div>
-        </div>
-      </div>
-    );
-    return withCard ? (
-      <Card key={index} className="py-2">
-        <CardContent className="p-0">{content}</CardContent>
-      </Card>
-    ) : (
-      <div key={index} className="p-0">
-        {content}
-      </div>
-    );
-  };
-
   return (
     <div className={containerClassName}>
       {Array.from({ length: items }).map((_, i) => (
-        <Item key={i} index={i} />
+        <SkeletonItem key={i} withCard={withCard} aspectClassName={aspectClassName} />
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- Lift `Item` out of `LoadingGridSkeleton` to module scope. Defining it inside the parent recreates the component identity on every render, destroying any internal state and breaking memoization downstream.
- Add a global `@media (prefers-reduced-motion: reduce)` rule to `globals.css` that neutralizes CSS animations, transitions, and smooth scroll. Satisfies WCAG 2.3.3 at the CSS layer.

Both issues were surfaced by `npx react-doctor@latest`. The remaining ~1250 findings from that scan were either false positives (Three.js JSX, JSON-RPC POSTs from GET handlers, `Vector3.sub()` matched as a subscription) or stylistic opinions (no em-dashes, no gradient text, no default Tailwind palette) and are not addressed here.

## Changes
- `src/components/skeletons/loading-grid-skeleton.tsx` — extract `SkeletonItem` to module scope, pass `withCard` and `aspectClassName` as props.
- `src/app/globals.css` — append reduced-motion media query. Prettier also normalized a few pre-existing multi-selector lines (cosmetic).

## Test plan
- [ ] Loading skeletons still render on `/auctions` past auctions and treasury NFT holdings (both `LoadingGridSkeleton` consumers).
- [ ] With OS-level "reduce motion" enabled, CSS transitions and scroll-behavior animations are effectively instant. JS-driven motion (Framer Motion, GSAP, Three.js) is unaffected and should be revisited per-component if needed.
- [ ] `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)