### PR TITLE
feat(nogglesrails): auto-link propdates to rail pages

### DIFF
--- a/messages/en/installations.json
+++ b/messages/en/installations.json
@@ -90,7 +90,10 @@
       "viewProposal": "View Proposal",
       "organicProliferation": "Organic proliferation — no formal proposal.",
       "wantRailCta": "Want a NogglesRail in your city?",
-      "submitProposal": "Submit a Proposal"
+      "submitProposal": "Submit a Proposal",
+      "updates": "Updates",
+      "updatesSubtitle": "Onchain progress updates posted to the funding proposal.",
+      "viewAllUpdates": "View all updates"
     }
   }
 }

--- a/messages/pt-br/installations.json
+++ b/messages/pt-br/installations.json
@@ -90,7 +90,10 @@
       "viewProposal": "Ver Proposta",
       "organicProliferation": "Proliferação orgânica — sem proposta formal.",
       "wantRailCta": "Quer um NogglesRail na sua cidade?",
-      "submitProposal": "Enviar uma Proposta"
+      "submitProposal": "Enviar uma Proposta",
+      "updates": "Atualizações",
+      "updatesSubtitle": "Atualizações de progresso onchain publicadas na proposta de financiamento.",
+      "viewAllUpdates": "Ver todas as atualizações"
     }
   }
 }

--- a/src/app/[locale]/nogglesrails/[slug]/page.tsx
+++ b/src/app/[locale]/nogglesrails/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { getTranslations, setRequestLocale } from "next-intl/server";
 import { notFound } from "next/navigation";
 import { ArrowLeft, ExternalLink } from "lucide-react";
 import { DroposalEmbed } from "@/components/nogglesrails/DroposalEmbed";
