### PR TITLE
fix(navbar): stop Connect button overflowing in mobile menu

### DIFF
--- a/messages/en/nav.json
+++ b/messages/en/nav.json
@@ -2,7 +2,8 @@
   "languageSwitcherLabel": "Change language",
   "mobileMenu": {
     "toggleLabel": "Toggle menu",
-    "sheetTitle": "Navigation"
+    "sheetTitle": "Navigation",
+    "sheetDescription": "Browse the Gnars DAO sections and connect your wallet."
   },
   "switchNetwork": {
     "label": "Switch to Base",

--- a/messages/pt-br/nav.json
+++ b/messages/pt-br/nav.json
@@ -2,7 +2,8 @@
   "languageSwitcherLabel": "Mudar idioma",
   "mobileMenu": {
     "toggleLabel": "Alternar menu",
-    "sheetTitle": "Navegação"
+    "sheetTitle": "Navegação",
+    "sheetDescription": "Navegue pelas seções da Gnars DAO e conecte sua carteira."
   },
   "switchNetwork": {
     "label": "Mudar para Base",

--- a/src/components/layout/DaoHeader.tsx
+++ b/src/components/layout/DaoHeader.tsx
@@ -63,6 +63,7 @@ import {
 import {
   Sheet,
   SheetContent,
+  SheetDescription,
   SheetFooter,
   SheetHeader,
   SheetTitle,
@@ -410,6 +411,9 @@ function MobileNav() {
         <SheetContent side="left" className="w-[300px] sm:w-[400px]">
           <SheetHeader>
             <SheetTitle className="text-left">{t("mobileMenu.sheetTitle")}</SheetTitle>
+            <SheetDescription className="sr-only">
+              {t("mobileMenu.sheetDescription")}
+            </SheetDescription>
           </SheetHeader>
           <nav className="flex flex-col gap-4 mt-8 flex-1 overflow-y-auto">
             {navigationItems.map((item) => {
@@ -498,10 +502,11 @@ function MobileNav() {
                 {isPending ? t("switchNetwork.switching") : t("switchNetwork.label")}
               </Badge>
             )}
-            <div className="flex items-center justify-between w-full">
+            <div className="flex items-center justify-center gap-1">
+              <ThemeToggle />
               <LocaleSwitcher />
-              <ConnectButton />
             </div>
+            <ConnectButton />
           </SheetFooter>
         </SheetContent>
       </Sheet>


### PR DESCRIPTION
## Summary

- Fix the **Connect** button overflowing past the mobile navigation sheet edge.
- Small polish to the mobile menu footer (theme toggle parity + accessibility).

## Changes

- `src/components/layout/DaoHeader.tsx`: move the Connect button to its own full-width row in the mobile `SheetFooter`, so its `w-full` no longer shares a flex row with the `LocaleSwitcher` and overflows the sheet.
- Add the `ThemeToggle` (previously desktop-only) next to the `LocaleSwitcher` in the mobile menu footer.
- Add a visually-hidden `SheetDescription` to resolve the Radix dialog "missing description" accessibility warning.
- `messages/en/nav.json`, `messages/pt-br/nav.json`: add the `mobileMenu.sheetDescription` string (EN + PT-BR).

## Test plan

- [x] On a mobile viewport, open the hamburger menu.
- [x] Confirm the Connect button stays within the sheet (no horizontal overflow), both connected and disconnected.
- [x] Confirm the theme toggle and language switcher render centered above the Connect button.
- [x] Switch theme and language from the mobile menu and confirm both still work.
