### PR TITLE
fix(ui): add cursor-pointer to Button base

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all cursor-pointer disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary

- Tailwind v4's preflight sets `cursor: default` on `<button>`, so every enabled button in the app lost its pointer cursor on hover. This adds `cursor-pointer` to the shared shadcn `Button` base classes — fixing it app-wide in one place.

## Changes

- `src/components/ui/button.tsx` — add `cursor-pointer` to the base `cva` string.

## Notes

- Disabled buttons keep `disabled:pointer-events-none`, so the pointer doesn't show on disabled state (no change there).
- `asChild`/link usages (rendered as `<a>`) already had pointer; this is harmless there.

## Test plan

- [ ] Hover any enabled button (bounties, auctions, nav, etc.) → cursor is a pointer
- [ ] Hover a disabled button → no pointer (unchanged)

Generated with [Claude Code](https://claude.com/claude-code)