### PR TITLE
perf(vercel): slim proposal list payload + cache member OG metadata

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,6 +10,7 @@ This is the canonical entry point for project documentation. Everything below sh
 ## Architecture
 
 - `docs/architecture/thirdweb-wallet-layer.md` — provider tree, reads/writes split, view-mode toggle (EOA/SA), AA config, known escape hatches
+- `docs/architecture/vercel-quota-strategy.md` — Hobby quota playbook: billing mechanics, data cadence → cache strategy, fix backlog, traps
 - `docs/architecture/exploration-progress.md`
 - `docs/architecture/refactor-audit.md`
 - `docs/i18n/tone-brief.md` — PT-BR translation tone brief

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -11,6 +11,7 @@ This is the canonical entry point for project documentation. Everything below sh
 
 - `docs/architecture/thirdweb-wallet-layer.md` — provider tree, reads/writes split, view-mode toggle (EOA/SA), AA config, known escape hatches
 - `docs/architecture/vercel-quota-strategy.md` — Hobby quota playbook: billing mechanics, data cadence → cache strategy, fix backlog, traps
+- `docs/architecture/caching-standard.md` — route param + cache tag + mutation invalidation standard (long caches + event-driven revalidateTag)
 - `docs/architecture/exploration-progress.md`
 - `docs/architecture/refactor-audit.md`
 - `docs/i18n/tone-brief.md` — PT-BR translation tone brief

