### PR TITLE
feat(proposals): multi-select NFTs in send-nfts form

### DIFF
--- a/messages/en/propose.json
+++ b/messages/en/propose.json
@@ -99,13 +99,16 @@
     "descriptionPlaceholder": "Describe the purpose of this token transfer..."
   },
   "sendNfts": {
-    "selectGnarLabel": "Select a Gnar from Treasury *",
+    "selectGnarLabel": "Select Gnars from Treasury *",
     "failedToLoad": "Failed to load treasury NFTs: {error}",
     "noGnarsFound": "No Gnars found in treasury.",
     "toAddressLabel": "To Address *",
     "toAddressPlaceholder": "0x... or ENS name",
-    "pleaseSelectNft": "Please select an NFT",
-    "descriptionLabel": "Description",
+    "pleaseSelectNft": "Please select at least one NFT",
+    "selectedCount": "{count} selected",
+    "multiSelectHint": "Each NFT will be added as a separate transaction.",
+    "addNTransactions": "Add {count} transactions",
+    "descriptionLabel": "Description (optional)",
     "descriptionPlaceholder": "Describe the purpose of this NFT transfer..."
   },
   "droposal": {

--- a/messages/pt-br/propose.json
+++ b/messages/pt-br/propose.json
@@ -99,13 +99,16 @@
     "descriptionPlaceholder": "Descreva o propósito dessa transferência de token..."
   },
   "sendNfts": {
-    "selectGnarLabel": "Selecione um Gnar do Tesouro *",
+    "selectGnarLabel": "Selecione Gnars do Tesouro *",
     "failedToLoad": "Falha ao carregar NFTs do tesouro: {error}",
     "noGnarsFound": "Nenhum Gnar encontrado no tesouro.",
     "toAddressLabel": "Endereço de Destino *",
     "toAddressPlaceholder": "0x... ou nome ENS",
-    "pleaseSelectNft": "Por favor, selecione um NFT",
-    "descriptionLabel": "Descrição",
+    "pleaseSelectNft": "Por favor, selecione pelo menos um NFT",
+    "selectedCount": "{count} selecionado(s)",
+    "multiSelectHint": "Cada NFT será adicionado como uma transação separada.",
+    "addNTransactions": "Adicionar {count} transações",
+    "descriptionLabel": "Descrição (opcional)",
     "descriptionPlaceholder": "Descreva o propósito dessa transferência de NFT..."
   },
   "droposal": {

--- a/src/components/proposals/builder/ActionForms.tsx
+++ b/src/components/proposals/builder/ActionForms.tsx
@@ -61,7 +61,7 @@ interface ActionFormsProps {
   actionType: string;
   onSubmit: () => void;
   onCancel: () => void;
-  onNftMultiSubmit?: (selectedIds: number[]) => void;
+  onNftMultiSubmit?: (selectedIds: number[], imageMap: Record<number, string | undefined>) => void;
 }
 
 export function ActionForms({ index, actionType, onSubmit, onCancel, onNftMultiSubmit }: ActionFormsProps) {
@@ -70,6 +70,7 @@ export function ActionForms({ index, actionType, onSubmit, onCancel, onNftMultiS
   const [isGenerating, setIsGenerating] = useState(false);
   const [sdkError, setSDKError] = useState<string | null>(null);
   const [nftSelectedIds, setNftSelectedIds] = useState<number[]>([]);
+  const [nftImageMap, setNftImageMap] = useState<Record<number, string | undefined>>({});
 
   // Add split creation hook
   const { createSplit } = useSplitCreation();
@@ -226,7 +227,7 @@ export function ActionForms({ index, actionType, onSubmit, onCancel, onNftMultiS
 
   const handleNftSubmit = () => {
     if (onNftMultiSubmit && nftSelectedIds.length > 1) {
-      onNftMultiSubmit(nftSelectedIds);
+      onNftMultiSubmit(nftSelectedIds, nftImageMap);
     } else {
       onSubmit();
     }
@@ -241,7 +242,15 @@ export function ActionForms({ index, actionType, onSubmit, onCancel, onNftMultiS
       case "send-tokens":
         return <SendTokensForm index={index} />;
       case "send-nfts":
-        return <SendNFTsForm index={index} onSelectionChange={setNftSelectedIds} />;
+        return (
+          <SendNFTsForm
+            index={index}
+            onSelectionChange={(ids, imageMap) => {
+              setNftSelectedIds(ids);
+              setNftImageMap(imageMap);
+            }}
+          />
+        );
       case "droposal":
         return <DroposalForm index={index} />;
       case "buy-coin":

--- a/src/components/proposals/builder/ActionForms.tsx
+++ b/src/components/proposals/builder/ActionForms.tsx
@@ -61,13 +61,15 @@ interface ActionFormsProps {
   actionType: string;
   onSubmit: () => void;
   onCancel: () => void;
+  onNftMultiSubmit?: (selectedIds: number[]) => void;
 }
 
-export function ActionForms({ index, actionType, onSubmit, onCancel }: ActionFormsProps) {
+export function ActionForms({ index, actionType, onSubmit, onCancel, onNftMultiSubmit }: ActionFormsProps) {
   const t = useTranslations("propose");
   const { handleSubmit, setValue, getValues } = useFormContext<ProposalFormValues>();
   const [isGenerating, setIsGenerating] = useState(false);
   const [sdkError, setSDKError] = useState<string | null>(null);
+  const [nftSelectedIds, setNftSelectedIds] = useState<number[]>([]);
 
   // Add split creation hook
   const { createSplit } = useSplitCreation();
@@ -222,6 +224,14 @@ export function ActionForms({ index, actionType, onSubmit, onCancel }: ActionFor
     }
   };
 
+  const handleNftSubmit = () => {
+    if (onNftMultiSubmit && nftSelectedIds.length > 1) {
+      onNftMultiSubmit(nftSelectedIds);
+    } else {
+      onSubmit();
+    }
+  };
+
   const renderForm = () => {
     switch (actionType) {
       case "send-eth":
@@ -231,7 +241,7 @@ export function ActionForms({ index, actionType, onSubmit, onCancel }: ActionFor
       case "send-tokens":
         return <SendTokensForm index={index} />;
       case "send-nfts":
-        return <SendNFTsForm index={index} />;
+        return <SendNFTsForm index={index} onSelectionChange={setNftSelectedIds} />;
       case "droposal":
         return <DroposalForm index={index} />;
       case "buy-coin":
@@ -291,7 +301,9 @@ export function ActionForms({ index, actionType, onSubmit, onCancel }: ActionFor
                 ? handleDroposalSubmit
                 : actionType === "buy-coin"
                   ? handleBuyCoinSubmit
-                  : onSubmit,
+                  : actionType === "send-nfts"
+                    ? handleNftSubmit
+                    : onSubmit,
               onError,
             )}
             disabled={isGenerating}
@@ -305,6 +317,8 @@ export function ActionForms({ index, actionType, onSubmit, onCancel }: ActionFor
                     ? t("transactions.generating")
                     : t("transactions.saving")}
               </>
+            ) : actionType === "send-nfts" && nftSelectedIds.length > 1 ? (
+              t("sendNfts.addNTransactions", { count: nftSelectedIds.length })
             ) : (
               t("transactions.saveTransaction")
             )}

--- a/src/components/proposals/builder/TransactionBuilder.tsx
+++ b/src/components/proposals/builder/TransactionBuilder.tsx
@@ -73,8 +73,6 @@ export function TransactionBuilder({ onFormsVisibilityChange }: TransactionBuild
   };
 
   const handleTransactionSubmit = () => {
-    // Values are already bound to useFieldArray via nested registration
-    // Parent callbacks can still be notified for external side-effects
     if (editingTransactionIndex !== null) {
       const currentValues = getValues();
       const updatedTx = currentValues.transactions[
@@ -82,7 +80,39 @@ export function TransactionBuilder({ onFormsVisibilityChange }: TransactionBuild
       ] as unknown as TransactionFormValues;
       update(editingTransactionIndex, updatedTx);
     }
-    // For new items, onAddTransaction already handled on append
+    setShowActionForms(false);
+    setSelectedActionType("");
+    setEditingTransactionIndex(null);
+    onFormsVisibilityChange?.(false);
+    setIsCreatingNew(false);
+  };
+
+  // Called by ActionForms when the user selects multiple NFTs.
+  // Replaces the stub at editingTransactionIndex with the first NFT and
+  // appends one additional send-nfts transaction per remaining token.
+  const handleNftMultiSubmit = (selectedIds: number[]) => {
+    if (editingTransactionIndex === null || selectedIds.length === 0) return;
+    const currentValues = getValues();
+    const baseTx = currentValues.transactions[editingTransactionIndex] as unknown as Extract<
+      TransactionFormValues,
+      { type: "send-nfts" }
+    >;
+
+    // Update the existing stub with the first selected token
+    const [firstId, ...restIds] = selectedIds;
+    update(editingTransactionIndex, {
+      ...baseTx,
+      tokenId: String(firstId),
+    } as unknown as TransactionFormValues);
+
+    // Append one transaction per additional token
+    for (const id of restIds) {
+      append({
+        ...baseTx,
+        tokenId: String(id),
+      } as unknown as TransactionFormValues);
+    }
+
     setShowActionForms(false);
     setSelectedActionType("");
     setEditingTransactionIndex(null);
@@ -220,6 +250,7 @@ export function TransactionBuilder({ onFormsVisibilityChange }: TransactionBuild
           actionType={selectedActionType}
           onSubmit={handleTransactionSubmit}
           onCancel={handleCancel}
+          onNftMultiSubmit={handleNftMultiSubmit}
         />
       )}
     </div>

--- a/src/components/proposals/builder/TransactionBuilder.tsx
+++ b/src/components/proposals/builder/TransactionBuilder.tsx
@@ -90,7 +90,7 @@ export function TransactionBuilder({ onFormsVisibilityChange }: TransactionBuild
   // Called by ActionForms when the user selects multiple NFTs.
   // Replaces the stub at editingTransactionIndex with the first NFT and
   // appends one additional send-nfts transaction per remaining token.
-  const handleNftMultiSubmit = (selectedIds: number[]) => {
+  const handleNftMultiSubmit = (selectedIds: number[], imageMap: Record<number, string | undefined>) => {
     if (editingTransactionIndex === null || selectedIds.length === 0) return;
     const currentValues = getValues();
     const baseTx = currentValues.transactions[editingTransactionIndex] as unknown as Extract<
@@ -103,13 +103,15 @@ export function TransactionBuilder({ onFormsVisibilityChange }: TransactionBuild
     update(editingTransactionIndex, {
       ...baseTx,
       tokenId: String(firstId),
+      nftImage: imageMap[firstId] ?? baseTx.nftImage,
     } as unknown as TransactionFormValues);
 
-    // Append one transaction per additional token
+    // Append one transaction per additional token, each with its own image
     for (const id of restIds) {
       append({
         ...baseTx,
         tokenId: String(id),
+        nftImage: imageMap[id],
       } as unknown as TransactionFormValues);
     }
 

--- a/src/components/proposals/builder/forms/send-nfts-form.tsx
+++ b/src/components/proposals/builder/forms/send-nfts-form.tsx
@@ -18,9 +18,10 @@ import { type ProposalFormValues } from "../../schema";
 
 interface Props {
   index: number;
+  onSelectionChange?: (ids: number[]) => void;
 }
 
-export function SendNFTsForm({ index }: Props) {
+export function SendNFTsForm({ index, onSelectionChange }: Props) {
   const t = useTranslations("propose");
   const {
     register,
@@ -32,7 +33,7 @@ export function SendNFTsForm({ index }: Props) {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [tokens, setTokens] = useState<Array<{ id: number; imageUrl?: string }>>([]);
-  const [selectedTokenId, setSelectedTokenId] = useState<number | null>(null);
+  const [selectedTokenIds, setSelectedTokenIds] = useState<Set<number>>(new Set());
   const [visibleTokensCount, setVisibleTokensCount] = useState(60);
 
   const viewportRef = useRef<HTMLDivElement | null>(null);
@@ -117,31 +118,54 @@ export function SendNFTsForm({ index }: Props) {
     return () => observer.disconnect();
   }, [visibleTokensCount, tokens.length]);
 
-  // Initialize selected state from form if already present
+  // Initialize selected state from form if already present (single-token edit path)
   useEffect(() => {
     const current = watch(`transactions.${index}.tokenId` as const);
     const parsed = current ? parseInt(String(current), 10) : NaN;
     if (!Number.isNaN(parsed)) {
-      setSelectedTokenId(parsed);
+      setSelectedTokenIds(new Set([parsed]));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [index]);
 
   const handleSelect = (id: number) => {
-    setSelectedTokenId(id);
-    const token = tokens.find((t) => t.id === id);
-    setValue(`transactions.${index}.contractAddress` as const, DAO_ADDRESSES.token);
-    setValue(`transactions.${index}.from` as const, DAO_ADDRESSES.treasury);
-    setValue(`transactions.${index}.tokenId` as const, String(id));
-    if (token?.imageUrl) {
-      setValue(`transactions.${index}.nftImage` as const, token.imageUrl);
-    }
+    setSelectedTokenIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      // Keep the form field in sync with the first selected token so
+      // validation still passes (multi-submit handled by ActionForms/TransactionBuilder)
+      const first = next.size > 0 ? [...next][0] : null;
+      if (first !== null) {
+        const token = tokens.find((t) => t.id === first);
+        setValue(`transactions.${index}.contractAddress` as const, DAO_ADDRESSES.token);
+        setValue(`transactions.${index}.from` as const, DAO_ADDRESSES.treasury);
+        setValue(`transactions.${index}.tokenId` as const, String(first));
+        if (token?.imageUrl) {
+          setValue(`transactions.${index}.nftImage` as const, token.imageUrl);
+        }
+      } else {
+        setValue(`transactions.${index}.tokenId` as const, "");
+      }
+      onSelectionChange?.([...next]);
+      return next;
+    });
   };
 
   return (
     <div className="space-y-4">
       <div className="space-y-2">
-        <Label>{t("sendNfts.selectGnarLabel")}</Label>
+        <div className="flex items-center justify-between">
+          <Label>{t("sendNfts.selectGnarLabel")}</Label>
+          {selectedTokenIds.size > 0 && (
+            <span className="text-xs text-muted-foreground">
+              {t("sendNfts.selectedCount", { count: selectedTokenIds.size })}
+            </span>
+          )}
+        </div>
         <Card className="py-0">
           <CardContent>
             <ScrollArea className="h-80" viewportRef={viewportRef}>
@@ -156,7 +180,7 @@ export function SendNFTsForm({ index }: Props) {
               ) : (
                 <div className="my-6 grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 gap-2 pr-2">
                   {tokens.slice(0, visibleTokensCount).map((t) => {
-                    const isSelected = selectedTokenId === t.id;
+                    const isSelected = selectedTokenIds.has(t.id);
                     return (
                       <button
                         key={`gnar-${t.id}`}
@@ -205,6 +229,11 @@ export function SendNFTsForm({ index }: Props) {
             </ScrollArea>
           </CardContent>
         </Card>
+        {selectedTokenIds.size > 1 && (
+          <p className="text-xs text-muted-foreground">
+            {t("sendNfts.multiSelectHint")}
+          </p>
+        )}
         {errors.transactions?.[index] && "tokenId" in (errors.transactions?.[index] as object) && (
           <p className="text-xs text-red-500">{t("sendNfts.pleaseSelectNft")}</p>
         )}

--- a/src/components/proposals/builder/forms/send-nfts-form.tsx
+++ b/src/components/proposals/builder/forms/send-nfts-form.tsx
@@ -149,6 +149,7 @@ export function SendNFTsForm({ index, onSelectionChange }: Props) {
         }
       } else {
         setValue(`transactions.${index}.tokenId` as const, "");
+        setValue(`transactions.${index}.nftImage` as const, "");
       }
       const imageMap = Object.fromEntries([...next].map((id) => [id, tokens.find((t) => t.id === id)?.imageUrl]));
       onSelectionChange?.([...next], imageMap);
@@ -190,7 +191,7 @@ export function SendNFTsForm({ index, onSelectionChange }: Props) {
                         className={cn(
                           "cursor-pointer relative aspect-square overflow-hidden rounded-lg bg-muted",
                           "border-2 border-transparent hover:border-primary/60 transition focus:outline-none",
-                          isSelected && "border-yellow-400 shadow-[0_0_0_1px_theme(colors.yellow.400)]",
+                          isSelected && "border-yellow-400 ring-1 ring-yellow-400",
                         )}
                         aria-pressed={isSelected}
                       >

--- a/src/components/proposals/builder/forms/send-nfts-form.tsx
+++ b/src/components/proposals/builder/forms/send-nfts-form.tsx
@@ -188,8 +188,8 @@ export function SendNFTsForm({ index, onSelectionChange }: Props) {
                         onClick={() => handleSelect(t.id)}
                         className={cn(
                           "cursor-pointer relative aspect-square overflow-hidden rounded-lg bg-muted",
-                          "border-1 border-transparent hover:border-primary transition focus:outline-none",
-                          isSelected && "border-2 border-primary shadow",
+                          "border-2 border-transparent hover:border-primary/60 transition focus:outline-none",
+                          isSelected && "border-yellow-400 shadow-[0_0_0_1px_theme(colors.yellow.400)]",
                         )}
                         aria-pressed={isSelected}
                       >
@@ -213,7 +213,7 @@ export function SendNFTsForm({ index, onSelectionChange }: Props) {
                         <div className="absolute top-1.5 left-1.5">
                           <Badge
                             variant={isSelected ? "default" : "secondary"}
-                            className="font-mono text-[10px]"
+                            className={cn("font-mono text-[10px]", isSelected && "bg-yellow-400 text-yellow-950 border-yellow-400")}
                           >
                             #{String(t.id)}
                           </Badge>

--- a/src/components/proposals/builder/forms/send-nfts-form.tsx
+++ b/src/components/proposals/builder/forms/send-nfts-form.tsx
@@ -18,7 +18,7 @@ import { type ProposalFormValues } from "../../schema";
 
 interface Props {
   index: number;
-  onSelectionChange?: (ids: number[]) => void;
+  onSelectionChange?: (ids: number[], imageMap: Record<number, string | undefined>) => void;
 }
 
 export function SendNFTsForm({ index, onSelectionChange }: Props) {
@@ -150,7 +150,8 @@ export function SendNFTsForm({ index, onSelectionChange }: Props) {
       } else {
         setValue(`transactions.${index}.tokenId` as const, "");
       }
-      onSelectionChange?.([...next]);
+      const imageMap = Object.fromEntries([...next].map((id) => [id, tokens.find((t) => t.id === id)?.imageUrl]));
+      onSelectionChange?.([...next], imageMap);
       return next;
     });
   };

--- a/tests/e2e/verify-nft-multiselect.spec.ts
+++ b/tests/e2e/verify-nft-multiselect.spec.ts
@@ -1,0 +1,133 @@
+import { test, expect } from "@playwright/test";
+import path from "path";
+import fs from "fs";
+
+const SCREENSHOTS_DIR = path.join(
+  process.env.TEMP || "C:/Users/MATHEU~1/AppData/Local/Temp",
+  "verify-nft-multiselect",
+);
+
+test.beforeAll(() => {
+  if (!fs.existsSync(SCREENSHOTS_DIR)) fs.mkdirSync(SCREENSHOTS_DIR, { recursive: true });
+});
+
+async function screenshot(page: import("@playwright/test").Page, name: string) {
+  const p = path.join(SCREENSHOTS_DIR, `${name}.png`);
+  await page.screenshot({ path: p, fullPage: false });
+  return p;
+}
+
+test("multi-NFT select in proposal builder", async ({ page }) => {
+  // ── 1. Land on /en/propose ────────────────────────────────────────────────
+  await page.goto("http://localhost:3000/en/propose", { waitUntil: "networkidle" });
+  await screenshot(page, "01-propose-landing");
+
+  // Fill in required title so we can advance
+  const titleInput = page.locator('input[name="title"], textarea[name="title"], input[placeholder*="title" i], input[placeholder*="Title" i]').first();
+  if (await titleInput.isVisible({ timeout: 3000 }).catch(() => false)) {
+    await titleInput.fill("Test multi-select NFT proposal");
+  }
+
+  // ── 2. Navigate to the Transactions step ─────────────────────────────────
+  // Click "Next" or the Transactions tab to reach the builder
+  const nextBtn = page.locator('button:has-text("Next"), button:has-text("Transactions"), [role="tab"]:has-text("Transactions")').first();
+  if (await nextBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
+    await nextBtn.click();
+    await page.waitForTimeout(500);
+  }
+  await screenshot(page, "02-transactions-step");
+
+  // ── 3. Click "Send NFTs" action type card ─────────────────────────────────
+  const sendNftsCard = page.locator(
+    'button:has-text("Send NFTs"), [role="button"]:has-text("Send NFTs")',
+  ).first();
+  await expect(sendNftsCard).toBeVisible({ timeout: 10000 });
+  await sendNftsCard.click();
+  await screenshot(page, "03-send-nfts-clicked");
+
+  // ── 4. Wait for the NFT grid to load ──────────────────────────────────────
+  // Grid items are <button> elements inside the scroll area
+  const firstNft = page.locator('.aspect-square button, button[aria-pressed]').first();
+  await expect(firstNft).toBeVisible({ timeout: 20000 });
+  await screenshot(page, "04-nft-grid-loaded");
+
+  // ── 5. Select first NFT ───────────────────────────────────────────────────
+  const nftButtons = page.locator('button[aria-pressed]');
+  const count = await nftButtons.count();
+  console.log(`NFT buttons found: ${count}`);
+  expect(count).toBeGreaterThan(0);
+
+  await nftButtons.nth(0).click();
+  await page.waitForTimeout(300);
+  await screenshot(page, "05-first-nft-selected");
+
+  // Verify aria-pressed=true on first
+  const firstPressed = await nftButtons.nth(0).getAttribute("aria-pressed");
+  expect(firstPressed).toBe("true");
+
+  // ── 6. Select second NFT ──────────────────────────────────────────────────
+  await nftButtons.nth(1).click();
+  await page.waitForTimeout(300);
+  await screenshot(page, "06-second-nft-selected");
+
+  // ── 7. Verify "2 selected" counter ────────────────────────────────────────
+  const selectedCount = page.locator('text=/2 selected/i, text=/selected/i').first();
+  await expect(selectedCount).toBeVisible({ timeout: 3000 });
+  const countText = await selectedCount.textContent();
+  console.log(`Counter text: "${countText}"`);
+
+  // ── 8. Verify multi-select hint ───────────────────────────────────────────
+  const hint = page.locator('text=/separate transaction/i').first();
+  await expect(hint).toBeVisible({ timeout: 3000 });
+  await screenshot(page, "07-counter-and-hint");
+
+  // ── 9. Verify "Add 2 transactions" button ─────────────────────────────────
+  const submitBtn = page.locator('button:has-text("Add 2 transactions"), button:has-text("Add")').first();
+  await expect(submitBtn).toBeVisible({ timeout: 3000 });
+  const btnText = await submitBtn.textContent();
+  console.log(`Submit button text: "${btnText}"`);
+  expect(btnText).toMatch(/Add 2/i);
+  await screenshot(page, "08-add-2-transactions-button");
+
+  // ── 10. Also fill the "To" address field to pass validation ───────────────
+  const toInput = page.locator('input[id="to"], input[placeholder*="0x"]').first();
+  if (await toInput.isVisible({ timeout: 2000 }).catch(() => false)) {
+    await toInput.fill("0x1111111111111111111111111111111111111111");
+  }
+
+  // ── 11. Click "Add 2 transactions" ────────────────────────────────────────
+  await submitBtn.click();
+  await page.waitForTimeout(800);
+  await screenshot(page, "09-after-submit");
+
+  // ── 12. Verify transaction list shows 2 send-nfts entries ─────────────────
+  const txCards = page.locator('[class*="TransactionCard"], .space-y-3 > *').all();
+  const nftTxEntries = page.locator('text=/Send NFTs/i');
+  const nftTxCount = await nftTxEntries.count();
+  console.log(`Send-NFTs entries in list: ${nftTxCount}`);
+  await screenshot(page, "10-transaction-list");
+  expect(nftTxCount).toBeGreaterThanOrEqual(2);
+
+  // ── PROBE: Select 3 NFTs ──────────────────────────────────────────────────
+  // Go back and try with 3 selections to ensure label updates correctly
+  const addMoreBtn = page.locator('button:has-text("Send NFTs"), [role="button"]:has-text("Send NFTs")').first();
+  if (await addMoreBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
+    await addMoreBtn.click();
+    await page.waitForTimeout(500);
+
+    const nftBtns3 = page.locator('button[aria-pressed]');
+    if ((await nftBtns3.count()) >= 3) {
+      await nftBtns3.nth(2).click();
+      await nftBtns3.nth(3).click();
+      await nftBtns3.nth(4).click();
+      await page.waitForTimeout(300);
+      const btn3 = page.locator('button:has-text("Add 3 transactions"), button:has-text("Add")').first();
+      const text3 = await btn3.textContent().catch(() => "");
+      console.log(`3-select button text: "${text3}"`);
+      await screenshot(page, "11-probe-3-selected");
+    }
+  }
+
+  // ── PROBE: Deselect all → button reverts to "Save Transaction" ────────────
+  // (handled by clicking same NFT again)
+});

--- a/tests/e2e/verify-nft-multiselect.spec.ts
+++ b/tests/e2e/verify-nft-multiselect.spec.ts
@@ -1,11 +1,9 @@
 import { test, expect } from "@playwright/test";
 import path from "path";
 import fs from "fs";
+import os from "os";
 
-const SCREENSHOTS_DIR = path.join(
-  process.env.TEMP || "C:/Users/MATHEU~1/AppData/Local/Temp",
-  "verify-nft-multiselect",
-);
+const SCREENSHOTS_DIR = path.join(os.tmpdir(), "verify-nft-multiselect");
 
 test.beforeAll(() => {
   if (!fs.existsSync(SCREENSHOTS_DIR)) fs.mkdirSync(SCREENSHOTS_DIR, { recursive: true });
@@ -101,7 +99,6 @@ test("multi-NFT select in proposal builder", async ({ page }) => {
   await screenshot(page, "09-after-submit");
 
   // ── 12. Verify transaction list shows 2 send-nfts entries ─────────────────
-  const txCards = page.locator('[class*="TransactionCard"], .space-y-3 > *').all();
   const nftTxEntries = page.locator('text=/Send NFTs/i');
   const nftTxCount = await nftTxEntries.count();
   console.log(`Send-NFTs entries in list: ${nftTxCount}`);


### PR DESCRIPTION
## Summary

- Allow selecting multiple Gnars from treasury in the send-nfts proposal form
- Each selected NFT is automatically added as a separate \`send-nfts\` transaction
- Yellow border + badge on selected cards for clear visual feedback

## Changes

- \`send-nfts-form.tsx\` — multi-select via \`Set<number>\`, yellow border/badge on selected NFTs, selection counter, multi-select hint
- \`ActionForms.tsx\` — tracks selected IDs + imageMap, dynamic button label ("Add N transactions")
- \`TransactionBuilder.tsx\` — \`handleNftMultiSubmit\` expands selection into one transaction per NFT, each with its own thumbnail
- \`messages/en/propose.json\` + \`messages/pt-br/propose.json\` — new i18n keys for counter, hint, and button
- \`tests/e2e/verify-nft-multiselect.spec.ts\` — Playwright spec covering the full multi-select flow

## Fixes (post-review)

- **nftImage per token** — each appended transaction now carries its own thumbnail via \`imageMap\` instead of inheriting the first selected NFT's image
- **os.tmpdir()** — replaced hardcoded Windows TEMP path in e2e spec
- **unused txCards** — removed unused variable that caused lint warning
- **stale nftImage on deselect** — clears \`nftImage\` field when all NFTs are deselected
- **Tailwind v4** — replaced \`shadow-[0_0_0_1px_theme(colors.yellow.400)]\` with \`ring-1 ring-yellow-400\`

## Test plan

- [ ] Open \`/propose\` → Transactions → Send NFTs
- [ ] Select a single Gnar — button shows "Save transaction", submits 1 tx
- [ ] Select 3 Gnars — yellow borders appear, counter shows "3 selected", hint appears, button shows "Add 3 transactions"
- [ ] Submit — 3 separate send-nfts entries appear in the transaction list, **each with its own correct thumbnail**
- [ ] Edit an existing send-nfts tx — single-select still works correctly
- [ ] PT-BR locale works the same

Generated with [Claude Code](https://claude.com/claude-code)