### PR TITLE
feat(store): KeepKey dropship live-API polling + webhook hardening

### DIFF
--- a/docs/integrations/keepkey-fulfillment.md
+++ b/docs/integrations/keepkey-fulfillment.md
@@ -26,16 +26,19 @@ drawn against a **$500 credit line**. Sandbox orders return `settlement: null`. 
 ## Codebase map
 
 - Client — `src/services/keepkey-dropship.ts` (server-only; `listDropshipProducts`,
-  `getDropshipProduct`, `createDropshipOrder`, `getDropshipOrder`, `verifyWebhookSignature`,
-  `isSandbox`, `isDropshipConfigured`, `DROPSHIP_SANDBOX_SKU`).
+  `getDropshipProduct`, `createDropshipOrder`, `getDropshipOrder`,
+  `getDropshipOrderByExternalId`, `verifyWebhookSignature`, `isSandbox`,
+  `isDropshipConfigured`, `DROPSHIP_SANDBOX_SKU`).
 - Types + zod — `src/lib/schemas/dropship.ts`.
 - Routes:
   - `POST /api/store/orders` — forward a paid order (live creation gated, see below).
+  - `GET  /api/store/orders?externalOrderId=…` — poll status/tracking + settlement by our id.
   - `GET  /api/store/orders/[id]` — fulfillment status by `keepKeyOrderId`.
   - `POST /api/store/keepkey-webhook` — signed status webhook.
+- Tests — `src/services/keepkey-dropship.test.ts` (signature verification + externalOrderId lookup).
 - Product model — `src/types/store.ts`; catalog `src/data/store.json` via `src/services/store.ts`.
 - Still TODO: `TODO(checkout)` (`ProductDetail.tsx`), `TODO(inventory)` (order persistence /
-  customer notification in the webhook), `TODO(keepkey-webhook)` (confirm exact signing string).
+  customer notification in the webhook).
 
 ## API (as built)
 
@@ -101,7 +104,7 @@ address → `invalid_address`). Response:
 }
 ```
 
-### Order status — `GET /orders/{keepKeyOrderId}`
+### Order status — `GET /orders/{keepKeyOrderId}` and `GET /orders?externalOrderId=…`
 
 ```json
 {
@@ -111,29 +114,49 @@ address → `invalid_address`). Response:
   "trackingNumber": null,
   "trackingUrl": null,
   "carrier": null,
