### PR TITLE
fix(bounties): graceful POIDH downtime + nav/copy refresh

### DIFF
--- a/messages/en/bounties.json
+++ b/messages/en/bounties.json
@@ -1,7 +1,6 @@
 {
-  "title": "Challenges",
-  "description": "Gnars Bountie is a new lane for small onchain grants built to keep the wheels turning.",
-  "poweredBy": "Powered by POIDH",
+  "title": "Bounties",
+  "description": "Gnars Bounties are challenges from the community: pay athletes in ETH to land the tricks, runs, and stunts the DAO wants to see filmed.",
   "cta": {
     "createBounty": "Create Bounty",
     "create": "Create",
@@ -59,9 +58,9 @@
     "error": "Failed to load bounties"
   },
   "manifesto": {
-    "sectionLabel": "Manifesto",
+    "sectionLabel": "How it works",
     "p1": "Gnars Bounties builds on prior community-driven moments by enabling direct, permissionless execution. It removes friction from traditional grant systems, allowing ideas to be posted, funded, completed, and rewarded onchain in a simple, open flow.",
-    "howItWorksLabel": "How It Works:",
+    "howItWorksLabel": "The flow:",
     "howItWorksBody": "Create or select a bounty → fund or support a mission → execute and submit work → get verified → receive onchain payment"
   },
   "detail": {

--- a/messages/en/nav.json
+++ b/messages/en/nav.json
@@ -36,6 +36,10 @@
         "title": "Treasury",
         "description": "ETH, ERC-20s, NFTs, and onchain analytics for the DAO treasury"
       },
+      "bounties": {
+        "title": "Bounties",
+        "description": "Gnarly challenges from the action sports community"
+      },
       "swap": {
         "title": "Swap",
         "description": "Trade tokens on Base via 0x — best price across 150+ DEXes"
@@ -66,10 +70,6 @@
       "createCoin": {
         "title": "Create Coin",
         "description": "Create a new coin on Zora"
-      },
-      "bounties": {
-        "title": "Bounties",
-        "description": "Gnarly challenges from the action sports community"
       }
     }
   }

--- a/messages/pt-br/bounties.json
+++ b/messages/pt-br/bounties.json
@@ -1,7 +1,6 @@
 {
-  "title": "Desafios",
-  "description": "Gnars Bountie é uma nova via de pequenos grants onchain feita pra manter as rodas girando.",
-  "poweredBy": "Powered by POIDH",
+  "title": "Bounties",
+  "description": "Os Gnars Bounties são desafios da comunidade: paguem atletas em ETH para mandar as manobras, runs e tretas que a DAO quer ver filmadas.",
   "cta": {
     "createBounty": "Criar Bounty",
     "create": "Criar",
@@ -59,9 +58,9 @@
     "error": "Falha ao carregar bounties"
   },
   "manifesto": {
-    "sectionLabel": "Manifesto",
+    "sectionLabel": "Como funciona",
     "p1": "Gnars Bounties se apoia em momentos anteriores movidos pela comunidade ao permitir execução direta e permissionless. Tira a fricção dos sistemas tradicionais de grant, permitindo que ideias sejam postadas, financiadas, concluídas e recompensadas onchain num fluxo simples e aberto.",
-    "howItWorksLabel": "Como funciona:",
+    "howItWorksLabel": "O fluxo:",
     "howItWorksBody": "Crie ou selecione um bounty → financie ou apoie uma missão → execute e envie o trabalho → seja verificado → receba pagamento onchain"
   },
   "detail": {

--- a/messages/pt-br/nav.json
+++ b/messages/pt-br/nav.json
@@ -36,6 +36,10 @@
         "title": "Tesouro",
         "description": "ETH, ERC-20s, NFTs e analytics onchain do tesouro da DAO"
       },
+      "bounties": {
+        "title": "Bounties",
+        "description": "Desafios gnarly da comunidade de esportes radicais"
+      },
       "swap": {
         "title": "Swap",
         "description": "Troque tokens na Base via 0x — melhor preço em mais de 150 DEXes"
@@ -66,10 +70,6 @@
       "createCoin": {
         "title": "Criar Coin",
         "description": "Crie um novo coin na Zora"
-      },
-      "bounties": {
-        "title": "Bounties",
-        "description": "Desafios gnarly da comunidade de esportes radicais"
       }
     }
   }

