### PR TITLE
fix(farcaster): point manifest accountAssociation at the Gnars account (fid 3757)

### DIFF
--- a/src/lib/miniapp-config.ts
+++ b/src/lib/miniapp-config.ts
@@ -16,12 +16,13 @@ import { BASE_URL, DAO_ADDRESSES, DAO_DESCRIPTION } from "./config";
 export const MINIAPP_CONFIG = {
   // Account association - MUST be filled in after signing at base.dev/preview
   // Leave empty strings until you've signed the manifest
+  // Signed for the Gnars custody account (fid 3757, domain gnars.com).
   accountAssociation: {
     header:
-      "eyJmaWQiOjUzODgzOSwidHlwZSI6ImN1c3RvZHkiLCJrZXkiOiIweDk3Yjc4ZDdCM2M2NmMyZmZiOTYxYWEwQURCNmNlNjcyQTM3MTZEOEMifQ",
+      "eyJmaWQiOjM3NTcsInR5cGUiOiJjdXN0b2R5Iiwia2V5IjoiMHhjQzI5YjVFNmZhOWM1OGU3QzRGMWQ3ZTAzMzExRjMxNjE0M0ZkNWZmIn0",
     payload: "eyJkb21haW4iOiJnbmFycy5jb20ifQ",
     signature:
-      "qm+dqd4UcCOzjAYvNCDaoQOp1A4PoXAm9B6Qv6D4iJ9kzFZ4zjVpoL3s21y2UckqPC+QPO2/HkKuRzoU8GmV4xs=",
+      "j7zi5DsViINJnAaGbXCA36xMmKDtgZ72oRVjAbVCDKsawCrrDnbXR58dD420FxQsQQnFBRFv2bw0K7yCPrzCGRs=",
   },
 
   // Base builder configuration - add your Base account address


### PR DESCRIPTION
## Problem
`/.well-known/farcaster.json` (via `MINIAPP_CONFIG.accountAssociation` in `src/lib/miniapp-config.ts`) was signed for **fid 538839**, not the Gnars custody account — so the Farcaster mini app verifies against the wrong account.

## Fix
Replace the `accountAssociation` header + signature with the manifest signed for the **Gnars account (fid 3757)**, domain `gnars.com`. The payload (`{"domain":"gnars.com"}`) is unchanged. This single source is reused by the Gnar TV + Proposals manifests, so all three are fixed.

Decoded new header: `{"fid":3757,"type":"custody","key":"0xcC29b5E6fa9c58e7C4F1d7e03311F316143Fd5ff"}`

## After merge / deploy
The manifest must be reachable at `https://gnars.com/.well-known/farcaster.json` (the signed domain is `gnars.com`). Note the apex currently 307-redirects to `www` — confirm Farcaster resolves the association against the `gnars.com` domain as signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)