+import { RailPropdates } from "@/components/nogglesrails/RailPropdates";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { getRailBySlug, NOGGLES_RAILS } from "@/content/nogglesrails";
@@ -145,6 +146,9 @@ export default async function NogglesRailDetailPage({ params }: PageProps) {
             <h2 className="mb-2 text-lg font-semibold">{t("nogglesrails.detail.about")}</h2>
             <p className="leading-relaxed text-muted-foreground">{rail.description}</p>
           </div>
+
+          {/* Onchain updates (auto-linked from the funding proposal's propdates) */}
+          {rail.proposalNumber != null && <RailPropdates proposalNumber={rail.proposalNumber} />}
 
           {/* Gallery */}
           {gallery.length > 0 && (

--- a/src/components/nogglesrails/RailPropdates.tsx
+++ b/src/components/nogglesrails/RailPropdates.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useQuery } from "@tanstack/react-query";
+import { ArrowRight } from "lucide-react";
+import { PropdateCard } from "@/components/proposals/detail/PropdateCard";
+import { Link } from "@/i18n/navigation";
+import type { Propdate } from "@/services/propdates";
+
+/** Max propdates shown inline on a rail page before linking out to the full list. */
+const MAX_INLINE = 3;
+
+interface ProposalWithPropdatesJSON {
+  proposal: { proposalNumber: number };
+  propdates: Propdate[];
+  updateCount: number;
+}
+
+interface RailPropdatesProps {
+  proposalNumber: number;
+}
+
+/**
+ * Auto-links a rail to the onchain propdates of its funding proposal.
+ *
+ * Client component on purpose: it reuses the already-cached
+ * `/api/propdates/enriched` endpoint (revalidate=300 + CDN) so the rail page
+ * stays fully static — no extra SSR/ISR cost. Renders nothing when the proposal
+ * has no propdates, so Snapshot/Nouns/organic rails are no-ops.
+ */
+export function RailPropdates({ proposalNumber }: RailPropdatesProps) {
+  const t = useTranslations("installations");
+  const { data } = useQuery<ProposalWithPropdatesJSON[]>({
+    queryKey: ["propdates-feed-enriched"],
+    queryFn: () => fetch("/api/propdates/enriched").then((r) => r.json()),
+  });
+
+  const entry = data?.find((e) => e.proposal.proposalNumber === proposalNumber);
+  if (!entry || entry.propdates.length === 0) return null;
+
+  const visible = entry.propdates.slice(0, MAX_INLINE);
+  const allUpdatesHref = `/proposals/base/${proposalNumber}?tab=propdates`;
+
+  return (
+    <div>
+      <div className="mb-3 flex items-end justify-between gap-2">
+        <div>
+          <h2 className="text-lg font-semibold">{t("nogglesrails.detail.updates")}</h2>
+          <p className="text-sm text-muted-foreground">
+            {t("nogglesrails.detail.updatesSubtitle")}
+          </p>
+        </div>
+        {entry.updateCount > MAX_INLINE && (
+          <Link
+            href={allUpdatesHref}
+            className="inline-flex shrink-0 items-center gap-1 text-sm font-medium text-primary hover:underline"
+          >
+            {t("nogglesrails.detail.viewAllUpdates")}
+            <ArrowRight className="size-3.5" />
+          </Link>
+        )}
+      </div>
+      <div className="space-y-3">
+        {visible.map((propdate) => (
+          <PropdateCard key={propdate.txid} propdate={propdate} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/proposals/detail/ProposalDetail.tsx
+++ b/src/components/proposals/detail/ProposalDetail.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
+import { useSearchParams } from "next/navigation";
 import { VotingControls } from "@/components/common/VotingControls";
 import { Propdates } from "@/components/proposals/detail/Propdates";
 import { ProposalActions } from "@/components/proposals/detail/ProposalActions";
@@ -223,6 +224,24 @@ export function ProposalDetail({ proposal }: ProposalDetailProps) {
   const visibleTabsCount = 1 + (shouldShowVotesTab ? 1 : 0) + (shouldShowPropdatesTab ? 1 : 0);
   const shouldShowTabsList = visibleTabsCount > 1;
 
+  // Deep links (?tab=votes|propdates) can't use <Tabs defaultValue> because
+  // those tabs are revealed post-mount; honor the param once, when the target
+  // tab becomes visible, then hand control back to the user.
+  const searchParams = useSearchParams();
+  const requestedTab = searchParams.get("tab");
+  const [activeTab, setActiveTab] = useState("details");
+  const honoredTabParam = useRef(false);
+  useEffect(() => {
+    if (honoredTabParam.current) return;
+    if (
+      (requestedTab === "votes" && shouldShowVotesTab) ||
+      (requestedTab === "propdates" && shouldShowPropdatesTab)
+    ) {
+      honoredTabParam.current = true;
+      setActiveTab(requestedTab);
+    }
+  }, [requestedTab, shouldShowVotesTab, shouldShowPropdatesTab]);
+
   // Show voting card for active proposals (connection check moved to VotingControls to avoid hydration issues)
   // Hide voting for read-only proposals (Snapshot and Ethereum)
   const isProposalActive = proposal.status === "Active";
@@ -290,7 +309,7 @@ export function ProposalDetail({ proposal }: ProposalDetailProps) {
       {isProposalSuccessful(proposal.status) && (
         <ProposalActions proposal={proposal} onActionSuccess={handleActionSuccess} />
       )}
-      <Tabs defaultValue="details" className="w-full">
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
         {shouldShowTabsList && (
           <div className="overflow-x-auto">
             <TabsList

--- a/src/content/nogglesrails.ts
+++ b/src/content/nogglesrails.ts
@@ -16,6 +16,12 @@ export interface NogglesRailLocation {
     name: string;
     link: string;
   };
+  /**
+   * Base (Gnars DAO) proposal number used to auto-link onchain propdates to
+   * this rail. Only set for rails funded by a Base proposal — Snapshot/Nouns/
+   * organic rails leave it undefined and simply show no Updates section.
+   */
+  proposalNumber?: number;
   video?: string;
   droposals?: number[];
   thumbnailPosition?: string;
@@ -116,6 +122,7 @@ export const NOGGLES_RAILS: NogglesRailLocation[] = [
       name: "Gnars Proposal 20",
       link: "https://www.gnars.com/proposals/20",
     },
+    proposalNumber: 20,
     slug: "rio-de-janeiro-delta",
   },
   {
@@ -176,6 +183,7 @@ export const NOGGLES_RAILS: NogglesRailLocation[] = [
       name: "Gnars Proposal",
       link: "https://gnars.com/proposals/73",
     },
+    proposalNumber: 73,
     slug: "nairobi",
   },
   {
@@ -194,6 +202,7 @@ export const NOGGLES_RAILS: NogglesRailLocation[] = [
       name: "Gnars Proposal",
       link: "https://www.gnars.com/dao/proposal/4",
     },
+    proposalNumber: 4,
     slug: "sao-paulo-sopa-de-letras",
   },
   {
@@ -263,6 +272,7 @@ export const NOGGLES_RAILS: NogglesRailLocation[] = [
       name: "Gnars Proposal",
       link: "https://www.gnars.com/dao/proposal/25",
     },
+    proposalNumber: 25,
     slug: "medellin",
   },
   {
@@ -286,6 +296,7 @@ export const NOGGLES_RAILS: NogglesRailLocation[] = [
       name: "Gnars Proposal",
       link: "https://www.gnars.com/dao/proposal/33",
     },
+    proposalNumber: 33,
     slug: "london",
   },
   {
@@ -309,6 +320,7 @@ export const NOGGLES_RAILS: NogglesRailLocation[] = [
       name: "Gnars Proposal",
       link: "https://www.gnars.com/proposals/41",
     },
+    proposalNumber: 41,
     slug: "buenos-aires",
   },
   {
@@ -332,6 +344,7 @@ export const NOGGLES_RAILS: NogglesRailLocation[] = [
       name: "Gnars Proposal",
       link: "https://www.gnars.com/dao/proposal/68",
     },
+    proposalNumber: 68,
     slug: "milan",
   },
   {
@@ -353,6 +366,7 @@ export const NOGGLES_RAILS: NogglesRailLocation[] = [
       name: "Gnars Proposal",
       link: "https://www.gnars.com/proposals/63",
     },
+    proposalNumber: 63,
     slug: "oc-ramp",
   },
   {
@@ -376,6 +390,7 @@ export const NOGGLES_RAILS: NogglesRailLocation[] = [
       name: "Gnars Proposal",
       link: "https://www.gnars.com/proposals/89",
     },
+    proposalNumber: 89,
     slug: "sao-paulo-itapetininga",
   },
 ];

--- a/tests/e2e/proposal-tab-deeplink.spec.ts
+++ b/tests/e2e/proposal-tab-deeplink.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Regression tests for ?tab= deep links on the proposal detail page
+ * (e.g. the "View all updates" link on nogglesrails pages points to
+ * /proposals/base/{n}?tab=propdates).
+ *
+ * The votes/propdates tabs are revealed post-mount from fetched data, so the
+ * deep link is honored asynchronously — assertions wait for the trigger to
+ * appear before checking it is active.
+ */
+
+interface EnrichedEntry {
+  proposal: { proposalNumber: number };
+  propdates: unknown[];
+}
+
+async function findProposalWithPropdates(
+  request: Parameters<Parameters<typeof test>[2]>[0]["request"],
+): Promise<number | null> {
+  const res = await request.get("/api/propdates/enriched");
+  if (!res.ok()) return null;
+  const entries = (await res.json()) as EnrichedEntry[];
+  const entry = entries.find((e) => (e.propdates?.length ?? 0) > 0);
+  return entry ? entry.proposal.proposalNumber : null;
+}
+
+// Serial: three parallel first-loads of the same heavy route stall the dev
+// server past the goto timeout; these are fast (<5s each) once compiled.
+test.describe.configure({ mode: "serial" });
+
+test.describe("Proposal tab deep links", () => {
+  test("?tab=propdates activates the Propdates tab", async ({ page, request }) => {
+    const proposalNumber = await findProposalWithPropdates(request);
+    test.skip(proposalNumber === null, "No proposal with propdates in this environment");
+
+    await page.goto(`/proposals/base/${proposalNumber}?tab=propdates`, {
+      waitUntil: "domcontentloaded",
+      timeout: 60000,
+    });
+
+    const propdatesTab = page.getByRole("tab", { name: /propdates/i });
+    await expect(propdatesTab).toBeVisible({ timeout: 30000 });
+    await expect(propdatesTab).toHaveAttribute("data-state", "active", { timeout: 15000 });
+    await expect(page.getByRole("tab", { name: /details/i })).toHaveAttribute(
+      "data-state",
+      "inactive",
+    );
+  });
+
+  test("without ?tab the Details tab stays default", async ({ page, request }) => {
+    const proposalNumber = await findProposalWithPropdates(request);
+    test.skip(proposalNumber === null, "No proposal with propdates in this environment");
+
+    await page.goto(`/proposals/base/${proposalNumber}`, {
+      waitUntil: "domcontentloaded",
+      timeout: 60000,
+    });
+
+    // Wait for the tab list to be revealed post-mount, then assert default.
+    const detailsTab = page.getByRole("tab", { name: /details/i });
+    await expect(detailsTab).toBeVisible({ timeout: 30000 });
+    await expect(detailsTab).toHaveAttribute("data-state", "active");
+  });
+
+  test("unknown ?tab value is ignored and falls back to Details", async ({ page, request }) => {
+    const proposalNumber = await findProposalWithPropdates(request);
+    test.skip(proposalNumber === null, "No proposal with propdates in this environment");
+
+    await page.goto(`/proposals/base/${proposalNumber}?tab=bogus`, {
+      waitUntil: "domcontentloaded",
+      timeout: 60000,
+    });
+
+    const detailsTab = page.getByRole("tab", { name: /details/i });
+    await expect(detailsTab).toBeVisible({ timeout: 30000 });
+    await expect(detailsTab).toHaveAttribute("data-state", "active");
+  });
+});


### PR DESCRIPTION
## Summary

- Cada rail financiado por uma proposta da Base agora exibe automaticamente os **propdates onchain** daquela proposta numa seção "Updates", em vez de texto escrito à mão.
- A ligação é feita por um novo campo `proposalNumber` nos 9 rails financiados por propostas da Base (validados contra produção).
- A seção carrega no client reusando o endpoint `/api/propdates/enriched` (já cacheado, revalidate=300 + CDN), então a página do rail **continua estática** (●) — sem custo novo de SSR/ISR.

## Changes

- `src/content/nogglesrails.ts` — novo campo opcional `proposalNumber` + preenchido nos 9 rails de proposta Base (4, 20, 25, 33, 41, 63, 68, 73, 89). Rails de Snapshot/Nouns/orgânicos ficam sem o campo (no-op).
- `src/components/nogglesrails/RailPropdates.tsx` (novo) — client component que busca `/api/propdates/enriched`, casa por `proposalNumber` e renderiza com o `PropdateCard` existente. Retorna `null` quando não há propdate.
- `src/app/[locale]/nogglesrails/[slug]/page.tsx` — renderiza a seção entre a descrição e a galeria, só quando há `proposalNumber`.
- `messages/{en,pt-br}/installations.json` — strings novas (Updates / Atualizações).

## Test plan

- [ ] Abrir no preview: `/nogglesrails/rio-de-janeiro-delta` → deve mostrar a seção "Updates" com os propdates reais da proposta #20.
- [ ] Abrir `/nogglesrails/silverado` (proposta Nouns, sem propdate na Base) → NÃO deve mostrar a seção (gating correto).
- [ ] Versão PT: `/pt-br/nogglesrails/rio-de-janeiro-delta` → seção "Atualizações".
- [ ] Conferir layout no mobile.

> ⚠️ **Nota pra quem revisar:** rodando localmente com o `.env` de teste, nenhum rail mostra a seção (as propostas de teste não correspondem a rails). Testar no **preview/produção**, que usam o DAO real da Base — lá a #20 já tem 3 propdates.

Generated with [Claude Code](https://claude.com/claude-code)