-  "shippedAt": null
+  "shippedAt": null,
+  "settlement": { "amountDue": 49, "status": "unpaid", "...": "..." }
 }
 ```
 
 `status`: `received | processing | shipped | cancelled | failed`.
 
+**Tracking today is poll-only.** Per the go-live handoff (2026-07-15), KeepKey's
+`order.shipped` webhook **does not fire yet** — poll `GET /orders?externalOrderId=…` a few
+times a day and read `status` / `trackingNumber` / `trackingUrl` / `carrier`. That endpoint
+also re-returns the order's `settlement` block, so a lost create-order response is
+recoverable. When tracking-sync ships upstream, `order.shipped` starts arriving on the
+existing webhook with no change on our side. `getDropshipOrderByExternalId` /
+`GET /api/store/orders?externalOrderId=…` implement this.
+
 ### Webhooks — `POST` to our `/api/store/keepkey-webhook`
 
-Events: `order.received | order.processing | order.shipped | order.cancelled | order.failed`.
-Signed with **HMAC-SHA256** via the `X-KeepKey-Signature` header (timestamped) using
-`KEEPKEY_DROPSHIP_WEBHOOK_SECRET`. Payload: `eventType, keepKeyOrderId, externalOrderId,
-status, trackingNumber?, trackingUrl?, carrier?, timestamp`.
-
-> `TODO(keepkey-webhook)`: the exact signed-payload string (`${t}.${rawBody}` vs `rawBody`)
-> is not yet confirmed from the docs; `verifyWebhookSignature` tries both. Confirm against a
-> real event, then drop the fallback. With no secret set, webhooks are accepted **only in
-> sandbox** (logged as unverified) and rejected in live.
+Events: `order.received | order.processing | order.shipped | order.cancelled | order.failed`
+(only `order.received` fires today). Signed **Stripe-style**: `X-KeepKey-Signature:
+t=<unix>,v1=<hex>`, where `v1 = HMAC-SHA256(secret, "${t}.${rawBody}")` computed over the
+**raw** request body. `verifyWebhookSignature` recomputes that and **rejects timestamps
+outside a 5-minute window** (replay defense; `WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS`). Payload:
+`eventType, keepKeyOrderId, externalOrderId, status, trackingNumber?, trackingUrl?, carrier?,
+timestamp`. With no secret set, webhooks are accepted **only in sandbox** (logged as
+unverified) and rejected in live.
 
 ### Errors
 
 `{ "error": { "code": "...", "message": "..." } }` with codes like `invalid_request`,
-`invalid_address`, `out_of_stock`, `insufficient_credit`, plus `401` (bad/missing token).
+`invalid_address`, `out_of_stock`, `insufficient_credit`, `account_suspended` (an overdue
+settlement blocks new orders until it clears), plus `401` (bad/missing token).
 `DropshipApiError` carries the HTTP status + code; routes surface them unchanged.
+
+## Settlement (live orders)
+
+Each live order response carries a `settlement` block — the wholesale owed to KeepKey as a
+crypto deposit (`amountDue` in USD, `chainAmount` in BTC to a unique per-order
+`depositAddress`, `dueAt` ≈ 30 days), drawn against the $500 credit line. Send **exactly
+`chainAmount`** to that order's `depositAddress` before `dueAt`; detection is automatic
+(~15 min, 1 confirmation) and restores credit. **Store or recover the settlement** — the
+create-order response has it, and `GET /orders?externalOrderId=…` re-returns it. An overdue
+settlement suspends the account (`account_suspended`). At $49/unit the $500 line is ≈10
+unsettled orders in flight; settle roughly weekly. Sandbox orders return `settlement: null`.
 
 ## Sandbox
 
@@ -158,7 +181,13 @@ Set real values in Vercel env / `.env.local`; they are gitignored and never comm
 
 1. Build Gnars checkout + payment; only call `POST /api/store/orders` **after** payment settles.
 2. Set `KEEPKEY_DROPSHIP_LIVE_TOKEN`, `KEEPKEY_DROPSHIP_WEBHOOK_SECRET`,
-   `KEEPKEY_DROPSHIP_INTERNAL_SECRET` in Vercel; flip `KEEPKEY_DROPSHIP_MODE=live`.
-3. Register the webhook URL with KeepKey; confirm the signing string and remove the fallback.
-4. Persist orders + surface tracking to the customer (`TODO(inventory)`).
-5. Fund/monitor the crypto settlement against the $500 credit line.
+   `KEEPKEY_DROPSHIP_INTERNAL_SECRET` in Vercel; flip `KEEPKEY_DROPSHIP_MODE=live`. Order the
+   real SKU `KK-HW-001` (not `KK-TEST-001`); pass the color finish in `notes`.
+3. Do one **recommended first live order** (1× `KK-HW-001` to a real address via the
+   internal-secret gate), confirm `sandbox:false` + a non-null `settlement`, verify the
+   signed `order.received` webhook arrives, then pay the settlement early to prove the BTC
+   flow and restore credit.
+4. Poll `GET /orders?externalOrderId=…` until `shipped` (the `order.shipped` webhook is not
+   live yet); then wire storefront traffic.
+5. Persist orders + surface tracking to the customer (`TODO(inventory)`).
+6. Fund/monitor the crypto settlement against the $500 credit line.

--- a/src/app/api/store/orders/route.ts
+++ b/src/app/api/store/orders/route.ts
@@ -3,12 +3,60 @@ import { dropshipOrderInputSchema } from "@/lib/schemas/dropship";
 import {
   createDropshipOrder,
   DropshipApiError,
+  getDropshipOrderByExternalId,
   isDropshipConfigured,
   isSandbox,
 } from "@/services/keepkey-dropship";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+
+/**
+ * Poll fulfillment status/tracking for an order by our own `externalOrderId`.
+ *
+ * This is the supported way to track a live order until KeepKey's `order.shipped` webhook
+ * ships (it doesn't fire yet). The response also carries the `settlement` block, so an
+ * order's crypto deposit details are recoverable here.
+ */
+export async function GET(request: NextRequest) {
+  if (!isDropshipConfigured()) {
+    return NextResponse.json(
+      { error: { code: "not_configured", message: "KeepKey dropship token is not set" } },
+      { status: 503 },
+    );
+  }
+
+  const externalOrderId = request.nextUrl.searchParams.get("externalOrderId");
+  if (!externalOrderId) {
+    return NextResponse.json(
+      { error: { code: "invalid_request", message: "externalOrderId query param is required" } },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const order = await getDropshipOrderByExternalId(externalOrderId);
+    if (!order) {
+      return NextResponse.json(
+        { error: { code: "not_found", message: "No order for that externalOrderId" } },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json(order);
+  } catch (error) {
+    if (error instanceof DropshipApiError) {
+      return NextResponse.json(
+        { error: { code: error.code, message: error.message } },
+        { status: error.httpStatus },
+      );
+    }
+    console.error("getDropshipOrderByExternalId failed:", error);
+    return NextResponse.json(
+      { error: { code: "server_error", message: "Failed to fetch order" } },
+      { status: 502 },
+    );
+  }
+}
 
 /**
  * Forward a paid order to KeepKey for fulfillment.

--- a/src/components/store/SandboxOrderTester.tsx
+++ b/src/components/store/SandboxOrderTester.tsx
@@ -10,21 +10,31 @@ import { Button } from "@/components/ui/button";
  * detail page only while KEEPKEY_DROPSHIP_MODE=test (the server passes `enabled`), so it
  * disappears automatically in live mode. Never ships, never draws credit.
  */
+interface TesterOrder {
+  keepKeyOrderId: string;
+  externalOrderId: string;
+  status: string;
+  trackingNumber?: string | null;
+  trackingUrl?: string | null;
+  carrier?: string | null;
+}
+
 export function SandboxOrderTester() {
   const [loading, setLoading] = useState(false);
-  const [order, setOrder] = useState<{ keepKeyOrderId: string; status: string } | null>(null);
+  const [order, setOrder] = useState<TesterOrder | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   async function placeOrder() {
     setLoading(true);
     setError(null);
     setOrder(null);
+    const externalOrderId = `gnars-sandbox-${Date.now()}`;
     try {
       const res = await fetch("/api/store/orders", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          externalOrderId: `gnars-sandbox-${Date.now()}`,
+          externalOrderId,
           customerName: "Gnars Sandbox",
           customerEmail: "sandbox@gnars.com",
           shippingAddress: {
@@ -39,7 +49,7 @@ export function SandboxOrderTester() {
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data?.error?.message || `HTTP ${res.status}`);
-      setOrder({ keepKeyOrderId: data.keepKeyOrderId, status: data.status });
+      setOrder({ keepKeyOrderId: data.keepKeyOrderId, externalOrderId, status: data.status });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to place order");
     } finally {
@@ -47,15 +57,26 @@ export function SandboxOrderTester() {
     }
   }
 
+  // Polls by externalOrderId — the same path a live order uses to learn its shipment status
+  // (KeepKey's order.shipped webhook doesn't fire yet).
   async function refreshStatus() {
     if (!order) return;
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(`/api/store/orders/${order.keepKeyOrderId}`);
+      const res = await fetch(
+        `/api/store/orders?externalOrderId=${encodeURIComponent(order.externalOrderId)}`,
+      );
       const data = await res.json();
       if (!res.ok) throw new Error(data?.error?.message || `HTTP ${res.status}`);
-      setOrder({ keepKeyOrderId: data.keepKeyOrderId, status: data.status });
+      setOrder({
+        keepKeyOrderId: data.keepKeyOrderId,
+        externalOrderId: data.externalOrderId,
+        status: data.status,
+        trackingNumber: data.trackingNumber,
+        trackingUrl: data.trackingUrl,
+        carrier: data.carrier,
+      });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to fetch status");
     } finally {
@@ -88,9 +109,29 @@ export function SandboxOrderTester() {
       </div>
 
       {order && (
-        <p className="mt-3 font-mono text-xs text-foreground">
-          {order.keepKeyOrderId} — <span className="text-[#e08968]">{order.status}</span>
-        </p>
+        <div className="mt-3 space-y-1 font-mono text-xs text-foreground">
+          <p>
+            {order.keepKeyOrderId} — <span className="text-[#e08968]">{order.status}</span>
+          </p>
+          {order.trackingNumber && (
+            <p className="text-muted-foreground">
+              {order.carrier ?? "tracking"}: {order.trackingNumber}
+              {order.trackingUrl ? (
+                <>
+                  {" "}
+                  <a
+                    href={order.trackingUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-[#e08968] underline"
+                  >
+                    track
+                  </a>
+                </>
+              ) : null}
+            </p>
+          )}
+        </div>
       )}
       {error && <p className="mt-3 text-xs text-red-500">{error}</p>}
     </div>

--- a/src/lib/schemas/dropship.ts
+++ b/src/lib/schemas/dropship.ts
@@ -68,6 +68,13 @@ export interface DropshipOrderRecord {
   trackingUrl: string | null;
   carrier: string | null;
   shippedAt: string | null;
+  estimatedShippingDate?: string | null;
+  /**
+   * The order's crypto settlement, re-returned by `GET /orders?externalOrderId=…`.
+   * Lets us recover an order's `depositAddress` / `amountDue` / `dueAt` if the
+   * create-order response was lost. Null/absent in sandbox.
+   */
+  settlement?: DropshipSettlement | null;
 }
 
 export const shippingAddressSchema = z.object({

--- a/src/services/keepkey-dropship.test.ts
+++ b/src/services/keepkey-dropship.test.ts
@@ -1,0 +1,134 @@
+import { createHmac } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getDropshipOrderByExternalId,
+  verifyWebhookSignature,
+  WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS,
+} from "./keepkey-dropship";
+
+const SECRET = "whsec_test_secret";
+const NOW_MS = 1_800_000_000_000; // fixed clock for deterministic timestamp checks
+const NOW_S = Math.floor(NOW_MS / 1000);
+
+function sign(rawBody: string, ts: number, secret = SECRET): string {
+  const v1 = createHmac("sha256", secret).update(`${ts}.${rawBody}`).digest("hex");
+  return `t=${ts},v1=${v1}`;
+}
+
+describe("verifyWebhookSignature", () => {
+  const body = JSON.stringify({ eventType: "order.received", keepKeyOrderId: "kk_1" });
+
+  beforeEach(() => {
+    process.env.KEEPKEY_DROPSHIP_MODE = "live";
+    process.env.KEEPKEY_DROPSHIP_WEBHOOK_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.KEEPKEY_DROPSHIP_WEBHOOK_SECRET;
+    delete process.env.KEEPKEY_DROPSHIP_MODE;
+  });
+
+  it("accepts a correctly signed, fresh payload", () => {
+    const header = sign(body, NOW_S);
+    expect(verifyWebhookSignature(body, header, NOW_MS)).toEqual({
+      valid: true,
+      reason: "verified",
+    });
+  });
+
+  it("rejects a tampered body", () => {
+    const header = sign(body, NOW_S);
+    const res = verifyWebhookSignature(body + " ", header, NOW_MS);
+    expect(res.valid).toBe(false);
+    expect(res.reason).toBe("signature-mismatch");
+  });
+
+  it("rejects a stale timestamp beyond tolerance (replay)", () => {
+    const staleTs = NOW_S - WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS - 1;
+    const header = sign(body, staleTs);
+    expect(verifyWebhookSignature(body, header, NOW_MS)).toEqual({
+      valid: false,
+      reason: "stale-timestamp",
+    });
+  });
+
+  it("accepts a timestamp at the tolerance edge", () => {
+    const edgeTs = NOW_S - WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS;
+    const header = sign(body, edgeTs);
+    expect(verifyWebhookSignature(body, header, NOW_MS).valid).toBe(true);
+  });
+
+  it("rejects a valid signature made with the wrong secret", () => {
+    const header = sign(body, NOW_S, "whsec_attacker");
+    expect(verifyWebhookSignature(body, header, NOW_MS).valid).toBe(false);
+  });
+
+  it("rejects a malformed header missing v1", () => {
+    expect(verifyWebhookSignature(body, `t=${NOW_S}`, NOW_MS)).toEqual({
+      valid: false,
+      reason: "malformed-signature",
+    });
+  });
+
+  it("rejects when no signature header is present", () => {
+    expect(verifyWebhookSignature(body, null, NOW_MS).reason).toBe("missing-signature");
+  });
+
+  it("rejects in live mode when no secret is configured", () => {
+    delete process.env.KEEPKEY_DROPSHIP_WEBHOOK_SECRET;
+    expect(verifyWebhookSignature(body, sign(body, NOW_S), NOW_MS)).toEqual({
+      valid: false,
+      reason: "no-secret-configured",
+    });
+  });
+
+  it("allows (unverified) in sandbox mode when no secret is configured", () => {
+    delete process.env.KEEPKEY_DROPSHIP_WEBHOOK_SECRET;
+    process.env.KEEPKEY_DROPSHIP_MODE = "test";
+    expect(verifyWebhookSignature(body, null, NOW_MS)).toEqual({
+      valid: true,
+      reason: "unverified-sandbox-no-secret",
+    });
+  });
+});
+
+describe("getDropshipOrderByExternalId", () => {
+  beforeEach(() => {
+    process.env.KEEPKEY_DROPSHIP_MODE = "test";
+    process.env.KEEPKEY_DROPSHIP_TEST_TOKEN = "kk_ds_test_x";
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.KEEPKEY_DROPSHIP_TEST_TOKEN;
+    delete process.env.KEEPKEY_DROPSHIP_MODE;
+  });
+
+  function mockFetch(json: unknown) {
+    return vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify(json), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+  }
+
+  it("unwraps a single-record response and encodes the query", async () => {
+    const record = { keepKeyOrderId: "kk_1", externalOrderId: "gnars-1001", status: "shipped" };
+    const spy = mockFetch(record);
+    const out = await getDropshipOrderByExternalId("gnars 1001");
+    expect(out).toEqual(record);
+    expect(spy.mock.calls[0][0]).toContain("/orders?externalOrderId=gnars%201001");
+  });
+
+  it("unwraps an { orders: [...] } collection response", async () => {
+    const record = { keepKeyOrderId: "kk_2", externalOrderId: "gnars-1002", status: "received" };
+    mockFetch({ orders: [record] });
+    expect(await getDropshipOrderByExternalId("gnars-1002")).toEqual(record);
+  });
+
+  it("returns null for an empty collection response", async () => {
+    mockFetch({ orders: [] });
+    expect(await getDropshipOrderByExternalId("gnars-none")).toBeNull();
+  });
+});

--- a/src/services/keepkey-dropship.ts
+++ b/src/services/keepkey-dropship.ts
@@ -112,17 +112,43 @@ export function getDropshipOrder(keepKeyOrderId: string): Promise<DropshipOrderR
 }
 
 /**
- * Verify an inbound webhook's `X-KeepKey-Signature` (HMAC-SHA256 over the raw body,
- * keyed by KEEPKEY_DROPSHIP_WEBHOOK_SECRET). KeepKey signs with a timestamp, so we
- * accept the Stripe-style `t=<ts>,v1=<hex>` header and a bare `<hex>` fallback.
+ * Look up an order by our own `externalOrderId` (the idempotency key we set on creation).
  *
- * TODO(keepkey-webhook): confirm the exact signed-payload string against the docs'
- * Webhooks section (whether it's `${t}.${rawBody}` or just `rawBody`) and drop the
- * fallback once verified end-to-end with a real event.
+ * This is the ONLY way to learn a live order's shipment status today: per the 2026-07-15
+ * go-live handoff, KeepKey's `order.shipped` webhook does not fire yet, so callers poll
+ * this a few times a day and read `status` / `trackingNumber` / `trackingUrl` / `carrier`.
+ * The live response also carries the order's `settlement` block, so a lost create-order
+ * response is recoverable here. Returns null when no order matches that id.
+ */
+export async function getDropshipOrderByExternalId(
+  externalOrderId: string,
+): Promise<DropshipOrderRecord | null> {
+  const res = await request<DropshipOrderRecord | { orders: DropshipOrderRecord[] }>(
+    `/orders?externalOrderId=${encodeURIComponent(externalOrderId)}`,
+  );
+  // The filtered endpoint may return the record directly or wrapped as { orders: [...] }.
+  if (res && typeof res === "object" && "orders" in res) {
+    return res.orders[0] ?? null;
+  }
+  return (res as DropshipOrderRecord) ?? null;
+}
+
+/** Max clock skew tolerated on a webhook's signed timestamp before it's treated as a replay. */
+export const WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS = 5 * 60;
+
+/**
+ * Verify an inbound webhook's `X-KeepKey-Signature`. Per the go-live handoff, KeepKey signs
+ * Stripe-style: the header is `t=<unix>,v1=<hex>`, and `v1` is the HMAC-SHA256 of
+ * `${t}.${rawBody}` keyed by KEEPKEY_DROPSHIP_WEBHOOK_SECRET, computed over the **raw**
+ * request body. We also reject deliveries whose timestamp is older (or newer) than
+ * WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS to defeat replays.
+ *
+ * `nowMs` is injectable for tests; it defaults to the current time.
  */
 export function verifyWebhookSignature(
   rawBody: string,
   signatureHeader: string | null,
+  nowMs: number = Date.now(),
 ): { valid: boolean; reason: string } {
   const secret = process.env.KEEPKEY_DROPSHIP_WEBHOOK_SECRET;
   if (!secret) {
@@ -140,16 +166,17 @@ export function verifyWebhookSignature(
     }),
   );
   const ts = parts["t"];
-  const provided = parts["v1"] ?? (signatureHeader.includes("=") ? undefined : signatureHeader);
+  const provided = parts["v1"];
+  if (!ts || !provided) return { valid: false, reason: "malformed-signature" };
 
-  const candidates = ts ? [`${ts}.${rawBody}`, rawBody] : [rawBody];
-
-  for (const payload of candidates) {
-    const expected = createHmac("sha256", secret).update(payload).digest("hex");
-    if (provided && safeEqualHex(expected, provided)) {
-      return { valid: true, reason: "verified" };
-    }
+  const tsSeconds = Number(ts);
+  if (!Number.isFinite(tsSeconds)) return { valid: false, reason: "malformed-timestamp" };
+  if (Math.abs(nowMs / 1000 - tsSeconds) > WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS) {
+    return { valid: false, reason: "stale-timestamp" };
   }
+
+  const expected = createHmac("sha256", secret).update(`${ts}.${rawBody}`).digest("hex");
+  if (safeEqualHex(expected, provided)) return { valid: true, reason: "verified" };
   return { valid: false, reason: "signature-mismatch" };
 }
 

--- a/src/test/server-only-stub.ts
+++ b/src/test/server-only-stub.ts
@@ -1,0 +1,4 @@
+// Test stub for the `server-only` package. In production Next.js uses it to throw at build
+// time if a server module is imported into a client bundle; under vitest there is no bundle
+// boundary, so it's a no-op. Aliased in vitest.config.ts.
+export {};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,9 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      // `server-only` is a Next.js build-time guard with no runtime; stub it so server
+      // modules that import it can be unit-tested under the node environment.
+      "server-only": path.resolve(__dirname, "./src/test/server-only-stub.ts"),
     },
   },
 });


### PR DESCRIPTION
## Summary

- Align the KeepKey dropship integration with the live API contract from the 2026-07-15 go-live handoff so live orders can be tracked and settled.
- Poll-by-`externalOrderId` (KeepKey's `order.shipped` webhook doesn't fire yet, so this is the only way to learn a live order shipped).
- Harden webhook signature verification (confirmed Stripe-style HMAC + 5-min replay window).

## Changes

- `src/services/keepkey-dropship.ts` — `getDropshipOrderByExternalId()`; `verifyWebhookSignature()` now single Stripe-style scheme `HMAC("${t}.${rawBody}")` + rejects timestamps outside 5 min (`WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS`).
- `src/app/api/store/orders/route.ts` — new `GET /api/store/orders?externalOrderId=…`.
- `src/lib/schemas/dropship.ts` — `DropshipOrderRecord` carries `settlement` + `estimatedShippingDate`.
- `src/components/store/SandboxOrderTester.tsx` — polls the new route, shows tracking.
- `src/services/keepkey-dropship.test.ts` (+ `src/test/server-only-stub.ts`, vitest alias) — 12 tests.
- `docs/integrations/keepkey-fulfillment.md` — poll-only tracking, settlement, `account_suspended`, live-order checklist.

## Test plan

- [x] `pnpm test` — 102 passing (12 new)
- [x] `pnpm lint` + `prettier` clean
- [x] Verified end-to-end against the KeepKey sandbox: POST place → `GET ?externalOrderId=` poll round-trip
- [ ] After merge + redeploy, exercise the sandbox tester on `/store/keepkey-hardware-wallet`

Generated with [Claude Code](https://claude.com/claude-code)