### PR TITLE
fix(proposals): show duplicate banner in preview by rendering description as Markdown

### DIFF
--- a/src/components/proposals/ProposalPreview.tsx
+++ b/src/components/proposals/ProposalPreview.tsx
@@ -425,9 +425,7 @@ export function ProposalPreview() {
             </div>
           )}
           <h1 className="text-3xl font-bold mb-4">{data.title}</h1>
-          <div className="prose prose-gray max-w-none">
-            <Markdown>{data.description ?? ""}</Markdown>
-          </div>
+          <Markdown>{data.description ?? ""}</Markdown>
         </CardContent>
       </Card>
 

--- a/src/components/proposals/ProposalPreview.tsx
+++ b/src/components/proposals/ProposalPreview.tsx
@@ -15,6 +15,7 @@ import {
 } from "thirdweb";
 import { base } from "thirdweb/chains";
 import { parseEventLogs } from "viem";
+import { Markdown } from "@/components/common/Markdown";
 import { TransactionsSummaryList } from "@/components/proposals/preview/TransactionsSummaryList";
 import { ProposalDebugPanel } from "@/components/proposals/ProposalDebugPanel";
 import { useProposalEligibilityContext } from "@/components/proposals/ProposalEligibilityContext";
@@ -425,11 +426,7 @@ export function ProposalPreview() {
           )}
           <h1 className="text-3xl font-bold mb-4">{data.title}</h1>
           <div className="prose prose-gray max-w-none">
-            {(data.description ?? "").split("\n\n").map((paragraph, i) => (
-              <p key={i} className="mb-4 last:mb-0">
-                {paragraph}
-              </p>
-            ))}
+            <Markdown>{data.description ?? ""}</Markdown>
           </div>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary

- Replace plain text `split("\n\n")` with `<Markdown>` in `ProposalPreview` so the preview renders identically to the published proposal detail page
- If the user accidentally pastes the banner image into the description, they will see it duplicated in the preview and can fix it before submitting

## Changes

- `src/components/proposals/ProposalPreview.tsx` — swap `split("\n\n")` for `<Markdown>` component

## Test plan

- [ ] Create a proposal with a banner image selected
- [ ] Paste `![banner](url)` into the description field
- [ ] Go to preview — banner should appear twice, user can correct before submitting
- [ ] Create a proposal without duplicating the banner — preview shows correctly

Generated with [Claude Code](https://claude.com/claude-code)