--- a/docs/architecture/caching-standard.md
+++ b/docs/architecture/caching-standard.md
@@ -1,0 +1,105 @@
+# Next.js Caching & Freshness Standard
+
+TL;DR: today freshness comes from short TTLs (polling model): every page re-renders every 300s whether data changed or not — which simultaneously blows Vercel quotas AND still feels slow (a vote takes 5–10min to reach other users). The standard below inverts the model: **long/idle caches everywhere + event-driven invalidation when a mutation happens**. Quota mechanics live in `vercel-quota-strategy.md`; this doc is the policy for route params, cache tags and mutation wiring.
+
+## Why actions propagate slowly today (measured path of a vote)
+
+The voter sees their vote instantly (optimistic local state in `ProposalDetail.tsx`). Everyone else waits through four stacked layers:
+
+| #   | Layer                                | Delay                                                                | Notes                                                                                                         |
+| --- | ------------------------------------ | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| 1   | Goldsky subgraph indexing            | seconds–~1min (UNKNOWN: measure)                                     | tx is onchain but not yet queryable                                                                           |
+| 2   | ISR route cache (`revalidate = 300`) | up to 300s, **+1 visit**                                             | stale-while-revalidate: the first visitor after expiry still gets the stale page; regen happens in background |
+| 3   | Client router segment cache          | up to ~5min                                                          | Next 16 segment cache on pages the user already visited                                                       |
+| 4   | React Query defaults                 | `staleTime` 5min, `refetchOnWindowFocus: false` (`Providers.tsx:28`) | client-fetched data (votes list, feeds)                                                                       |
+
+Worst case ≈ 10min. Nothing in the repo calls `revalidateTag`/`revalidatePath` — **zero event-driven invalidation exists**. Same for proposal creation: it appears on `/proposals` only after layers 1+2+3 elapse.
+
+## The standard
+
+### Rule 1 — route segment config decision tree
+
+```
+Is the response per-user or uncacheable (cookies/headers/POST)?
+├─ yes → force-dynamic, but every expensive lookup inside goes through
+│        unstable_cache (pattern: /members/[address], PR #127)
+└─ no → Is the data immutable (terminal proposal, closed round, static JSON)?
+    ├─ yes → generateStaticParams + long revalidate (86400) or fully static
+    └─ no → Is the route hit mostly on unique paths by bots (profile-like)?
+        ├─ yes → dynamic + Cache-Control: public, s-maxage, SWR (zero ISR writes)
+        └─ no → ISR with LONG revalidate (1800–3600) + tagged data reads
+                (freshness comes from revalidateTag, not from the TTL)
+```
+
+Never combine `force-dynamic` with `revalidate` (force-dynamic silently wins — the sitemap bug).
+
+### Rule 2 — every service read is tagged
+
+All reads in `src/services/*` go through `unstable_cache` with canonical tags. TTL is a _backstop_, not the freshness mechanism.
+
+| Tag                       | Covers                         | Backstop TTL               |
+| ------------------------- | ------------------------------ | -------------------------- |
+| `proposals`               | proposal lists (all consumers) | 1800                       |
+| `proposal:<number>`       | one proposal detail + votes    | 1800 (Active/Pending: 120) |
+| `auction`                 | current auction state          | 60                         |
+| `auctions`                | settled auction history        | 3600                       |
+| `feed`                    | activity feed events           | 300                        |
+| `members`                 | holders list, overviews        | 3600                       |
+| `treasury`                | balances                       | 900                        |
+| `propdates`               | EAS attestations               | 300                        |
+| `rounds` / `round:<slug>` | rounds listings / one round    | 300 / closed: 86400        |
+
+### Rule 3 — mutations invalidate, clients don't poll
+
+After a write-hook confirms a receipt it must:
+
+1. `queryClient.invalidateQueries(...)` for the local view (pattern already exists in `AuctionBidForm` / `AuctionSettleButton` — votes and propose are missing it).
+2. `POST /api/revalidate { tags: [...] }` (new route, tag-allowlist, light rate limit) so **other users'** server caches drop. Because of subgraph lag, fire it after polling the subgraph for the event (bounded ~30–45s), with a fallback second call at +60s.
+
+| Mutation (hook)         | Tags to invalidate                        |
+| ----------------------- | ----------------------------------------- |
+| `useCastVote`           | `proposal:<n>`, `proposals`, `feed`       |
+| propose (wizard submit) | `proposals`, `feed`                       |
+| bid                     | `auction`, `feed`                         |
+| settle                  | `auction`, `auctions`, `feed`, `treasury` |
+| propdate post           | `propdates`, `proposal:<n>`               |
+| delegate                | `members`                                 |
+| round vote/submit       | `round:<slug>`, `rounds`                  |
+
+### Rule 4 — prefetch discipline
+
+Grids with >20 `<Link>`s (`ProposalCard`, members list, auctions) set `prefetch={false}`. Each card in viewport otherwise prefetches the detail page's segments — ISR writes with no pageview, multiplied by bots.
+
+### Rule 5 — client defaults per data class
+
+Keep the global React Query `staleTime: 5min`. Live views override per-query: current auction `refetchInterval` while open, active-proposal votes `staleTime ≤ 60s`. Never lower the global default to fix a single stale view.
+
+### Rule 6 — images
+
+`images.minimumCacheTTL: 2592000` (proposal banners / Zora media are immutable IPFS content) and replace `hostname: "**"` with an allowlist when feasible.
+
+## Current state vs target (route params)
+
+| Route                                     | Today                                     | Target                                                                 |
+| ----------------------------------------- | ----------------------------------------- | ---------------------------------------------------------------------- |
+| `/proposals`                              | revalidate 300                            | 1800 + `proposals` tag                                                 |
+| `/proposals/[chain]/[id]`                 | 300 for all                               | 120 Active/Pending, 86400 terminal (status-aware) + `proposal:<n>` tag |
+| `/proposals/snapshot`                     | 300                                       | static (immutable JSON)                                                |
+| `/` (home)                                | 300                                       | 900 + tags (`proposals`, `auction`, `feed`)                            |
+| `/members/[address]`                      | force-dynamic ✅                          | keep; cached lookups (done PR #127)                                    |
+| `/members`                                | 3600 ✅                                   | + `members` tag                                                        |
+| `/feed`                                   | 300 (inner cache 15s!)                    | 300 route + inner cache aligned 300 + `feed` tag                       |
+| `/blogs`, `/blogs/[slug]`                 | 300                                       | 3600 (match data cache)                                                |
+| `/installations/[slug]`                   | 300                                       | 3600/static                                                            |
+| `/rounds*`                                | 300, raw pg                               | tagged `unstable_cache`; closed rounds 86400                           |
+| `/droposals*`                             | 1800 ✅                                   | executed → static                                                      |
+| `sitemap.xml`                             | revalidate 3600 **+ force-dynamic (bug)** | drop force-dynamic                                                     |
+| `/tv`, `/treasury`, `/community/bounties` | 300                                       | 900–1800 (client components already handle live parts)                 |
+
+## Rollout (round 3, ordered so freshness improves first)
+
+1. **P1 — event-driven freshness** (closes the user complaint): `/api/revalidate` route + tags on `services/proposals.ts` + wire `useCastVote` and the propose wizard (invalidateQueries + revalidate call with subgraph-sync poll). After this, a vote/proposal reaches everyone in ~subgraph-lag seconds instead of ~10min — while TTLs get LONGER, not shorter.
+2. **P2 — param standardization**: table above (sitemap one-liner, status-aware proposal detail, blogs/installations TTLs, prefetch discipline, minimumCacheTTL).
+3. **P3 — plumbing**: replace `no-store` in `lib/subgraph.ts` with per-caller tagged caches; terminal-state RPC skip; static immutable pages.
+
+UNKNOWN: real Goldsky indexing lag distribution (instrument the revalidate endpoint and log tx→queryable delta); whether `revalidateTag` frequency has practical limits on Hobby (docs: on-demand writes bill only changed bytes — cheap).

--- a/docs/architecture/vercel-quota-strategy.md
+++ b/docs/architecture/vercel-quota-strategy.md
@@ -4,17 +4,17 @@ TL;DR: the site exceeds Vercel Hobby quotas because immutable or slow-moving DAO
 
 ## Quota status (billing window Jun 3 – Jul 3, 2026)
 
-| Quota | Used / Limit | Primary drivers |
-| --- | --- | --- |
-| ISR Writes | 620K / 200K units | `/proposals` list payload, 300s revalidate everywhere, ×2 locales, ×3 cache entries |
-| Fluid Active CPU | 11h22 / 4h | `/members/[address]` (force-dynamic + bot crawl), home, `/api/tv/feed`, RPC fan-out |
-| Fast Origin Transfer | 12.4GB / 10GB | Same pages: big RSC payloads leaving compute on every render/regen |
+| Quota                | Used / Limit      | Primary drivers                                                                     |
+| -------------------- | ----------------- | ----------------------------------------------------------------------------------- |
+| ISR Writes           | 620K / 200K units | `/proposals` list payload, 300s revalidate everywhere, ×2 locales, ×3 cache entries |
+| Fluid Active CPU     | 11h22 / 4h        | `/members/[address]` (force-dynamic + bot crawl), home, `/api/tv/feed`, RPC fan-out |
+| Fast Origin Transfer | 12.4GB / 10GB     | Same pages: big RSC payloads leaving compute on every render/regen                  |
 
 Bot traffic (Googlebot, OpenAI, Baiduspider — ~12–14K req/12h each) hits mostly-unique paths, so per-path caches don't amortize; every crawl of an expired path is a full render + ISR write.
 
 ## Billing mechanics (measured on this project)
 
-- ISR writes are billed in **units per cache entry** (~8KB granularity). One page revalidation in Next 16 writes **~3 entries** (page + `_full.segment` + `__PAGE__.segment`), and `[locale]` doubles everything → one route at `revalidate = 300` costs up to `12/h × 3 × 2 = 72` write units/hour **per KB-bucket of payload**. `/en/proposals` alone measured ~70 units *per write* before slimming (1.3MB embedded JSON).
+- ISR writes are billed in **units per cache entry** (~8KB granularity). One page revalidation in Next 16 writes **~3 entries** (page + `_full.segment` + `__PAGE__.segment`), and `[locale]` doubles everything → one route at `revalidate = 300` costs up to `12/h × 3 × 2 = 72` write units/hour **per KB-bucket of payload**. `/en/proposals` alone measured ~70 units _per write_ before slimming (1.3MB embedded JSON).
 - Writes are traffic-triggered (revalidate-on-request after expiry). No traffic → no writes. Bots count as traffic.
 - `react.cache()` dedupes **within one render pass only**. It does not persist across revalidations or across routes. Only `unstable_cache` / fetch `next.revalidate` hit the shared data cache.
 - `export const dynamic = "force-dynamic"` **overrides** `export const revalidate` on the same route (see the sitemap bug below).
@@ -23,50 +23,50 @@ Bot traffic (Googlebot, OpenAI, Baiduspider — ~12–14K req/12h each) hits mos
 
 The core principle: **DAO data is mostly append-only and terminal.** Once a proposal is Executed/Defeated/Cancelled/Vetoed/Expired, an auction settled, a round closed, a droposal executed — that record never changes again. Only a small live window (active auction, proposals in their 4-day voting window, prices, feed) needs freshness.
 
-| Data | Real cadence | Current handling | Target |
-| --- | --- | --- | --- |
-| Base proposals (list) | new ~weekly; votes change during 4-day window; terminal states immutable | subgraph `no-store` + 123 RPC `state()` reads per invocation, route 300s | `unstable_cache` 900–1800s; **skip `state()` RPC for terminal proposals** (subgraph already has `executed/canceled/vetoed/queued` booleans) |
-| Proposal detail pages | immutable once finalized | revalidate 300 for all | status-aware: short TTL only for Active/Pending; long/static for finalized |
-| Ethereum-era + Snapshot proposals | **immutable** (static JSON) | re-processed every 300s via consumers | static import / `revalidate = false`; `generateStaticParams` |
-| Settled auctions | immutable; +1/day | `no-store` subgraph | `unstable_cache` 3600+ |
-| Treasury balances | change on tx (slow); prices per-minute | fetch 60s on balances | balances 300–900s; prices already CDN-cached (fine) |
-| Feed events | event-driven | `unstable_cache` **15s** under a 300s route | align to 120–300s |
-| Members | holdings ~daily | `/members/[address]` force-dynamic (see trap below) | keep dynamic; cache the data lookups (`unstable_cache`) |
-| Blogs | editorial | data cached 3600s but route 300s | route revalidate 3600 to match |
-| Installations | static JSON | `[slug]` 300s | 3600+/static |
-| Rounds (Postgres) | live while open; closed = immutable | raw `pg` on every call, no cache | `unstable_cache` 120–300s for listings; closed rounds static |
-| TV/coins feed | hourly aggregation | CDN s-maxage 3600 (ok), but 2s CPU per cold miss | cap upstream fan-out, persist HEAD-probe cache |
+| Data                              | Real cadence                                                             | Current handling                                                         | Target                                                                                                                                      |
+| --------------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Base proposals (list)             | new ~weekly; votes change during 4-day window; terminal states immutable | subgraph `no-store` + 123 RPC `state()` reads per invocation, route 300s | `unstable_cache` 900–1800s; **skip `state()` RPC for terminal proposals** (subgraph already has `executed/canceled/vetoed/queued` booleans) |
+| Proposal detail pages             | immutable once finalized                                                 | revalidate 300 for all                                                   | status-aware: short TTL only for Active/Pending; long/static for finalized                                                                  |
+| Ethereum-era + Snapshot proposals | **immutable** (static JSON)                                              | re-processed every 300s via consumers                                    | static import / `revalidate = false`; `generateStaticParams`                                                                                |
+| Settled auctions                  | immutable; +1/day                                                        | `no-store` subgraph                                                      | `unstable_cache` 3600+                                                                                                                      |
+| Treasury balances                 | change on tx (slow); prices per-minute                                   | fetch 60s on balances                                                    | balances 300–900s; prices already CDN-cached (fine)                                                                                         |
+| Feed events                       | event-driven                                                             | `unstable_cache` **15s** under a 300s route                              | align to 120–300s                                                                                                                           |
+| Members                           | holdings ~daily                                                          | `/members/[address]` force-dynamic (see trap below)                      | keep dynamic; cache the data lookups (`unstable_cache`)                                                                                     |
+| Blogs                             | editorial                                                                | data cached 3600s but route 300s                                         | route revalidate 3600 to match                                                                                                              |
+| Installations                     | static JSON                                                              | `[slug]` 300s                                                            | 3600+/static                                                                                                                                |
+| Rounds (Postgres)                 | live while open; closed = immutable                                      | raw `pg` on every call, no cache                                         | `unstable_cache` 120–300s for listings; closed rounds static                                                                                |
+| TV/coins feed                     | hourly aggregation                                                       | CDN s-maxage 3600 (ok), but 2s CPU per cold miss                         | cap upstream fan-out, persist HEAD-probe cache                                                                                              |
 
 ## Traps (learned the hard way — do not repeat)
 
-1. **Do NOT convert `/members/[address]` to ISR.** Hundreds of unique addresses are in the sitemap ×2 locales; bots crawl each path once. ISR would write ~3 cache entries per unique path per crawl (~5K+ units/day) into the *tightest* quota. Correct approach: stay `force-dynamic`, cache the expensive lookups (Zora profile + overview via `unstable_cache`, done in PR #127) — or remove member pages from the sitemap.
+1. **Do NOT convert `/members/[address]` to ISR.** Hundreds of unique addresses are in the sitemap ×2 locales; bots crawl each path once. ISR would write ~3 cache entries per unique path per crawl (~5K+ units/day) into the _tightest_ quota. Correct approach: stay `force-dynamic`, cache the expensive lookups (Zora profile + overview via `unstable_cache`, done in PR #127) — or remove member pages from the sitemap.
 2. **`force-dynamic` + `revalidate` on the same route = fully dynamic.** The sitemap has both; every crawler hit re-runs the full fan-out (all proposals + coins + members + blogs + droposals).
 3. **Slimming beats TTL-raising.** PR #120 raised TTLs (60→300) and barely moved the needle; PR #127 cut the payload 68% — write units scale with payload size × entry count, not just frequency.
 4. **`src/lib/subgraph.ts` hardcodes `cache: "no-store"`** — every caller re-fetches origin on every regen regardless of route TTL.
 
 ## Fix backlog (impact ÷ effort, merged from route sweep + data-cadence audit)
 
-| # | Fix | Quota hit | Status |
-| --- | --- | --- | --- |
-| 1 | Slim `/proposals` + home payloads (`toListProposal`) | ISR + FOT | ✅ PR #127 |
-| 2 | Cache member OG metadata (`unstable_cache` 30min) | CPU | ✅ PR #127 |
-| 3 | Sitemap: remove `force-dynamic` (one line) | CPU + FOT | todo |
-| 4 | Skip `governor.state()` RPC for terminal proposals; `listMultiChainProposals` fetches 1000 → fetch what's needed | CPU | todo |
-| 5 | Status-aware revalidate on `/proposals/[chain]/[id]` | ISR | todo |
-| 6 | `images.minimumCacheTTL: 2592000` (banners/media are immutable) | FOT + CPU | todo |
-| 7 | Batch-add `Cache-Control: public, s-maxage, stale-while-revalidate` to API GETs without it (`md/*`, `api/proposals/per-month`, `api/members`, `api/coins/gnars-paired`, `api/poidh/bounties`, …) | CPU + FOT | todo |
-| 8 | `/api/alchemy`: 9.9% error rate — only `eth_getBalance` has RPC fallback; add fallback/retry + micro-cache for read methods | CPU + errors | todo |
-| 9 | Immutable content → static (`Snapshot`/ETH-era proposals, installations `[slug]`, executed droposals, closed rounds) | ISR | todo |
-| 10 | Align `/blogs` route TTL to data TTL (300 → 3600) | ISR | todo |
-| 11 | Replace `no-store` in `subgraph.ts` with per-caller `next.revalidate` | CPU + FOT | todo |
-| 12 | Bot mitigation: tighten robots.txt (Baiduspider/AI crawlers), reconsider member URLs in sitemap | all | decide with team |
+| #   | Fix                                                                                                                                                                                              | Quota hit    | Status           |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------ | ---------------- |
+| 1   | Slim `/proposals` + home payloads (`toListProposal`)                                                                                                                                             | ISR + FOT    | ✅ PR #127       |
+| 2   | Cache member OG metadata (`unstable_cache` 30min)                                                                                                                                                | CPU          | ✅ PR #127       |
+| 3   | Sitemap: remove `force-dynamic` (one line)                                                                                                                                                       | CPU + FOT    | todo             |
+| 4   | Skip `governor.state()` RPC for terminal proposals; `listMultiChainProposals` fetches 1000 → fetch what's needed                                                                                 | CPU          | todo             |
+| 5   | Status-aware revalidate on `/proposals/[chain]/[id]`                                                                                                                                             | ISR          | todo             |
+| 6   | `images.minimumCacheTTL: 2592000` (banners/media are immutable)                                                                                                                                  | FOT + CPU    | todo             |
+| 7   | Batch-add `Cache-Control: public, s-maxage, stale-while-revalidate` to API GETs without it (`md/*`, `api/proposals/per-month`, `api/members`, `api/coins/gnars-paired`, `api/poidh/bounties`, …) | CPU + FOT    | todo             |
+| 8   | `/api/alchemy`: 9.9% error rate — only `eth_getBalance` has RPC fallback; add fallback/retry + micro-cache for read methods                                                                      | CPU + errors | todo             |
+| 9   | Immutable content → static (`Snapshot`/ETH-era proposals, installations `[slug]`, executed droposals, closed rounds)                                                                             | ISR          | todo             |
+| 10  | Align `/blogs` route TTL to data TTL (300 → 3600)                                                                                                                                                | ISR          | todo             |
+| 11  | Replace `no-store` in `subgraph.ts` with per-caller `next.revalidate`                                                                                                                            | CPU + FOT    | todo             |
+| 12  | Bot mitigation: tighten robots.txt (Baiduspider/AI crawlers), reconsider member URLs in sitemap                                                                                                  | all          | decide with team |
 
 ## How to verify (after each deploy)
 
 Vercel dashboard → project `gnars-shadcn` → Observability:
 
-- **ISR** tab, sort by *Total Written*, view in **Units** (that's what's billed). Expect `/en/proposals` ~70 → ~10 units/write after #127.
-- **Functions** tab, sort by *Active CPU*: `/[locale]/members/[address]` and `/api/tv/feed` are the benchmarks.
+- **ISR** tab, sort by _Total Written_, view in **Units** (that's what's billed). Expect `/en/proposals` ~70 → ~10 units/write after #127.
+- **Functions** tab, sort by _Active CPU_: `/[locale]/members/[address]` and `/api/tv/feed` are the benchmarks.
 - **Fast Data Transfer** tab for payload regressions.
 
 The account-level Usage page charts frequently fail to load; per-project Observability is the reliable path. Give changes 24–48h in the 30-day rolling window before judging.

--- a/docs/architecture/vercel-quota-strategy.md
+++ b/docs/architecture/vercel-quota-strategy.md
@@ -1,0 +1,72 @@
+# Vercel Quota Strategy
+
+TL;DR: the site exceeds Vercel Hobby quotas because immutable or slow-moving DAO data is re-rendered, re-fetched and re-cached as if it were live. The fix is matching cache lifetime to the **real update cadence of each data type**, slimming RSC payloads, and shielding origin from bot traffic. This doc is the playbook; keep it current as fixes land.
+
+## Quota status (billing window Jun 3 – Jul 3, 2026)
+
+| Quota | Used / Limit | Primary drivers |
+| --- | --- | --- |
+| ISR Writes | 620K / 200K units | `/proposals` list payload, 300s revalidate everywhere, ×2 locales, ×3 cache entries |
+| Fluid Active CPU | 11h22 / 4h | `/members/[address]` (force-dynamic + bot crawl), home, `/api/tv/feed`, RPC fan-out |
+| Fast Origin Transfer | 12.4GB / 10GB | Same pages: big RSC payloads leaving compute on every render/regen |
+
+Bot traffic (Googlebot, OpenAI, Baiduspider — ~12–14K req/12h each) hits mostly-unique paths, so per-path caches don't amortize; every crawl of an expired path is a full render + ISR write.
+
+## Billing mechanics (measured on this project)
+
+- ISR writes are billed in **units per cache entry** (~8KB granularity). One page revalidation in Next 16 writes **~3 entries** (page + `_full.segment` + `__PAGE__.segment`), and `[locale]` doubles everything → one route at `revalidate = 300` costs up to `12/h × 3 × 2 = 72` write units/hour **per KB-bucket of payload**. `/en/proposals` alone measured ~70 units *per write* before slimming (1.3MB embedded JSON).
+- Writes are traffic-triggered (revalidate-on-request after expiry). No traffic → no writes. Bots count as traffic.
+- `react.cache()` dedupes **within one render pass only**. It does not persist across revalidations or across routes. Only `unstable_cache` / fetch `next.revalidate` hit the shared data cache.
+- `export const dynamic = "force-dynamic"` **overrides** `export const revalidate` on the same route (see the sitemap bug below).
+
+## Data type × real cadence → correct strategy
+
+The core principle: **DAO data is mostly append-only and terminal.** Once a proposal is Executed/Defeated/Cancelled/Vetoed/Expired, an auction settled, a round closed, a droposal executed — that record never changes again. Only a small live window (active auction, proposals in their 4-day voting window, prices, feed) needs freshness.
+
+| Data | Real cadence | Current handling | Target |
+| --- | --- | --- | --- |
+| Base proposals (list) | new ~weekly; votes change during 4-day window; terminal states immutable | subgraph `no-store` + 123 RPC `state()` reads per invocation, route 300s | `unstable_cache` 900–1800s; **skip `state()` RPC for terminal proposals** (subgraph already has `executed/canceled/vetoed/queued` booleans) |
+| Proposal detail pages | immutable once finalized | revalidate 300 for all | status-aware: short TTL only for Active/Pending; long/static for finalized |
+| Ethereum-era + Snapshot proposals | **immutable** (static JSON) | re-processed every 300s via consumers | static import / `revalidate = false`; `generateStaticParams` |
+| Settled auctions | immutable; +1/day | `no-store` subgraph | `unstable_cache` 3600+ |
+| Treasury balances | change on tx (slow); prices per-minute | fetch 60s on balances | balances 300–900s; prices already CDN-cached (fine) |
+| Feed events | event-driven | `unstable_cache` **15s** under a 300s route | align to 120–300s |
+| Members | holdings ~daily | `/members/[address]` force-dynamic (see trap below) | keep dynamic; cache the data lookups (`unstable_cache`) |
+| Blogs | editorial | data cached 3600s but route 300s | route revalidate 3600 to match |
+| Installations | static JSON | `[slug]` 300s | 3600+/static |
+| Rounds (Postgres) | live while open; closed = immutable | raw `pg` on every call, no cache | `unstable_cache` 120–300s for listings; closed rounds static |
+| TV/coins feed | hourly aggregation | CDN s-maxage 3600 (ok), but 2s CPU per cold miss | cap upstream fan-out, persist HEAD-probe cache |
+
+## Traps (learned the hard way — do not repeat)
+
+1. **Do NOT convert `/members/[address]` to ISR.** Hundreds of unique addresses are in the sitemap ×2 locales; bots crawl each path once. ISR would write ~3 cache entries per unique path per crawl (~5K+ units/day) into the *tightest* quota. Correct approach: stay `force-dynamic`, cache the expensive lookups (Zora profile + overview via `unstable_cache`, done in PR #127) — or remove member pages from the sitemap.
+2. **`force-dynamic` + `revalidate` on the same route = fully dynamic.** The sitemap has both; every crawler hit re-runs the full fan-out (all proposals + coins + members + blogs + droposals).
+3. **Slimming beats TTL-raising.** PR #120 raised TTLs (60→300) and barely moved the needle; PR #127 cut the payload 68% — write units scale with payload size × entry count, not just frequency.
+4. **`src/lib/subgraph.ts` hardcodes `cache: "no-store"`** — every caller re-fetches origin on every regen regardless of route TTL.
+
+## Fix backlog (impact ÷ effort, merged from route sweep + data-cadence audit)
+
+| # | Fix | Quota hit | Status |
+| --- | --- | --- | --- |
+| 1 | Slim `/proposals` + home payloads (`toListProposal`) | ISR + FOT | ✅ PR #127 |
+| 2 | Cache member OG metadata (`unstable_cache` 30min) | CPU | ✅ PR #127 |
+| 3 | Sitemap: remove `force-dynamic` (one line) | CPU + FOT | todo |
+| 4 | Skip `governor.state()` RPC for terminal proposals; `listMultiChainProposals` fetches 1000 → fetch what's needed | CPU | todo |
+| 5 | Status-aware revalidate on `/proposals/[chain]/[id]` | ISR | todo |
+| 6 | `images.minimumCacheTTL: 2592000` (banners/media are immutable) | FOT + CPU | todo |
+| 7 | Batch-add `Cache-Control: public, s-maxage, stale-while-revalidate` to API GETs without it (`md/*`, `api/proposals/per-month`, `api/members`, `api/coins/gnars-paired`, `api/poidh/bounties`, …) | CPU + FOT | todo |
+| 8 | `/api/alchemy`: 9.9% error rate — only `eth_getBalance` has RPC fallback; add fallback/retry + micro-cache for read methods | CPU + errors | todo |
+| 9 | Immutable content → static (`Snapshot`/ETH-era proposals, installations `[slug]`, executed droposals, closed rounds) | ISR | todo |
+| 10 | Align `/blogs` route TTL to data TTL (300 → 3600) | ISR | todo |
+| 11 | Replace `no-store` in `subgraph.ts` with per-caller `next.revalidate` | CPU + FOT | todo |
+| 12 | Bot mitigation: tighten robots.txt (Baiduspider/AI crawlers), reconsider member URLs in sitemap | all | decide with team |
+
+## How to verify (after each deploy)
+
+Vercel dashboard → project `gnars-shadcn` → Observability:
+
+- **ISR** tab, sort by *Total Written*, view in **Units** (that's what's billed). Expect `/en/proposals` ~70 → ~10 units/write after #127.
+- **Functions** tab, sort by *Active CPU*: `/[locale]/members/[address]` and `/api/tv/feed` are the benchmarks.
+- **Fast Data Transfer** tab for payload regressions.
+
+The account-level Usage page charts frequently fail to load; per-project Observability is the reliable path. Give changes 24–48h in the 30-day rolling window before judging.

--- a/docs/architecture/vercel-quota-strategy.md
+++ b/docs/architecture/vercel-quota-strategy.md
@@ -12,12 +12,15 @@ TL;DR: the site exceeds Vercel Hobby quotas because immutable or slow-moving DAO
 
 Bot traffic (Googlebot, OpenAI, Baiduspider — ~12–14K req/12h each) hits mostly-unique paths, so per-path caches don't amortize; every crawl of an expired path is a full render + ISR write.
 
-## Billing mechanics (measured on this project)
+## Billing mechanics (measured here + confirmed against Vercel/Next docs, 2026-07)
 
-- ISR writes are billed in **units per cache entry** (~8KB granularity). One page revalidation in Next 16 writes **~3 entries** (page + `_full.segment` + `__PAGE__.segment`), and `[locale]` doubles everything → one route at `revalidate = 300` costs up to `12/h × 3 × 2 = 72` write units/hour **per KB-bucket of payload**. `/en/proposals` alone measured ~70 units _per write_ before slimming (1.3MB embedded JSON).
-- Writes are traffic-triggered (revalidate-on-request after expiry). No traffic → no writes. Bots count as traffic.
+- **1 ISR write unit = 8KB** of data written to the ISR cache, compressed, billed per stored representation ([pricing doc](https://vercel.com/docs/incremental-static-regeneration/limits-and-pricing)). One page revalidation in Next 16 writes the HTML **plus N `.segment` entries** (`__PAGE__`, `_tree`, `_head`, `_full`), and `[locale]` doubles everything. `/en/proposals` alone measured ~70 units _per write_ before slimming (1.3MB embedded JSON). The segment-cache write multiplication is architectural — **it cannot be disabled in Next 16.2** (`clientSegmentCache` flag removed in 16.1; `cacheComponents` doesn't reduce it — [vercel/next.js#93210](https://github.com/vercel/next.js/issues/93210)).
+- Writes are traffic-triggered (revalidate-on-request after expiry). No traffic → no writes; unchanged bytes → 0 units. Bots count as traffic — **including `<Link>` viewport prefetches**, which write detail-page segments without a real pageview.
+- **Dynamic route + `Cache-Control: public, s-maxage` = zero ISR writes.** The CDN cache is free; the route only burns FOT + edge requests ([CDN usage doc](https://vercel.com/docs/manage-cdn-usage)). For routes hit mostly on unique paths by bots, dynamic+CDN beats ISR (ISR wastes a durable write per never-revisited path). `s-maxage` also moves repeat traffic from Fast Origin Transfer (10GB) to Fast Data Transfer (100GB on Hobby).
+- **Fluid Active CPU bills only actual compute, not I/O wait** ([Vercel blog](https://vercel.com/blog/introducing-active-cpu-pricing-for-fluid-compute)). Slow subgraph/RPC fetches are ~free on the CPU meter; `JSON.parse`/RSC serialization of big payloads is what burns it — another reason slimming beats TTL-raising.
 - `react.cache()` dedupes **within one render pass only**. It does not persist across revalidations or across routes. Only `unstable_cache` / fetch `next.revalidate` hit the shared data cache.
 - `export const dynamic = "force-dynamic"` **overrides** `export const revalidate` on the same route (see the sitemap bug below).
+- next-intl: 2 locales = 2 cache entries, unavoidable at runtime. The real lever is full static prerender (`setRequestLocale` in every layout+page + `generateStaticParams` for `[en, pt-br]`, no `revalidate`) → 0 runtime ISR writes, refreshed via on-demand `revalidateTag` or redeploy ([next-intl doc](https://next-intl.dev/docs/getting-started/app-router/with-i18n-routing)).
 
 ## Data type × real cadence → correct strategy
 
@@ -43,23 +46,36 @@ The core principle: **DAO data is mostly append-only and terminal.** Once a prop
 2. **`force-dynamic` + `revalidate` on the same route = fully dynamic.** The sitemap has both; every crawler hit re-runs the full fan-out (all proposals + coins + members + blogs + droposals).
 3. **Slimming beats TTL-raising.** PR #120 raised TTLs (60→300) and barely moved the needle; PR #127 cut the payload 68% — write units scale with payload size × entry count, not just frequency.
 4. **`src/lib/subgraph.ts` hardcodes `cache: "no-store"`** — every caller re-fetches origin on every regen regardless of route TTL.
+5. **robots.txt is not enforcement.** GPTBot mostly honors it; most AI crawlers ignore or spoof it (Baiduspider UA is widely forged). The real tool is the Vercel WAF at the edge — a Deny there runs **before** functions, so blocked requests cost no invocation, CPU, ISR write or FOT.
 
 ## Fix backlog (impact ÷ effort, merged from route sweep + data-cadence audit)
 
-| #   | Fix                                                                                                                                                                                              | Quota hit    | Status           |
-| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------ | ---------------- |
-| 1   | Slim `/proposals` + home payloads (`toListProposal`)                                                                                                                                             | ISR + FOT    | ✅ PR #127       |
-| 2   | Cache member OG metadata (`unstable_cache` 30min)                                                                                                                                                | CPU          | ✅ PR #127       |
-| 3   | Sitemap: remove `force-dynamic` (one line)                                                                                                                                                       | CPU + FOT    | todo             |
-| 4   | Skip `governor.state()` RPC for terminal proposals; `listMultiChainProposals` fetches 1000 → fetch what's needed                                                                                 | CPU          | todo             |
-| 5   | Status-aware revalidate on `/proposals/[chain]/[id]`                                                                                                                                             | ISR          | todo             |
-| 6   | `images.minimumCacheTTL: 2592000` (banners/media are immutable)                                                                                                                                  | FOT + CPU    | todo             |
-| 7   | Batch-add `Cache-Control: public, s-maxage, stale-while-revalidate` to API GETs without it (`md/*`, `api/proposals/per-month`, `api/members`, `api/coins/gnars-paired`, `api/poidh/bounties`, …) | CPU + FOT    | todo             |
-| 8   | `/api/alchemy`: 9.9% error rate — only `eth_getBalance` has RPC fallback; add fallback/retry + micro-cache for read methods                                                                      | CPU + errors | todo             |
-| 9   | Immutable content → static (`Snapshot`/ETH-era proposals, installations `[slug]`, executed droposals, closed rounds)                                                                             | ISR          | todo             |
-| 10  | Align `/blogs` route TTL to data TTL (300 → 3600)                                                                                                                                                | ISR          | todo             |
-| 11  | Replace `no-store` in `subgraph.ts` with per-caller `next.revalidate`                                                                                                                            | CPU + FOT    | todo             |
-| 12  | Bot mitigation: tighten robots.txt (Baiduspider/AI crawlers), reconsider member URLs in sitemap                                                                                                  | all          | decide with team |
+| #   | Fix                                                                                                                                                                                              | Quota hit    | Status        |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------ | ------------- |
+| 1   | Slim `/proposals` + home payloads (`toListProposal`)                                                                                                                                             | ISR + FOT    | ✅ PR #127    |
+| 2   | Cache member OG metadata (`unstable_cache` 30min)                                                                                                                                                | CPU          | ✅ PR #127    |
+| 3   | Sitemap: remove `force-dynamic` (one line)                                                                                                                                                       | CPU + FOT    | todo          |
+| 4   | Skip `governor.state()` RPC for terminal proposals; `listMultiChainProposals` fetches 1000 → fetch what's needed                                                                                 | CPU          | todo          |
+| 5   | Status-aware revalidate on `/proposals/[chain]/[id]`                                                                                                                                             | ISR          | todo          |
+| 6   | `images.minimumCacheTTL: 2592000` (banners/media are immutable)                                                                                                                                  | FOT + CPU    | todo          |
+| 7   | Batch-add `Cache-Control: public, s-maxage, stale-while-revalidate` to API GETs without it (`md/*`, `api/proposals/per-month`, `api/members`, `api/coins/gnars-paired`, `api/poidh/bounties`, …) | CPU + FOT    | todo          |
+| 8   | `/api/alchemy`: 9.9% error rate — only `eth_getBalance` has RPC fallback; add fallback/retry + micro-cache for read methods                                                                      | CPU + errors | todo          |
+| 9   | Immutable content → static (`Snapshot`/ETH-era proposals, installations `[slug]`, executed droposals, closed rounds)                                                                             | ISR          | todo          |
+| 10  | Align `/blogs` route TTL to data TTL (300 → 3600)                                                                                                                                                | ISR          | todo          |
+| 11  | Replace `no-store` in `subgraph.ts` with per-caller `next.revalidate`                                                                                                                            | CPU + FOT    | todo          |
+| 12  | `prefetch={false}` on high-fan-out `<Link>` grids (proposal cards, members, auctions) — each card in viewport prefetches detail-page segments                                                    | ISR          | todo          |
+| 13  | Audit `router.refresh()` after mutations (`ProposalDetail.tsx:117`, `RoundsAdminDashboard.tsx:102`) — refresh after revalidate is a known segment-write multiplier                               | ISR          | todo          |
+| 14  | Fully static prerender for stable pages (`setRequestLocale` + `generateStaticParams`, drop `revalidate`, on-demand `revalidateTag`)                                                              | ISR + CPU    | todo (larger) |
+
+### #0 — no-code, do first: WAF bot blocking (dashboard only)
+
+Vercel → project → Firewall:
+
+1. Enable the free **"AI Bots" managed ruleset** → **Deny** (one toggle, available on Hobby, doesn't consume the custom-rule budget — [changelog](https://vercel.com/changelog/new-one-click-ai-bot-managed-ruleset)). Blocks GPTBot, ClaudeBot, Bytespider, PerplexityBot, etc. at the edge.
+2. Use the **3 free custom WAF rules** for named offenders the ruleset misses — e.g. User-Agent contains `Baiduspider` → Deny ([WAF doc](https://vercel.com/docs/vercel-firewall/vercel-waf)).
+3. Keep **Attack Challenge Mode** in mind for traffic spikes (free, blocked requests don't count as usage).
+
+With ~1/3 of identifiable traffic being AI/foreign crawlers hitting unique expensive paths, this is the single highest-leverage action and requires zero code. Decide with the team whether OpenAI/Claude crawler visibility matters for the DAO before denying (SEO via Googlebot is unaffected — it's not in the AI ruleset).
 
 ## How to verify (after each deploy)
 

--- a/src/app/[locale]/members/[address]/page.tsx
+++ b/src/app/[locale]/members/[address]/page.tsx
@@ -133,7 +133,7 @@ interface MemberPageProps {
 }
 
 // Helper to fetch member metadata for OG tags
-async function getMemberMetadata(address: string) {
+async function getMemberMetadataUncached(address: string) {
   try {
     // Fetch Zora profile data
     if (process.env.NEXT_PUBLIC_ZORA_API_KEY) {
@@ -188,6 +188,17 @@ async function getMemberMetadata(address: string) {
     return null;
   }
 }
+
+/**
+ * The page stays force-dynamic (ISR here would burn write units on every
+ * unique bot-crawled address), but the metadata lookup — Zora profile +
+ * member overview, the bulk of per-request CPU — is served from the data
+ * cache for 30 minutes per address.
+ */
+const getMemberMetadata = unstable_cache(getMemberMetadataUncached, ["members:og-metadata"], {
+  revalidate: 1800,
+  tags: ["members:og-metadata"],
+});
 
 export async function generateMetadata({ params }: MemberPageProps): Promise<Metadata> {
   const { address, locale } = await params;

--- a/src/app/[locale]/proposals/page.tsx
+++ b/src/app/[locale]/proposals/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { ProposalsGridSkeleton } from "@/components/proposals/ProposalsGrid";
 import { ProposalsView } from "@/components/proposals/ProposalsView";
+import { toListProposal } from "@/lib/proposal-list-payload";
 import { listMultiChainProposals } from "@/services/multi-chain-proposals";
 
 export const revalidate = 300;
@@ -46,7 +47,10 @@ async function getProposals() {
   try {
     // Only fetch Base proposals by default (for performance)
     // Ethereum and Snapshot are loaded client-side when filters are activated
-    return await listMultiChainProposals(200, false, false);
+    const proposals = await listMultiChainProposals(200, false, false);
+    // Slim payload: full descriptions + vote arrays are ~87% of the RSC
+    // payload and get re-billed as ISR write units on every revalidation.
+    return proposals.map(toListProposal);
   } catch (error) {
     console.error("Failed to fetch proposals:", error);
     return [];

--- a/src/components/home/RecentProposalsSection.tsx
+++ b/src/components/home/RecentProposalsSection.tsx
@@ -1,4 +1,5 @@
 import { RecentProposals } from "@/components/proposals/recent/RecentProposals";
+import { toListProposal } from "@/lib/proposal-list-payload";
 import { ProposalStatus } from "@/lib/schemas/proposals";
 import { listProposals } from "@/services/proposals";
 
@@ -12,7 +13,7 @@ export async function RecentProposalsSection({
   excludeStatuses = [ProposalStatus.CANCELLED],
 }: RecentProposalsSectionProps) {
   // Fetch a few extra to account for filtered statuses
-  const proposals = await listProposals(limit + 5);
+  const proposals = (await listProposals(limit + 5)).map(toListProposal);
 
   return (
     <RecentProposals

--- a/src/components/proposals/ProposalCard.tsx
+++ b/src/components/proposals/ProposalCard.tsx
@@ -80,7 +80,11 @@ export function ProposalCard({
   });
   const isPending = proposal.status === ProposalStatus.PENDING;
 
-  const bannerUrl = normalizeImageUrl(extractFirstUrl(proposal.description));
+  const bannerUrl = normalizeImageUrl(
+    proposal.bannerImageUrl !== undefined
+      ? proposal.bannerImageUrl
+      : extractFirstUrl(proposal.description),
+  );
   const currentBannerSrc = bannerUrl ?? "/logo-banner.jpg";
   const [bannerSrc, setBannerSrc] = useState<string>(currentBannerSrc);
   const [isImageLoaded, setIsImageLoaded] = useState<boolean>(false);

--- a/src/lib/proposal-list-payload.test.ts
+++ b/src/lib/proposal-list-payload.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { Proposal } from "@/components/proposals/types";
+import { ProposalStatus } from "@/lib/schemas/proposals";
+import { toListProposal } from "./proposal-list-payload";
+
+function makeProposal(overrides: Partial<Proposal> = {}): Proposal {
+  return {
+    proposalId: "0xabc",
+    proposalNumber: 42,
+    title: "Fund skate park",
+    description: "Some description",
+    status: ProposalStatus.EXECUTED,
+    proposer: "0x1234567890123456789012345678901234567890",
+    createdAt: 1700000000000,
+    endBlock: 123,
+    forVotes: 10,
+    againstVotes: 2,
+    abstainVotes: 1,
+    quorumVotes: 5,
+    calldatas: ["0x"],
+    targets: ["0x1234567890123456789012345678901234567890"],
+    values: ["0"],
+    signatures: [],
+    transactionHash: "0xdead",
+    votes: [
+      {
+        voter: "0x1234567890123456789012345678901234567890",
+        choice: "FOR",
+        votes: "10",
+        transactionHash: "0xbeef",
+        reason: "long reason text",
+      },
+    ],
+    voteStart: "2023-11-14T00:00:00.000Z",
+    voteEnd: "2023-11-18T00:00:00.000Z",
+    timeCreated: 1700000000,
+    ...overrides,
+  };
+}
+
+describe("toListProposal", () => {
+  it("drops the votes array", () => {
+    const slim = toListProposal(makeProposal());
+    expect(slim.votes).toBeUndefined();
+  });
+
+  it("extracts the first URL from the description as bannerImageUrl", () => {
+    const slim = toListProposal(
+      makeProposal({
+        description: "# Title\n\nIntro text\n\n![banner](https://example.com/pic.png) more",
+      }),
+    );
+    expect(slim.bannerImageUrl).toBe("https://example.com/pic.png");
+  });
+
+  it("sets bannerImageUrl to null when the description has no URL", () => {
+    const slim = toListProposal(makeProposal({ description: "plain text only" }));
+    expect(slim.bannerImageUrl).toBeNull();
+  });
+
+  it("strips markdown and truncates the description", () => {
+    const body = `# Heading\n\n**bold** text\n\n\`\`\`js\ncode();\n\`\`\`\n\n${"lorem ipsum ".repeat(200)}`;
+    const slim = toListProposal(makeProposal({ description: body }));
+    expect(slim.description.length).toBeLessThanOrEqual(600);
+    expect(slim.description).not.toContain("#");
+    expect(slim.description).not.toContain("**");
+    expect(slim.description).not.toContain("code()");
+    expect(slim.description).toContain("bold text");
+  });
+
+  it("keeps fields the cards depend on", () => {
+    const proposal = makeProposal();
+    const slim = toListProposal(proposal);
+    expect(slim.title).toBe(proposal.title);
+    expect(slim.forVotes).toBe(proposal.forVotes);
+    expect(slim.calldatas).toEqual(proposal.calldatas);
+    expect(slim.targets).toEqual(proposal.targets);
+    expect(slim.values).toEqual(proposal.values);
+    expect(slim.quorumVotes).toBe(proposal.quorumVotes);
+  });
+});

--- a/src/lib/proposal-list-payload.ts
+++ b/src/lib/proposal-list-payload.ts
@@ -1,0 +1,44 @@
+import type { Proposal } from "@/components/proposals/types";
+import { extractFirstUrl } from "@/components/proposals/utils";
+
+/**
+ * Max characters of stripped-markdown description kept for the list payload.
+ * Enough for the client-side search index to match intro text without
+ * shipping full proposal bodies (average body is ~5KB of markdown).
+ */
+const DESCRIPTION_EXCERPT_LENGTH = 600;
+
+function stripMarkdown(md: string): string {
+  return md
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`[^`]*`/g, " ")
+    .replace(/!?\[[^\]]*\]\([^)]*\)/g, " ")
+    .replace(/<[^>]*>/g, " ")
+    .replace(/[#>*_~-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Slim a proposal for list rendering (grids/cards). Full descriptions and
+ * vote arrays account for ~87% of the list RSC payload (measured 1.3MB for
+ * 123 proposals), which Vercel bills as ISR write units on every
+ * revalidation and as origin transfer on every miss.
+ *
+ * - `bannerImageUrl` is precomputed here because cards only use the
+ *   description to extract the first image URL.
+ * - `description` is reduced to a plain-text excerpt so the search worker
+ *   can still match intro text.
+ * - `votes` is dropped entirely; list UIs only read the aggregate
+ *   for/against/abstain counters.
+ *
+ * Detail pages must keep using the full proposal from the service layer.
+ */
+export function toListProposal<T extends Proposal>(proposal: T): T {
+  return {
+    ...proposal,
+    bannerImageUrl: extractFirstUrl(proposal.description),
+    description: stripMarkdown(proposal.description).slice(0, DESCRIPTION_EXCERPT_LENGTH),
+    votes: undefined,
+  };
+}

--- a/src/lib/schemas/proposals.ts
+++ b/src/lib/schemas/proposals.ts
@@ -29,6 +29,9 @@ export const proposalSchema = z.object({
   proposalNumber: z.number(),
   title: z.string(),
   description: z.string(),
+  // Precomputed by toListProposal() for slim list payloads; when present the
+  // card uses it instead of scanning `description` for the first URL.
+  bannerImageUrl: z.string().nullable().optional(),
   status: z.nativeEnum(ProposalStatus),
   proposer: z.string(),
   proposerEnsName: z.string().optional(),


### PR DESCRIPTION
## Summary

- Vercel Hobby quotas still exceeded after #120 (ISR Writes 620K/200K units, CPU 11h22/4h, FOT 12.4GB/10GB). Observability shows /proposals writing ~70 ISR units per revalidation (×3 cache entries ×2 locales) and /members/[address] as the top CPU + #2 transfer route (bot-crawled, force-dynamic).
- Measured: the proposals list embeds 1.3MB of JSON for 123 proposals — description (664KB) + votes (468KB) = 87% of the payload the cards never render.
- New `toListProposal()` slims list payloads: precomputes `bannerImageUrl`, truncates description to a 600-char plain-text excerpt (search still works), drops `votes`. Applied to /proposals and home RecentProposalsSection. Local page HTML: 1.85MB → 594KB (−68%).
- /members/[address] stays force-dynamic on purpose (ISR would burn write units on every unique bot-crawled address) but the OG metadata lookup (Zora profile + member overview — the bulk of per-request CPU) is now served from the data cache for 30min per address.

## Changes

- `src/lib/proposal-list-payload.ts` (+ unit tests) — slimming helper
- `src/lib/schemas/proposals.ts` — optional `bannerImageUrl` field
- `src/components/proposals/ProposalCard.tsx` — uses precomputed banner, falls back to description scan for client-fetched data
- `src/app/[locale]/proposals/page.tsx`, `src/components/home/RecentProposalsSection.tsx` — apply slimming
- `src/app/[locale]/members/[address]/page.tsx` — `unstable_cache` around OG metadata

## Test plan

- [x] `pnpm test` — 83 passed (5 new for toListProposal)
- [x] Runtime: /en/proposals renders 123 cards with banners, search filters (57/123 for "skate"), USDC totals intact
- [x] Runtime: home recent proposals with banners; /members/r4topunk.eth resolves ENS → profile with correct OG title
- [ ] After deploy: watch Observability ISR write units for /en/proposals (expect ~70 → ~10 units/write) and CPU for /[locale]/members/[address]

Generated with [Claude Code](https://claude.com/claude-code)