### PR TITLE
fix(rounds): verify smart-account signatures + stop admin PII leak

### DIFF
--- a/env.example
+++ b/env.example
@@ -68,6 +68,17 @@ NEYNAR_API_KEY=your_neynar_api_key_here
 ZEROX_API_KEY=your_0x_api_key_here
 
 # ===========================================
+# Rounds (community contests) — Postgres
+# ===========================================
+
+# Connection string for the Rounds feature datastore. Checked in priority
+# order: ROUNDS_DATABASE_URL → DATABASE_PUBLIC_URL → DATABASE_URL.
+# When none is set, the Rounds tab renders but submissions/voting are disabled.
+ROUNDS_DATABASE_URL=postgres://user:password@host:5432/dbname
+# DATABASE_PUBLIC_URL=
+# DATABASE_URL=
+
+# ===========================================
 # Optional / Advanced
 # ===========================================
 

--- a/src/app/[locale]/rounds/admin/page.tsx
+++ b/src/app/[locale]/rounds/admin/page.tsx
@@ -1,6 +1,6 @@
 import { RoundsAdminDashboard } from "@/components/rounds/RoundsAdminDashboard";
-import type { Round, RoundRequest } from "@/features/rounds/types";
-import { isRoundsDatabaseConfigured, listPublicRounds, listRoundRequests } from "@/services/rounds";
+import type { Round } from "@/features/rounds/types";
+import { isRoundsDatabaseConfigured, listPublicRounds } from "@/services/rounds";
 
 export const metadata = {
   title: "Rounds Admin | Gnars DAO",
@@ -9,19 +9,17 @@ export const metadata = {
 
 export default async function RoundsAdminPage() {
   let rounds: Round[] = [];
-  let requests: RoundRequest[] = [];
 
   try {
-    [rounds, requests] = await Promise.all([listPublicRounds(), listRoundRequests()]);
+    rounds = await listPublicRounds();
   } catch (error) {
     console.error("[rounds] admin load failed", error);
   }
 
-  return (
-    <RoundsAdminDashboard
-      rounds={rounds}
-      requests={requests}
-      databaseConfigured={isRoundsDatabaseConfigured()}
-    />
-  );
+  // Round requests carry requester PII (name + email) and are intentionally
+  // NOT fetched here: props from a Server Component are serialized into the
+  // RSC payload sent to every visitor, and the client `isAdmin` check only
+  // hides DOM. Requests are loaded client-side from a signature-gated admin
+  // API route after an approved wallet authenticates.
+  return <RoundsAdminDashboard rounds={rounds} databaseConfigured={isRoundsDatabaseConfigured()} />;
 }

--- a/src/app/api/rounds/[slug]/submit/route.ts
+++ b/src/app/api/rounds/[slug]/submit/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { verifyRoundActionSignature } from "@/features/rounds/signature";
+import { verifyRoundActionSignature } from "@/features/rounds/verify-signature";
 import { createRoundSubmission } from "@/services/rounds";
 
 type SubmitBody = {

--- a/src/app/api/rounds/[slug]/vote/route.ts
+++ b/src/app/api/rounds/[slug]/vote/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
-import { verifyRoundActionSignature } from "@/features/rounds/signature";
 import type { RoundVoteAllocationInput } from "@/features/rounds/types";
+import { verifyRoundActionSignature } from "@/features/rounds/verify-signature";
 import { castRoundVotes } from "@/services/rounds";
 
 type VoteBody = {

--- a/src/app/api/rounds/admin/requests/route.ts
+++ b/src/app/api/rounds/admin/requests/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { isRoundAdminAddress } from "@/features/rounds/admin";
+import { verifyRoundActionSignature } from "@/features/rounds/verify-signature";
+import { listRoundRequests } from "@/services/rounds";
+
+type AdminRequestsBody = {
+  walletAddress?: string;
+  issuedAt?: string;
+  signature?: `0x${string}`;
+};
+
+// Returns round requests (which include requester name + email PII) only to an
+// approved admin wallet that proves control via a fresh signed message. This
+// keeps PII out of the publicly-served admin page payload.
+export async function POST(request: Request) {
+  const path = "/api/rounds/admin/requests";
+
+  try {
+    const body = (await request.json()) as AdminRequestsBody;
+
+    if (!body.walletAddress || !body.issuedAt || !body.signature) {
+      return NextResponse.json({ error: "Signed admin request is required." }, { status: 401 });
+    }
+
+    if (!isRoundAdminAddress(body.walletAddress)) {
+      return NextResponse.json(
+        { error: "This wallet is not on the approved Rounds admin list." },
+        { status: 403 },
+      );
+    }
+
+    const verified = await verifyRoundActionSignature({
+      action: "admin",
+      method: "POST",
+      path,
+      walletAddress: body.walletAddress,
+      payload: { walletAddress: body.walletAddress },
+      issuedAt: body.issuedAt,
+      signature: body.signature,
+    });
+
+    if (!verified) {
+      return NextResponse.json({ error: "Invalid wallet signature." }, { status: 401 });
+    }
+
+    const requests = await listRoundRequests();
+    return NextResponse.json({ requests });
+  } catch (error) {
+    console.error("[rounds] admin requests failed", error);
+    return NextResponse.json({ error: "Unable to load round requests." }, { status: 500 });
+  }
+}

--- a/src/app/api/rounds/request/route.ts
+++ b/src/app/api/rounds/request/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
-import { verifyRoundActionSignature } from "@/features/rounds/signature";
 import type { RoundRequestInput } from "@/features/rounds/types";
+import { verifyRoundActionSignature } from "@/features/rounds/verify-signature";
 import { createRoundRequest } from "@/services/rounds";
 
 type RequestBody = {

--- a/src/components/rounds/RequestRoundForm.tsx
+++ b/src/components/rounds/RequestRoundForm.tsx
@@ -55,15 +55,18 @@ export function RequestRoundForm({ databaseConfigured }: { databaseConfigured: b
   const [message, setMessage] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  // The active (smart) account is what signs, so bind the request to its
+  // address rather than the EOA view address.
+  const signerAddress = account?.address;
   const requestPayload = useMemo(
     () => ({
       ...values,
-      walletAddress: address || "",
+      walletAddress: signerAddress || "",
       submissionsOpenAt: toIsoOrValue(values.submissionsOpenAt),
       votingStartsAt: toIsoOrValue(values.votingStartsAt),
       votingEndsAt: toIsoOrValue(values.votingEndsAt),
     }),
-    [address, values],
+    [signerAddress, values],
   );
 
   const canSubmit =
@@ -136,13 +139,13 @@ export function RequestRoundForm({ databaseConfigured }: { databaseConfigured: b
 
     try {
       const path = "/api/rounds/request";
-      const payload = { walletAddress: address, request: requestPayload };
+      const payload = { walletAddress: account.address, request: requestPayload };
       const issuedAt = new Date().toISOString();
       const messageToSign = createRoundActionMessage({
         action: "request",
         method: "POST",
         path,
-        walletAddress: address,
+        walletAddress: account.address,
         payload,
         issuedAt,
       });

--- a/src/components/rounds/RoundDetailView.tsx
+++ b/src/components/rounds/RoundDetailView.tsx
@@ -60,13 +60,16 @@ export function RoundDetailView({
         .map(([submissionId, voteCount]) => ({ submissionId, voteCount }))
         .filter((vote) => vote.voteCount > 0);
       const path = `/api/rounds/${round.slug}/vote`;
-      const payload = { walletAddress: address, votes };
+      // Sign and submit under the active (smart) account address — that is the
+      // account that actually signs, so the server verifies against it.
+      const signerAddress = account.address;
+      const payload = { walletAddress: signerAddress, votes };
       const issuedAt = new Date().toISOString();
       const messageToSign = createRoundActionMessage({
         action: "vote",
         method: "POST",
         path,
-        walletAddress: address,
+        walletAddress: signerAddress,
         payload,
         issuedAt,
       });

--- a/src/components/rounds/RoundsAdminDashboard.tsx
+++ b/src/components/rounds/RoundsAdminDashboard.tsx
@@ -1,25 +1,72 @@
 "use client";
 
+import { useState } from "react";
 import { ArrowLeft, Database, ShieldCheck } from "lucide-react";
+import { useActiveAccount, useActiveWallet } from "thirdweb/react";
 import { Button } from "@/components/ui/button";
 import { isRoundAdminAddress } from "@/features/rounds/admin";
+import { createRoundActionMessage } from "@/features/rounds/signature";
 import { getRoundState } from "@/features/rounds/state";
 import type { Round, RoundRequest } from "@/features/rounds/types";
 import { useUserAddress } from "@/hooks/use-user-address";
 import { Link } from "@/i18n/navigation";
 
+type RequestsState = "idle" | "loading" | "loaded" | "error";
+
 export function RoundsAdminDashboard({
   rounds,
-  requests,
   databaseConfigured,
 }: {
   rounds: Round[];
-  requests: RoundRequest[];
   databaseConfigured: boolean;
 }) {
-  const { address, adminAddress, isConnected } = useUserAddress();
+  const { address, adminAddress, isConnected, isInAppWallet } = useUserAddress();
+  const account = useActiveAccount();
+  const wallet = useActiveWallet();
   const connectedAdminAddress = adminAddress ?? address;
   const isAdmin = isRoundAdminAddress(connectedAdminAddress);
+
+  const [requests, setRequests] = useState<RoundRequest[]>([]);
+  const [requestsState, setRequestsState] = useState<RequestsState>("idle");
+  const [requestsError, setRequestsError] = useState("");
+
+  const loadRequests = async () => {
+    if (!connectedAdminAddress) return;
+    // Sign with the admin EOA for external wallets (the allowlist is keyed by
+    // EOA); in-app sessions fall back to the smart account.
+    const signer = (!isInAppWallet ? wallet?.getAdminAccount?.() : undefined) ?? account;
+    if (!signer) return;
+
+    setRequestsState("loading");
+    setRequestsError("");
+
+    try {
+      const path = "/api/rounds/admin/requests";
+      const issuedAt = new Date().toISOString();
+      const message = createRoundActionMessage({
+        action: "admin",
+        method: "POST",
+        path,
+        walletAddress: connectedAdminAddress,
+        payload: { walletAddress: connectedAdminAddress },
+        issuedAt,
+      });
+      const signature = await signer.signMessage({ message });
+      const response = await fetch(path, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ walletAddress: connectedAdminAddress, issuedAt, signature }),
+      });
+      const result = await response.json();
+      if (!response.ok) throw new Error(result.error || "Unable to load round requests.");
+
+      setRequests((result.requests as RoundRequest[]) ?? []);
+      setRequestsState("loaded");
+    } catch (error) {
+      setRequestsError(error instanceof Error ? error.message : "Unable to load round requests.");
+      setRequestsState("error");
+    }
+  };
 
   return (
     <main className="container mx-auto max-w-6xl px-4 py-8">
@@ -42,9 +89,9 @@ export function RoundsAdminDashboard({
                 Rounds Dashboard
               </h1>
               <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
-                Review live rounds and database status. Creation and moderation APIs are
-                intentionally kept server-side; this page exposes the admin entry point without
-                showing controls to unapproved wallets.
+                Review live rounds and database status. Round requests contain requester contact
+                details and are loaded only after an approved admin wallet signs in — they are never
+                sent to unapproved visitors.
               </p>
             </div>
             <div className="inline-flex items-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm">
@@ -67,11 +114,31 @@ export function RoundsAdminDashboard({
         ) : (
           <>
             <section className="overflow-hidden rounded-lg border border-border bg-card">
-              <div className="border-b border-border px-5 py-4">
+              <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-5 py-4">
                 <h2 className="text-lg font-semibold tracking-tight">Round requests</h2>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={loadRequests}
+                  disabled={requestsState === "loading"}
+                >
+                  {requestsState === "loading"
+                    ? "Verifying..."
+                    : requestsState === "loaded"
+                      ? "Refresh"
+                      : "Load round requests"}
+                </Button>
               </div>
               <div className="divide-y divide-border">
-                {requests.length > 0 ? (
+                {requestsState === "error" ? (
+                  <div className="p-5 text-sm text-destructive">{requestsError}</div>
+                ) : requestsState === "idle" ? (
+                  <div className="p-5 text-sm text-muted-foreground">
+                    Sign with your admin wallet to load round requests.
+                  </div>
+                ) : requestsState === "loaded" && requests.length === 0 ? (
+                  <div className="p-5 text-sm text-muted-foreground">No round requests found.</div>
+                ) : (
                   requests.map((request) => (
                     <div
                       key={request.id}
@@ -91,8 +158,6 @@ export function RoundsAdminDashboard({
                       </Button>
                     </div>
                   ))
-                ) : (
-                  <div className="p-5 text-sm text-muted-foreground">No round requests found.</div>
                 )}
               </div>
             </section>

--- a/src/components/rounds/SubmitRoundForm.tsx
+++ b/src/components/rounds/SubmitRoundForm.tsx
@@ -52,13 +52,17 @@ export function SubmitRoundForm({
 
     try {
       const path = `/api/rounds/${round.slug}/submit`;
-      const payload = { walletAddress: address, submission: values };
+      // Sign and submit under the active (smart) account address — that is the
+      // account that actually signs (`account.signMessage`), so the verifier
+      // must check the signature against this address, not the EOA view address.
+      const signerAddress = account.address;
+      const payload = { walletAddress: signerAddress, submission: values };
       const issuedAt = new Date().toISOString();
       const messageToSign = createRoundActionMessage({
         action: "submit",
         method: "POST",
         path,
-        walletAddress: address,
+        walletAddress: signerAddress,
         payload,
         issuedAt,
       });

--- a/src/features/rounds/signature.test.ts
+++ b/src/features/rounds/signature.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { createRoundActionMessage, createRoundPayloadDigest } from "./signature";
+
+describe("createRoundPayloadDigest", () => {
+  it("is independent of object key order (client and server must agree)", () => {
+    const a = createRoundPayloadDigest({
+      walletAddress: "0xabc",
+      votes: [{ submissionId: "s1", voteCount: 2 }],
+    });
+    const b = createRoundPayloadDigest({
+      votes: [{ voteCount: 2, submissionId: "s1" }],
+      walletAddress: "0xabc",
+    });
+    expect(a).toBe(b);
+  });
+
+  it("changes when the payload changes", () => {
+    const base = createRoundPayloadDigest({
+      walletAddress: "0xabc",
+      votes: [{ submissionId: "s1", voteCount: 2 }],
+    });
+    const tampered = createRoundPayloadDigest({
+      walletAddress: "0xabc",
+      votes: [{ submissionId: "s1", voteCount: 3 }],
+    });
+    expect(tampered).not.toBe(base);
+  });
+});
+
+describe("createRoundActionMessage", () => {
+  const input = {
+    action: "vote" as const,
+    method: "POST" as const,
+    path: "/api/rounds/clip-round/vote",
+    walletAddress: "0xAbC0000000000000000000000000000000000001",
+    payload: { walletAddress: "0xAbC0000000000000000000000000000000000001", votes: [] },
+    issuedAt: "2026-05-28T12:00:00.000Z",
+  };
+
+  it("binds action, method, path, lowercased wallet, payload digest, and issuedAt", () => {
+    const message = createRoundActionMessage(input);
+    expect(message).toContain("Gnars Rounds");
+    expect(message).toContain("Action: vote");
+    expect(message).toContain("Method: POST");
+    expect(message).toContain(`Path: ${input.path}`);
+    expect(message).toContain(`Wallet: ${input.walletAddress.toLowerCase()}`);
+    expect(message).toContain(`Payload: ${createRoundPayloadDigest(input.payload)}`);
+    expect(message).toContain(`Issued At: ${input.issuedAt}`);
+  });
+
+  it("produces a different message when the bound action changes (no cross-action replay)", () => {
+    const vote = createRoundActionMessage(input);
+    const submit = createRoundActionMessage({ ...input, action: "submit" });
+    expect(vote).not.toBe(submit);
+  });
+});

--- a/src/features/rounds/signature.ts
+++ b/src/features/rounds/signature.ts
@@ -1,6 +1,6 @@
-import { keccak256, toBytes, verifyMessage } from "viem";
+import { keccak256, toBytes } from "viem";
 
-export type RoundSignedAction = "request" | "submit" | "vote";
+export type RoundSignedAction = "request" | "submit" | "vote" | "admin";
 
 export interface RoundSignatureMessageInput {
   action: RoundSignedAction;
@@ -34,34 +34,8 @@ export function createRoundActionMessage({
   ].join("\n");
 }
 
-export async function verifyRoundActionSignature({
-  action,
-  method,
-  path,
-  walletAddress,
-  payload,
-  issuedAt,
-  signature,
-}: RoundSignatureMessageInput & { signature: `0x${string}` }) {
-  const issuedAtTime = new Date(issuedAt).getTime();
-  if (!Number.isFinite(issuedAtTime) || Math.abs(Date.now() - issuedAtTime) > 10 * 60 * 1000) {
-    return false;
-  }
-
-  const message = createRoundActionMessage({
-    action,
-    method,
-    path,
-    walletAddress,
-    payload,
-    issuedAt,
-  });
-  return verifyMessage({
-    address: walletAddress as `0x${string}`,
-    message,
-    signature,
-  });
-}
+/** Issued-at window (ms) within which a signed action message is accepted. */
+export const ROUND_SIGNATURE_MAX_AGE_MS = 10 * 60 * 1000;
 
 function stableStringify(value: unknown): string {
   if (value === null || typeof value !== "object") return JSON.stringify(value);

--- a/src/features/rounds/verify-signature.ts
+++ b/src/features/rounds/verify-signature.ts
@@ -1,0 +1,59 @@
+import "server-only";
+import { verifyMessage } from "viem/actions";
+import { serverPublicClient } from "@/lib/rpc";
+import {
+  createRoundActionMessage,
+  ROUND_SIGNATURE_MAX_AGE_MS,
+  type RoundSignatureMessageInput,
+} from "./signature";
+
+/**
+ * Verify a signed Rounds action message server-side.
+ *
+ * Uses viem's public-client `verifyMessage` Action (ERC-6492 / ERC-1271 aware)
+ * rather than the offline EOA-only utility. This is required because every
+ * wallet on this site is wrapped in a thirdweb Smart Account (account
+ * abstraction, `sponsorGas: true`), so `account.signMessage` produces an
+ * ERC-1271 (deployed) or ERC-6492 (counterfactual) signature — never a raw
+ * EOA ECDSA signature. Validating those requires an onchain call, which the
+ * Action performs through `serverPublicClient` (Base). Plain EOA signatures
+ * (e.g. an admin signing with their personal wallet) still verify via the
+ * same path.
+ */
+export async function verifyRoundActionSignature({
+  action,
+  method,
+  path,
+  walletAddress,
+  payload,
+  issuedAt,
+  signature,
+}: RoundSignatureMessageInput & { signature: `0x${string}` }) {
+  const issuedAtTime = new Date(issuedAt).getTime();
+  if (
+    !Number.isFinite(issuedAtTime) ||
+    Math.abs(Date.now() - issuedAtTime) > ROUND_SIGNATURE_MAX_AGE_MS
+  ) {
+    return false;
+  }
+
+  const message = createRoundActionMessage({
+    action,
+    method,
+    path,
+    walletAddress,
+    payload,
+    issuedAt,
+  });
+
+  try {
+    return await verifyMessage(serverPublicClient, {
+      address: walletAddress as `0x${string}`,
+      message,
+      signature,
+    });
+  } catch {
+    // Malformed signature blob or RPC failure → treat as unverified.
+    return false;
+  }
+}

--- a/src/services/rounds.ts
+++ b/src/services/rounds.ts
@@ -444,15 +444,17 @@ export async function getPublicRoundBySlug(slug: string): Promise<RoundWithSubmi
   ]);
 
   const submissions = submissionsResult.rows.map(mapSubmission);
-  const voteActivity: RoundVoteActivity[] = activityResult.rows.map((row) => ({
-    id: String(row.id),
-    walletAddress: String(row.wallet_address),
-    submissionId: String(row.submission_id),
-    submissionTitle: String(row.submission_title),
-    voteCount: Number(row.vote_count || 0),
-    createdAt: new Date(String(row.created_at)).toISOString(),
-    updatedAt: new Date(String(row.updated_at)).toISOString(),
-  }));
+  const voteActivity: RoundVoteActivity[] = activityResult.rows.map(
+    (row: Record<string, unknown>) => ({
+      id: String(row.id),
+      walletAddress: String(row.wallet_address),
+      submissionId: String(row.submission_id),
+      submissionTitle: String(row.submission_title),
+      voteCount: Number(row.vote_count || 0),
+      createdAt: new Date(String(row.created_at)).toISOString(),
+      updatedAt: new Date(String(row.updated_at)).toISOString(),
+    }),
+  );
 
   return { ...round, submissions, voteActivity };
 }


### PR DESCRIPTION
## Summary

Stacked on `feat/rounds` (PR #108). Fixes the three merge blockers from review so the Rounds write path actually works and stops leaking PII.

- **#1 — Signature verification was broken for every real user.** The client signs via thirdweb `account.signMessage`, which returns an **ERC-1271/6492 smart-account** signature (all wallets are AA-wrapped, `sponsorGas: true`), but the server verified with viem's **offline EOA-only** `verifyMessage` utility (no client) → `recoverMessageAddress` returns a garbage address (or throws on a 6492 blob) → **HTTP 401 for in-app and AA-wrapped external wallets**. Verified against installed viem 2.36.0 + thirdweb sources.
- **#2 — `/rounds/admin` leaked requester emails to anyone.** It was an ungated Server Component that fetched round requests (name + email) and passed them as props to a client component whose `isAdmin` check only hides DOM — so the RSC payload shipped PII to every visitor.
- **#4 — Typecheck failed.** Implicit-`any` row mapper in `services/rounds.ts` (plus `pg` needed installing from the lockfile).

## Changes

- **`src/features/rounds/verify-signature.ts`** (new, `server-only`): verifies via viem's public-client `verifyMessage` Action using the existing Base `serverPublicClient`, so ERC-1271 (deployed) and ERC-6492 (counterfactual) smart-account signatures validate onchain. Plain EOA sigs still pass. try/catch → unverified on malformed sig / RPC error. Keeps the 10-min issued-at window.
- **`signature.ts`**: drop the broken EOA-only `verifyMessage`; export `ROUND_SIGNATURE_MAX_AGE_MS`; add `"admin"` to `RoundSignedAction`.
- **API routes** (`request`, `[slug]/submit`, `[slug]/vote`): import the new server-only verifier.
- **Forms** (`SubmitRoundForm`, `RoundDetailView`, `RequestRoundForm`): bind the signed message + payload to the **active (smart) account address** (the real signer), not the EOA view address — so the embedded wallet matches the signature.
- **`src/app/api/rounds/admin/requests/route.ts`** (new): signature-gated `POST` that returns round requests only after verifying an **approved-admin** signature (`isRoundAdminAddress` + `verifyRoundActionSignature`).
- **`admin/page.tsx`**: no longer fetches/serializes requests; passes only public `rounds`.
- **`RoundsAdminDashboard`**: loads requests client-side after the admin signs (signs with the **admin EOA** for external wallets since the allowlist is EOA-keyed; SA fallback for in-app).
- **`services/rounds.ts`**: type the `row` mapper param.
- **`env.example`**: document `ROUNDS_DATABASE_URL` / `DATABASE_URL`.
- **`signature.test.ts`** (new): guards the digest/message contract that keeps client and server in agreement.

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 real errors (rounds files clean)
- [x] `pnpm lint` — clean for all rounds files
- [x] `pnpm test` — 74 passed | 1 todo (8 files), incl. 4 new signature tests
- [ ] Manual: with `ROUNDS_DATABASE_URL` set + a published round, confirm submit/vote succeed for an in-app (social) login and for MetaMask — i.e. the 401 is gone
- [ ] Manual: hit `/rounds/admin` anonymously and as a non-admin, confirm requester emails are **not** in the network/RSC payload; confirm an approved admin can load requests after signing

## Out of scope (review follow-ups)

No admin write path (rounds never publishable via app), submissions auto-approve + no rate limiting, incomplete i18n on Rounds bodies, voting-power client/server mismatch + `one_per_nft` not checking ownership, Postgres/migrations ADR, `ROUND_ADMIN_WALLETS` → `config.ts`, `docs/INDEX.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)