### PR TITLE
fix(seo): default sitemap + robots to canonical www host

### DIFF
--- a/env.example
+++ b/env.example
@@ -3,7 +3,7 @@
 # ===========================================
 
 # Site Configuration
-NEXT_PUBLIC_SITE_URL=https://gnars.com
+NEXT_PUBLIC_SITE_URL=https://www.gnars.com
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
 
 # ===========================================

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,6 +1,9 @@
 import type { MetadataRoute } from "next";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://gnars.com";
+// Canonical host is www.gnars.com (matches metadataBase in [locale]/layout.tsx
+// and BASE_URL in lib/config.ts). Keeping this in sync is what lets Google index
+// the site — a non-www default here made every sitemap URL a redirect to www.
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://www.gnars.com";
 
 export default function robots(): MetadataRoute.Robots {
   const normalized = SITE_URL.replace(/\/+$/, "");

--- a/src/app/sitemap.xml/route.ts
+++ b/src/app/sitemap.xml/route.ts
@@ -30,7 +30,10 @@ const PROPOSAL_PAGE_SIZE = 200;
 const MAX_COIN_PAGES = 50;
 const COIN_PAGE_SIZE = 200;
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://gnars.com";
+// Canonical host is www.gnars.com (matches metadataBase in [locale]/layout.tsx
+// and BASE_URL in lib/config.ts). A non-www default here emitted 2,564 URLs that
+// all 307-redirected to www, so Google dropped them — keep this on www.
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://www.gnars.com";
 const BASE = SITE_URL.replace(/\/+$/, "");
 
 const toUrl = (path: string) => new URL(path, `${BASE}/`).toString();


### PR DESCRIPTION
## Problem
Google indexes only **~8 pages** of gnars.com. Root cause is a canonical-host split in the code defaults:

| Source | Default when `NEXT_PUBLIC_SITE_URL` is unset |
|---|---|
| `src/app/[locale]/layout.tsx` (`metadataBase` → page canonicals) | `https://www.gnars.com` |
| `src/lib/config.ts` (`BASE_URL`) | `https://www.gnars.com` |
| `src/app/robots.ts` | `https://gnars.com` ❌ |
| `src/app/sitemap.xml/route.ts` | `https://gnars.com` ❌ |

`NEXT_PUBLIC_SITE_URL` is unset in production, so the page **canonicals resolve to `www`** while the **sitemap emits 2,564 `non-www` URLs**. `gnars.com` 307-redirects to `www.gnars.com`, so every sitemap entry is a redirect that disagrees with the canonical — Google dropped almost the entire site. This lines up with the Search Console cliff: ~1,400 impressions/mo (Jan–Apr) → ~0 from May onward.

## Fix
Align `robots.ts` and `sitemap.xml/route.ts` defaults (and `env.example`) to the canonical **`https://www.gnars.com`**, matching `metadataBase` and `BASE_URL`. Now sitemap / robots / canonical all agree. No behavior change when `NEXT_PUBLIC_SITE_URL` is explicitly set.

## After merge / deploy
1. Redeploy so `/sitemap.xml` serves `www` URLs.
2. In Search Console, submit `https://www.gnars.com/sitemap.xml` (ideally on a **Domain property** `sc-domain:gnars.com`, which captures www + non-www) and request indexing on key pages.
3. Recommended (infra, not this PR): make the apex→www redirect **permanent (308)** — it's currently a **307 (temporary)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)