--- a/src/app/[locale]/community/bounties/[chainId]/[id]/error.tsx
+++ b/src/app/[locale]/community/bounties/[chainId]/[id]/error.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { AlertTriangle, ArrowLeft, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function BountyError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Bounty detail page error:", error);
+  }, [error]);
+
+  return (
+    <div className="container mx-auto px-4 py-16 max-w-2xl text-center">
+      <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-destructive/10">
+        <AlertTriangle className="h-8 w-8 text-destructive" />
+      </div>
+      <h1 className="text-2xl font-bold mb-2">Something went wrong</h1>
+      <p className="text-muted-foreground mb-8">
+        We hit an error loading this bounty. The POIDH service may be having issues.
+      </p>
+      <div className="flex items-center justify-center gap-2">
+        <Button variant="outline" onClick={reset}>
+          <RefreshCw className="h-4 w-4 mr-2" />
+          Try again
+        </Button>
+        <Button asChild variant="ghost">
+          <Link href="/community/bounties">
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back to Bounties
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/community/bounties/[chainId]/[id]/not-found.tsx
+++ b/src/app/[locale]/community/bounties/[chainId]/[id]/not-found.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import { ArrowLeft, SearchX } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function BountyNotFound() {
+  return (
+    <div className="container mx-auto px-4 py-16 max-w-2xl text-center">
+      <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-muted">
+        <SearchX className="h-8 w-8 text-muted-foreground" />
+      </div>
+      <h1 className="text-2xl font-bold mb-2">Bounty unavailable</h1>
+      <p className="text-muted-foreground mb-2">
+        We couldn&apos;t load this bounty. It may not exist, or the POIDH service may be temporarily
+        down.
+      </p>
+      <p className="text-sm text-muted-foreground mb-8">
+        Try again in a few minutes, or check{" "}
+        <a
+          href="https://poidh.xyz"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline underline-offset-4 hover:text-foreground"
+        >
+          poidh.xyz
+        </a>{" "}
+        for status.
+      </p>
+      <div className="flex items-center justify-center gap-2">
+        <Button asChild variant="outline">
+          <Link href="/community/bounties">
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back to Bounties
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/bounties/BountiesView.tsx
+++ b/src/components/bounties/BountiesView.tsx
@@ -114,7 +114,7 @@ export function BountiesView({ initialBounties }: BountiesViewProps) {
         <div className="flex items-start justify-between gap-4">
           <div>
             <h1 className="text-3xl font-bold tracking-tight">{t("title")}</h1>
-            <p className="text-muted-foreground mt-1">{t("description")}</p>
+            <p className="text-sm text-muted-foreground mt-1">{t("description")}</p>
           </div>
           <CreateBountyModal>
             <Button className="shrink-0">

--- a/src/components/bounties/BountiesView.tsx
+++ b/src/components/bounties/BountiesView.tsx
@@ -114,17 +114,7 @@ export function BountiesView({ initialBounties }: BountiesViewProps) {
         <div className="flex items-start justify-between gap-4">
           <div>
             <h1 className="text-3xl font-bold tracking-tight">{t("title")}</h1>
-            <p className="text-muted-foreground mt-1">
-              {t("description")}{" "}
-              <a
-                href="https://poidh.xyz"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-foreground underline underline-offset-4 decoration-muted-foreground/40 hover:decoration-foreground transition-colors"
-              >
-                {t("poweredBy")}
-              </a>
-            </p>
+            <p className="text-muted-foreground mt-1">{t("description")}</p>
           </div>
           <CreateBountyModal>
             <Button className="shrink-0">
@@ -239,6 +229,19 @@ export function BountiesView({ initialBounties }: BountiesViewProps) {
                 <p className="text-foreground">{t("manifesto.howItWorksLabel")}</p>
                 <p>{t("manifesto.howItWorksBody")}</p>
               </div>
+              <p className="pt-2 text-xs text-muted-foreground/80">
+                Powered by{" "}
+                <a
+                  href="https://poidh.xyz"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-foreground underline underline-offset-4 decoration-muted-foreground/40 hover:decoration-foreground transition-colors"
+                >
+                  POIDH
+                </a>{" "}
+                — Pics or it didn&apos;t happen. Bounties are escrowed onchain by the POIDH V3
+                contract.
+              </p>
             </div>
           </div>
         </div>

--- a/src/components/bounties/BountyDetailView.tsx
+++ b/src/components/bounties/BountyDetailView.tsx
@@ -1092,8 +1092,8 @@ export function BountyDetailView({ initialBounty, chainId, bountyId }: BountyDet
             </Card>
           )}
 
-          {/* Cancel (creator only) */}
-          {isCreator && !bounty.isCanceled && (
+          {/* Cancel (creator only — only available while the bounty is active) */}
+          {isCreator && isActive && (
             <Card className="border-destructive/20">
               <CardHeader className="pb-3">
                 <CardTitle className="text-base text-destructive/80">

--- a/src/components/layout/DaoHeader.tsx
+++ b/src/components/layout/DaoHeader.tsx
@@ -125,6 +125,13 @@ function buildNavigationItems(t: NavTranslations) {
           description: t("items.money.treasury.description"),
         },
         {
+          title: t("items.money.bounties.title"),
+          href: "/community/bounties",
+          icon: Gift,
+          description: t("items.money.bounties.description"),
+          badge: "NEW!",
+        },
+        {
           title: t("items.money.swap.title"),
           href: "/swap",
           icon: ArrowLeftRight,
@@ -173,13 +180,6 @@ function buildNavigationItems(t: NavTranslations) {
           href: "/create-coin",
           icon: Coins,
           description: t("items.community.createCoin.description"),
-          badge: "NEW!",
-        },
-        {
-          title: t("items.community.bounties.title"),
-          href: "/community/bounties",
-          icon: Gift,
-          description: t("items.community.bounties.description"),
           badge: "NEW!",
         },
       ],

--- a/src/hooks/usePoidhContract.ts
+++ b/src/hooks/usePoidhContract.ts
@@ -81,6 +81,7 @@ const POIDH_ERROR_MESSAGES: Record<string, string> = {
   WrongCaller: "You are not allowed to perform this action.",
   IssuerCannotClaim: "The bounty creator cannot submit a claim.",
   IssuerCannotWithdraw: "The bounty creator cannot withdraw as a contributor.",
+  IssuerCannotWithdrawFromOpenBounty: "The bounty creator can't withdraw as a contributor.",
   NotActiveParticipant: "You are not a participant in this bounty.",
   NotOpenBounty: "This action is only available for open bounties.",
   NotSoloBounty: "This action is only available for solo bounties.",
@@ -89,17 +90,43 @@ const POIDH_ERROR_MESSAGES: Record<string, string> = {
   MaxParticipantsReached: "This bounty has reached its maximum number of participants.",
   NotCancelledOpenBounty: "This bounty has not been cancelled.",
   VoteWouldPass: "Cannot reset — the vote would pass. Resolve it instead.",
-  MinimumBountyNotMet: "Amount is below the minimum required to create a bounty.",
-  MinimumContributionNotMet: "Amount is below the minimum required to contribute.",
-  NoEther: "No ETH sent.",
-  ContractsCannotCreateBounties: "Smart contracts cannot create bounties directly.",
-  TransferFailed: "ETH transfer failed.",
-  InsufficientBalance: "Insufficient balance.",
+  MinimumBountyNotMet: "Reward is below the minimum required by POIDH to create a bounty.",
+  MinimumContributionNotMet: "Contribution is below the minimum required by POIDH.",
+  NoEther: "You need to send some ETH with this transaction.",
+  ContractsCannotCreateBounties:
+    "Smart wallets can't create bounties directly. Switch to your EOA in the wallet drawer.",
+  TransferFailed: "ETH transfer failed. Try again in a moment.",
+  InsufficientBalance: "Not enough ETH in your wallet to cover this transaction.",
 };
+
+const USER_REJECTION_PATTERNS = [
+  "user rejected",
+  "user denied",
+  "rejected the request",
+  "userrejectedrequesterror",
+  "request rejected",
+  "transaction rejected",
+  "user cancelled",
+];
+
+const INSUFFICIENT_FUNDS_PATTERNS = [
+  "insufficient funds",
+  "exceeds the balance",
+  "insufficient balance for transfer",
+];
 
 function decodePoidhError(err: unknown): Error {
   if (!(err instanceof Error)) return new Error(String(err));
   const msg = err.message;
+  const lower = msg.toLowerCase();
+
+  if (USER_REJECTION_PATTERNS.some((p) => lower.includes(p))) {
+    return new Error("Transaction cancelled in wallet.");
+  }
+  if (INSUFFICIENT_FUNDS_PATTERNS.some((p) => lower.includes(p))) {
+    return new Error("Not enough ETH in your wallet to cover gas and the reward.");
+  }
+
   for (const [name, friendly] of Object.entries(POIDH_ERROR_MESSAGES)) {
     if (msg.includes(name)) return new Error(friendly);
   }

--- a/src/services/poidh.ts
+++ b/src/services/poidh.ts
@@ -129,7 +129,14 @@ export const fetchPoidhBounty = cache(
     if (!SUPPORTED_CHAIN_IDS.includes(chainId)) return null;
     if (isNaN(id) || id < 1) return null;
 
-    const bountyData = await fetchFromPoidh("bounties.fetch", { id, chainId }, DETAIL_CACHE_TTL);
+    let bountyData: unknown;
+    try {
+      bountyData = await fetchFromPoidh("bounties.fetch", { id, chainId }, DETAIL_CACHE_TTL);
+    } catch (err) {
+      // POIDH upstream failure — degrade gracefully instead of crashing the page
+      console.error("POIDH bounty fetch failed:", err);
+      return null;
+    }
 
     if (!bountyData) return null;
     const bounty = bountyData as PoidhBounty;


### PR DESCRIPTION
## Summary

Bounty detail page (`/community/bounties/[chainId]/[id]`) was returning **HTTP 500** instead of a friendly state when POIDH's hosted tRPC API was down (it currently returns `prisma.bounties.findUniqueOrThrow()` errors saying `public.Bounties` does not exist, plus intermittent `Too many database connections` and connect timeouts to `poidh.xyz:443`). The list page already caught and degraded to empty; the detail page did not, so the throw bypassed `notFound()` and Next.js rendered a hard 500.

This PR makes the bounty experience resilient to POIDH downtime and bundles the requested polish:

- **Bug fix**: `fetchPoidhBounty` now catches upstream failures and returns `null`, and the route ships a dedicated `not-found.tsx` + `error.tsx` explaining the outage with a link to `poidh.xyz` for status.
- **Nav**: `Bounties` moves from the **Community** menu to the **Money** menu in the 2nd slot (between Treasury and Swap).
- **Copy**: new headline framing — "Gnars Bounties are challenges from the community: pay athletes in ETH to land the tricks, runs, and stunts the DAO wants to see filmed." The **Powered by POIDH** mention is relocated into the renamed "How it works" section.
- **Create Bounty modal**: `decodePoidhError` now also catches wallet rejection and insufficient-funds errors, plus friendlier copy for `ContractsCannotCreateBounties` / `Minimum*NotMet` / `NoEther` / `InsufficientBalance`.
- **Detail UI state polish**: Cancel button hidden when bounty `isVoting` or `isCompleted` — contract would have reverted with `VotingOngoing` / `BountyClaimed`.

## Changes

- `src/services/poidh.ts` — try/catch around the POIDH detail fetch
- `src/app/community/bounties/[chainId]/[id]/not-found.tsx` (new) — friendly 404
- `src/app/community/bounties/[chainId]/[id]/error.tsx` (new) — error boundary with retry
- `src/components/layout/DaoHeader.tsx` — move Bounties to Money menu, position 2
- `src/components/bounties/BountiesView.tsx` — new copy + relocated Powered by POIDH attribution
- `src/components/bounties/BountyDetailView.tsx` — `isActive` gate on Cancel button
- `src/hooks/usePoidhContract.ts` — user-rejection / insufficient-funds detection in `decodePoidhError` + friendlier custom-error copy

## Test plan

- [x] `pnpm lint` — clean (1 pre-existing warning)
- [x] Local dev: `/community/bounties/8453/1167` returns 404 + "Bounty unavailable" UI while POIDH is down
- [x] Local dev: same URL returns 200 + full detail page when POIDH is back up
- [x] Local dev: `/community/bounties` list still renders (200) with empty grid on POIDH outage
- [ ] Manual: confirm Bounties appears under Money dropdown (desktop + mobile)
- [ ] Manual: trigger wallet rejection in Create Bounty modal → see "Transaction cancelled in wallet."
- [ ] Manual: open a completed bounty as creator → Cancel button hidden
- [ ] Manual: open a bounty currently in voting as creator → Cancel button hidden

Generated with [Claude Code](https://claude.com/claude-code)