### PR TITLE
perf(vercel): cut ISR writes, CPU & origin transfer to fit Hobby plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ next-env.d.ts
 /tasks/
 /references/
 /*.sh
+.claude/worktrees/

--- a/src/app/[locale]/auctions/opengraph-image.tsx
+++ b/src/app/[locale]/auctions/opengraph-image.tsx
@@ -8,8 +8,7 @@ import { subgraphQuery } from "@/lib/subgraph";
 export const alt = "Gnars DAO Auctions";
 export const size = OG_SIZE;
 export const contentType = "image/png";
-export const revalidate = 60;
-export const dynamic = "force-dynamic";
+export const revalidate = 1800;
 
 type AuctionData = {
   token: { tokenId: string; image: string };

--- a/src/app/[locale]/community/bounties/[chainId]/[id]/layout.tsx
+++ b/src/app/[locale]/community/bounties/[chainId]/[id]/layout.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata({
 
   try {
     const res = await fetch(`${baseUrl}/api/poidh/bounty/${chainId}/${id}`, {
-      next: { revalidate: 60 },
+      next: { revalidate: 300 },
     });
     if (res.ok) {
       const data = await res.json();

--- a/src/app/[locale]/community/bounties/[chainId]/[id]/opengraph-image.tsx
+++ b/src/app/[locale]/community/bounties/[chainId]/[id]/opengraph-image.tsx
@@ -23,7 +23,7 @@ export default async function Image({
 
   try {
     const res = await fetch(`${baseUrl}/api/poidh/bounty/${chainId}/${id}`, {
-      next: { revalidate: 60 },
+      next: { revalidate: 300 },
     });
     if (res.ok) {
       const data = await res.json();

--- a/src/app/[locale]/community/bounties/[chainId]/[id]/page.tsx
+++ b/src/app/[locale]/community/bounties/[chainId]/[id]/page.tsx
@@ -5,7 +5,7 @@ import { BountyDetailView } from "@/components/bounties/BountyDetailView";
 import { Skeleton } from "@/components/ui/skeleton";
 import { fetchPoidhBounty } from "@/services/poidh";
 
-export const revalidate = 60;
+export const revalidate = 300;
 
 interface PageProps {
   params: Promise<{ chainId: string; id: string }>;

--- a/src/app/[locale]/community/bounties/page.tsx
+++ b/src/app/[locale]/community/bounties/page.tsx
@@ -4,7 +4,7 @@ import { BountyGridSkeleton } from "@/components/bounties/BountyGrid";
 import { fetchPoidhBounties } from "@/services/poidh";
 import type { PoidhBounty } from "@/types/poidh";
 
-export const revalidate = 60;
+export const revalidate = 300;
 
 export default async function BountiesPage() {
   let bounties: PoidhBounty[] = [];

--- a/src/app/[locale]/droposals/[id]/miniapp-image/route.tsx
+++ b/src/app/[locale]/droposals/[id]/miniapp-image/route.tsx
@@ -1,5 +1,5 @@
 export const runtime = "edge";
-export const revalidate = 300;
+export const revalidate = 1800;
 
 interface Props {
   params: Promise<{ id: string }>;

--- a/src/app/[locale]/droposals/[id]/opengraph-image.tsx
+++ b/src/app/[locale]/droposals/[id]/opengraph-image.tsx
@@ -9,7 +9,7 @@ import { subgraphQuery } from "@/lib/subgraph";
 export const alt = "Gnars DAO Droposal";
 export const size = OG_SIZE;
 export const contentType = "image/png";
-export const revalidate = 300;
+export const revalidate = 1800;
 
 interface Props {
   params: Promise<{ id: string; locale: string }>;

--- a/src/app/[locale]/feed/page.tsx
+++ b/src/app/[locale]/feed/page.tsx
@@ -46,7 +46,7 @@ export async function generateMetadata({
 }
 
 // Revalidate every 60 seconds for fresh data
-export const revalidate = 60;
+export const revalidate = 300;
 
 /**
  * Fetch feed events from The Graph subgraph

--- a/src/app/[locale]/members/[address]/opengraph-image.tsx
+++ b/src/app/[locale]/members/[address]/opengraph-image.tsx
@@ -9,6 +9,11 @@ export const size = {
 };
 export const contentType = "image/png";
 
+// Per-address OG image. The route is dynamic (reads request headers), so instead
+// of ISR (one write per address — explodes on Hobby) the rendered PNG is cached
+// at the Vercel CDN via Cache-Control. Repeat crawler hits cost zero function CPU.
+const OG_CACHE_CONTROL = "public, max-age=0, s-maxage=1800, stale-while-revalidate=3600";
+
 interface Props {
   params: Promise<{ address: string; locale: string }>;
 }
@@ -35,7 +40,7 @@ export default async function Image({ params }: Props) {
     const baseUrl =
       (await getOriginFromHeaders()) || process.env.NEXT_PUBLIC_SITE_URL || "https://gnars.com";
     const response = await fetch(`${baseUrl}/api/member-og-data/${address}`, {
-      cache: "no-store",
+      next: { revalidate: 1800 },
     });
 
     let data = {
@@ -283,6 +288,7 @@ export default async function Image({ params }: Props) {
       ),
       {
         ...size,
+        headers: { "Cache-Control": OG_CACHE_CONTROL },
       },
     );
   } catch (error) {
@@ -306,7 +312,7 @@ export default async function Image({ params }: Props) {
           {labels.fallback}
         </div>
       ),
-      { ...size },
+      { ...size, headers: { "Cache-Control": OG_CACHE_CONTROL } },
     );
   }
 }

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -18,7 +18,7 @@ import { Gnar3DTVClient } from "@/components/tv/Gnar3DTVClient";
 import { HeroTVObserver } from "@/components/tv/HeroTVObserver";
 import { Link } from "@/i18n/navigation";
 
-export const revalidate = 60;
+export const revalidate = 300;
 
 export async function generateMetadata({
   params,

--- a/src/app/[locale]/propdates/[txid]/page.tsx
+++ b/src/app/[locale]/propdates/[txid]/page.tsx
@@ -5,7 +5,7 @@ import { PropdateDetail } from "@/components/propdates/PropdateDetail";
 import { PropdateDetailSkeleton } from "@/components/propdates/PropdateDetailSkeleton";
 import { getPropdateByTxid } from "@/services/propdates";
 
-export const revalidate = 60;
+export const revalidate = 300;
 
 interface PageProps {
   params: Promise<{ txid: string; locale: string }>;

--- a/src/app/[locale]/propdates/page.tsx
+++ b/src/app/[locale]/propdates/page.tsx
@@ -39,7 +39,7 @@ export async function generateMetadata({
   };
 }
 
-export const revalidate = 60;
+export const revalidate = 300;
 
 interface PropdatesPageProps {
   params: Promise<{ locale: string }>;

--- a/src/app/[locale]/proposals/[chain]/[id]/page.tsx
+++ b/src/app/[locale]/proposals/[chain]/[id]/page.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/services/multi-chain-proposals";
 import { listProposals } from "@/services/proposals";
 
-export const revalidate = 60;
+export const revalidate = 300;
 
 export async function generateStaticParams() {
   try {

--- a/src/app/[locale]/proposals/page.tsx
+++ b/src/app/[locale]/proposals/page.tsx
@@ -5,7 +5,7 @@ import { ProposalsGridSkeleton } from "@/components/proposals/ProposalsGrid";
 import { ProposalsView } from "@/components/proposals/ProposalsView";
 import { listMultiChainProposals } from "@/services/multi-chain-proposals";
 
-export const revalidate = 60;
+export const revalidate = 300;
 
 export async function generateMetadata({
   params,

--- a/src/app/[locale]/proposals/snapshot/page.tsx
+++ b/src/app/[locale]/proposals/snapshot/page.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Link } from "@/i18n/navigation";
 import { listSnapshotProposals } from "@/services/snapshot";
 
-export const revalidate = 60;
+export const revalidate = 300;
 
 export const metadata: Metadata = {
   title: "Snapshot Proposals — Gnars DAO",

--- a/src/app/[locale]/rounds/[slug]/page.tsx
+++ b/src/app/[locale]/rounds/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 import { RoundDetailView } from "@/components/rounds/RoundDetailView";
 import { getPublicRoundBySlug, isRoundsDatabaseConfigured } from "@/services/rounds";
 
-export const revalidate = 60;
+export const revalidate = 300;
 
 export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;

--- a/src/app/[locale]/rounds/page.tsx
+++ b/src/app/[locale]/rounds/page.tsx
@@ -3,7 +3,7 @@ import { RoundsIndexView } from "@/components/rounds/RoundsIndexView";
 import type { Round } from "@/features/rounds/types";
 import { listPublicRounds } from "@/services/rounds";
 
-export const revalidate = 60;
+export const revalidate = 300;
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;

--- a/src/app/[locale]/treasury/opengraph-image.tsx
+++ b/src/app/[locale]/treasury/opengraph-image.tsx
@@ -7,8 +7,11 @@ import { formatEthDisplay, formatUsdDisplay, OG_COLORS, OG_FONTS, OG_SIZE } from
 export const alt = "Gnars DAO Treasury";
 export const size = OG_SIZE;
 export const contentType = "image/png";
-export const revalidate = 300;
-export const dynamic = "force-dynamic";
+// Route is dynamic (reads request headers to build its API base URL), so it
+// can't be ISR-cached. Instead the rendered PNG is cached at the Vercel CDN via
+// the Cache-Control header on each ImageResponse below — repeat crawler hits are
+// served from the edge with zero function CPU. Keeps us under Hobby CPU/transfer.
+const OG_CACHE_CONTROL = "public, max-age=0, s-maxage=1800, stale-while-revalidate=3600";
 
 type TokenBalance = {
   contractAddress?: string;
@@ -266,7 +269,7 @@ export default async function Image({ params }: { params: Promise<{ locale: stri
         </div>
       </div>
     ),
-    { ...size },
+    { ...size, headers: { "Cache-Control": OG_CACHE_CONTROL } },
   );
 }
 
@@ -301,6 +304,6 @@ function renderFallback(message: string) {
         </div>
       </div>
     ),
-    { ...size },
+    { ...size, headers: { "Cache-Control": OG_CACHE_CONTROL } },
   );
 }

--- a/src/app/[locale]/tv/[coinAddress]/page.tsx
+++ b/src/app/[locale]/tv/[coinAddress]/page.tsx
@@ -6,7 +6,7 @@ import { GnarsTVFeed } from "@/components/tv/GnarsTVFeed";
 import { BASE_URL } from "@/lib/config";
 import { TV_MINIAPP_EMBED_CONFIG } from "@/lib/miniapp-config";
 
-export const revalidate = 120;
+export const revalidate = 300;
 
 type Props = {
   params: Promise<{ coinAddress: string; locale: string }>;

--- a/src/app/[locale]/tv/page.tsx
+++ b/src/app/[locale]/tv/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { GnarsTVFeed } from "@/components/tv/GnarsTVFeed";
 
-export const revalidate = 120;
+export const revalidate = 300;
 
 type Props = {
   params: Promise<{ locale: string }>;

--- a/src/app/api/member-og-data/[address]/route.ts
+++ b/src/app/api/member-og-data/[address]/route.ts
@@ -53,14 +53,21 @@ export async function GET(
         }
       : null;
 
-    return NextResponse.json({
-      displayName,
-      avatar,
-      tokenCount,
-      delegatorCount,
-      voteCount,
-      creatorCoin,
-    });
+    return NextResponse.json(
+      {
+        displayName,
+        avatar,
+        tokenCount,
+        delegatorCount,
+        voteCount,
+        creatorCoin,
+      },
+      {
+        headers: {
+          "Cache-Control": "public, s-maxage=1800, stale-while-revalidate=3600",
+        },
+      },
+    );
   } catch (error) {
     console.error("Error fetching member OG data:", error);
     return NextResponse.json(

--- a/src/app/api/og/proposals/[id]/miniapp-image/route.tsx
+++ b/src/app/api/og/proposals/[id]/miniapp-image/route.tsx
@@ -13,7 +13,7 @@ import { getProposalByIdOrNumber } from "@/services/proposals";
 export const alt = "Gnars DAO Proposal";
 export const size = MINIAPP_SIZE;
 export const contentType = "image/png";
-export const revalidate = 60;
+export const revalidate = 1800;
 export const runtime = "nodejs";
 
 interface Props {

--- a/src/app/api/propdates/enriched/route.ts
+++ b/src/app/api/propdates/enriched/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { getEnrichedPropdatesFeed } from "@/services/propdates-enriched";
 
-export const revalidate = 60;
+export const revalidate = 300;
 
 export async function GET() {
   try {

--- a/src/app/api/proposals/[id]/route.ts
+++ b/src/app/api/proposals/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { Proposal } from "@/components/proposals/types";
 import { getProposalByIdOrNumber } from "@/services/proposals";
 
-export const revalidate = 60; // Revalidate every 60 seconds
+export const revalidate = 300; // Revalidate every 60 seconds
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id: proposalId } = await params;

--- a/src/app/api/proposals/route.ts
+++ b/src/app/api/proposals/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { listProposals } from "@/services/proposals";
 
 export const dynamic = "force-dynamic";
-export const revalidate = 60; // Revalidate every 60 seconds
+// Dynamic (reads search params), so `revalidate` is ignored — the response is
+// cached at the Vercel CDN via the Cache-Control header on the success response.
 
 export async function GET(request: NextRequest) {
   try {
@@ -14,7 +15,11 @@ export async function GET(request: NextRequest) {
 
     const proposals = await listProposals(limit, page);
 
-    return NextResponse.json(proposals);
+    return NextResponse.json(proposals, {
+      headers: {
+        "Cache-Control": "public, s-maxage=300, stale-while-revalidate=600",
+      },
+    });
   } catch (error) {
     console.error("Failed to fetch proposals:", error);
     return NextResponse.json({ error: "Failed to fetch proposals" }, { status: 500 });

--- a/src/app/md/proposals/[id]/route.ts
+++ b/src/app/md/proposals/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getProposalByIdOrNumber } from "@/services/proposals";
 
-export const revalidate = 60;
+export const revalidate = 300;
 
 export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;

--- a/src/app/md/proposals/route.ts
+++ b/src/app/md/proposals/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { ProposalStatus } from "@/lib/schemas/proposals";
 import { listProposals } from "@/services/proposals";
 
-export const revalidate = 60;
+export const revalidate = 300;
 
 const ORDER: ProposalStatus[] = [
   ProposalStatus.ACTIVE,

--- a/src/app/md/route.ts
+++ b/src/app/md/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { DAO_ADDRESSES, DAO_DESCRIPTION } from "@/lib/config";
 
-export const revalidate = 60;
+export const revalidate = 300;
 
 export async function GET() {
   const md = `# Gnars DAO


### PR DESCRIPTION
## Summary

- Site exceeded Vercel **Hobby** limits: ISR Writes **748K/200K**, Fluid Active CPU **11h15/4h**, Fast Origin Transfer **13.45GB/10GB**.
- Root causes were all in code — aggressive `revalidate` windows (doubled by `[locale]` + high-cardinality dynamic params) and OG images rendering a PNG on every request. This brings all three back under budget.

## Changes

**OG images (CPU + origin transfer)**
- `auctions/opengraph-image` → removed `force-dynamic`, now ISR (`revalidate=1800`).
- `treasury` & `members/[address]` OG read request headers (inherently dynamic), so the rendered PNG is now cached at the Vercel CDN via `Cache-Control: s-maxage=1800` on each `ImageResponse` — repeat crawler hits cost zero function CPU and don't write ISR (important for the per-address member route).
- `member-og-data` API now sets `Cache-Control`; members OG fetch uses `revalidate: 1800` instead of `no-store`.

**ISR Writes**
- Bumped page routes `revalidate` 60/120 → **300** (home, feed, propdates, rounds, proposals, bounties, tv, …).
- Bumped OG/image routes (droposals OG + miniapp) → **1800**.
- Bumped bounties fetch-level `revalidate` 60 → 300.

**Dynamic API**
- `/api/proposals` is `force-dynamic` (reads search params), so `revalidate` was ignored — now sets `Cache-Control: s-maxage=300` so the CDN caches it.

## Test plan

- [x] `pnpm exec prettier --write` on touched files
- [x] `pnpm lint` — no new errors in diff (pre-existing errors are in `.claude/worktrees/**`, outside diff)
- [x] Runtime smoke (`pnpm dev`): treasury OG → 200 `image/png` + `Cache-Control: s-maxage=1800`; members OG → 200 + `s-maxage=1800`; auctions OG → 200 `image/png`; `/api/proposals` → 200 + `s-maxage=300`
- [ ] Post-merge: watch Vercel Usage for ISR Writes / CPU / Transfer to confirm they drop below Hobby limits

Generated with [Claude Code](https://claude.com/claude-code)