### PR TITLE
feat(rounds): move Rounds last in money menu + mark coming soon

### DIFF
--- a/messages/en/nav.json
+++ b/messages/en/nav.json
@@ -38,7 +38,7 @@
       },
       "rounds": {
         "title": "Rounds",
-        "description": "Community contests and voting rounds for Gnars projects"
+        "description": "Community contests and voting rounds for Gnars projects — coming soon, not available yet"
       },
       "bounties": {
         "title": "Bounties",

--- a/messages/pt-br/nav.json
+++ b/messages/pt-br/nav.json
@@ -38,7 +38,7 @@
       },
       "rounds": {
         "title": "Rounds",
-        "description": "Concursos e votacoes comunitarias para projetos Gnars"
+        "description": "Concursos e votacoes comunitarias para projetos Gnars — em breve, ainda nao disponivel"
       },
       "bounties": {
         "title": "Bounties",

--- a/src/components/layout/DaoHeader.tsx
+++ b/src/components/layout/DaoHeader.tsx
@@ -74,6 +74,15 @@ import { cn } from "@/lib/utils";
 
 type NavTranslations = ReturnType<typeof useTranslations<"nav">>;
 
+// Badge color by kind: BETA → orange, SOON (not live yet) → amber, default → green
+function badgeClassName(badge: string) {
+  if (badge === "BETA")
+    return "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-200";
+  if (badge === "SOON")
+    return "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200";
+  return "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200";
+}
+
 // Navigation structure — built as a function so titles/descriptions come from t()
 function buildNavigationItems(t: NavTranslations) {
   return [
@@ -126,13 +135,6 @@ function buildNavigationItems(t: NavTranslations) {
           description: t("items.money.treasury.description"),
         },
         {
-          title: t("items.money.rounds.title"),
-          href: "/rounds",
-          icon: Trophy,
-          description: t("items.money.rounds.description"),
-          badge: "NEW!",
-        },
-        {
           title: t("items.money.bounties.title"),
           href: "/community/bounties",
           icon: Gift,
@@ -145,6 +147,13 @@ function buildNavigationItems(t: NavTranslations) {
           icon: ArrowLeftRight,
           description: t("items.money.swap.description"),
           badge: "NEW!",
+        },
+        {
+          title: t("items.money.rounds.title"),
+          href: "/rounds",
+          icon: Trophy,
+          description: t("items.money.rounds.description"),
+          badge: "SOON",
         },
       ],
     },
@@ -319,11 +328,9 @@ function DesktopNav() {
                                     {"badge" in subItem && subItem.badge && (
                                       <Badge
                                         variant="secondary"
-                                        className={`h-4 px-1.5 text-[10px] ${
-                                          (subItem.badge as string) === "BETA"
-                                            ? "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-200"
-                                            : "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200"
-                                        }`}
+                                        className={`h-4 px-1.5 text-[10px] ${badgeClassName(
+                                          subItem.badge as string,
+                                        )}`}
                                       >
                                         {subItem.badge as string}
                                       </Badge>
@@ -467,11 +474,9 @@ function MobileNav() {
                           {"badge" in subItem && subItem.badge && (
                             <Badge
                               variant="secondary"
-                              className={`h-4 px-1.5 text-[10px] ${
-                                (subItem.badge as string) === "BETA"
-                                  ? "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-200"
-                                  : "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200"
-                              }`}
+                              className={`h-4 px-1.5 text-[10px] ${badgeClassName(
+                                subItem.badge as string,
+                              )}`}
                             >
                               {subItem.badge as string}
                             </Badge>

--- a/src/components/rounds/RoundsIndexView.tsx
+++ b/src/components/rounds/RoundsIndexView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { PlusCircle, Settings } from "lucide-react";
+import { Construction, PlusCircle, Settings } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { isRoundAdminAddress } from "@/features/rounds/admin";
 import { getRoundState } from "@/features/rounds/state";
@@ -10,13 +10,7 @@ import { useUserAddress } from "@/hooks/use-user-address";
 import { Link } from "@/i18n/navigation";
 import { RoundCard } from "./RoundCard";
 
-export function RoundsIndexView({
-  rounds,
-  error,
-}: {
-  rounds: Round[];
-  error?: string;
-}) {
+export function RoundsIndexView({ rounds, error }: { rounds: Round[]; error?: string }) {
   const { address, adminAddress } = useUserAddress();
   const connectedAdminAddress = adminAddress ?? address;
   const isAdmin = isRoundAdminAddress(connectedAdminAddress);
@@ -33,6 +27,20 @@ export function RoundsIndexView({
   return (
     <main className="container mx-auto max-w-7xl px-4 py-8">
       <div className="space-y-8">
+        <div
+          role="status"
+          className="flex items-start gap-3 rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-200"
+        >
+          <Construction className="mt-0.5 size-5 shrink-0" />
+          <div>
+            <p className="font-semibold">Rounds is coming soon</p>
+            <p className="mt-0.5 leading-6">
+              This feature isn&apos;t live yet — we&apos;re still finishing development and the
+              backend isn&apos;t deployed. It&apos;s on the roadmap; check back soon.
+            </p>
+          </div>
+        </div>
+
         <section className="flex flex-col gap-5 rounded-lg border border-border bg-muted/30 p-6 md:flex-row md:items-end md:justify-between md:p-8">
           <div className="max-w-3xl">
             <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">


### PR DESCRIPTION
## Summary

- Rounds isn't live yet (backend not deployed, development unfinished). This reorders it to the end of the **Money** menu and clearly flags it as coming soon so users don't expect a working feature.

## Changes

- `DaoHeader.tsx` — reorder money submenu (treasury → bounties → swap → **rounds**); add amber `SOON` badge variant via a `badgeClassName` helper that dedups the desktop/mobile badge styling.
- `messages/{en,pt-br}/nav.json` — Rounds description now reads "coming soon / not available yet".
- `RoundsIndexView.tsx` — coming-soon banner at the top of the Rounds index page.

## Test plan

- [ ] Open the **Money** dropdown (desktop + mobile): order is Treasury, Bounties, Swap, Rounds; Rounds shows an amber **SOON** badge.
- [ ] Visit `/rounds`: amber 'coming soon' banner renders above the hero.
- [ ] Toggle pt-br locale: nav description shows 'em breve, ainda nao disponivel'.

Generated with [Claude Code](https://claude.com/claude-code)