### PR TITLE
feat(store): USDC-on-Base checkout for KeepKey wallet

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -23,7 +23,7 @@ This is the canonical entry point for project documentation. Everything below sh
 - `docs/features/feed.md` — live feed components and integration notes
 - `docs/features/coin-proposal.md` — coin proposal wizard
 - `docs/features/buy-coin-transaction.md` — proposal transaction type for buy-coin
-- `docs/features/store-checkout.md` — /store checkout & payment design (crypto-on-Base recommended) + build plan
+- `docs/features/store-checkout.md` — /store checkout (USDC on Base, built Phase 1, real payment gated to live) + build plan
 - `docs/features/blog-archive.md` — historical blog archive, IPFS image migration, and the Drive→IPFS curation pipeline proposal
 
 ## Integrations

--- a/docs/features/store-checkout.md
+++ b/docs/features/store-checkout.md
@@ -1,8 +1,11 @@
-# Store Checkout & Payment (design)
+# Store Checkout & Payment
 
-Status: **design / not built.** Fulfillment (KeepKey dropship) is live in sandbox; the
-missing piece is collecting money from the customer and triggering the order. This doc
-picks a payment approach and lays out the build.
+Status: **Phase 1 built (USDC on Base), sandbox-verified.** The customer-facing checkout
+exists at `/store/[slug]/checkout`: shipping form → payment → order → confirmation with
+polled status. Real payment is **gated to live mode** — in sandbox (`KEEPKEY_DROPSHIP_MODE=test`)
+the flow skips payment and places a free `KK-TEST-001` order so the whole UX is testable.
+Phase 2 (receipts, buyer order lookup) and Phase 3 (settlement automation, cards) are still
+open. This doc records the chosen approach and what's left.
 
 ## The flow we're completing
 
@@ -61,37 +64,74 @@ a working checkout on gnars.com fastest.
 
 ## Build plan
 
-**Phase 1 — MVP checkout (USDC → sandbox order)**
+**Phase 1 — MVP checkout (USDC → order) — BUILT**
 
-1. Checkout form on `/store/[slug]` (or `/store/checkout`): shipping address + email + finish.
-2. Pay: thirdweb `sendTransaction` — USDC transfer of the retail amount to a Gnars checkout
-   address (treasury or a dedicated wallet). Capture `txHash`.
-3. Server verifies the tx with viem (recipient, token = `USDC_BASE`, amount ≥ price, N
-   confirmations, not already used), then calls `createDropshipOrder`.
-4. Persist the order (Postgres): `{ txHash, externalOrderId, keepKeyOrderId, status, buyer,
-address, createdAt }`. Confirmation page shows `keepKeyOrderId` + polled status.
+1. ✅ Checkout page `/store/[slug]/checkout`: finish + email + shipping address.
+2. ✅ Pay: thirdweb `sendTransaction` — USDC transfer of the retail amount to the store
+   checkout wallet, via `useUsdcPayment()`. Captures `txHash`. Signs through
+   `useWriteAccount()` so it honors the EOA/SA view mode.
+3. ✅ Server verifies the tx with viem (`verifyUsdcPayment`: recipient, token = Base USDC,
+   amount ≥ price, ≥1 confirmation, tx succeeded), then calls `createDropshipOrder`.
+4. ✅ Confirmation shows `keepKeyOrderId` + status polled via
+   `GET /api/store/orders?externalOrderId=…` (tracking appears once KeepKey ships).
+5. ⬜ Order persistence (Postgres) — deferred; KeepKey is currently the source of truth and
+   the order is recoverable by `externalOrderId`.
 
 **Phase 2 — status + receipts**
 
-- Register the KeepKey webhook (push status) + email receipt/tracking to the buyer.
-- Buyer-facing order lookup (by email or wallet).
+- Email receipt/tracking to the buyer; buyer-facing order lookup (by email or wallet).
 
 **Phase 3 — settle + cards**
 
 - Automate/operate USDC → BTC settlement to KeepKey against the credit line.
 - Add card checkout via a MoR when a legal entity exists.
 
+## How it works (as built)
+
+```
+/store/[slug] ──Buy now──▶ /store/[slug]/checkout ──▶ POST /api/store/checkout
+                                                        │
+                          sandbox: no payment ──────────┤
+                          live: verify USDC tx ─────────┘──▶ createDropshipOrder → KeepKey
+```
+
+- **Mode gate** — `isSandbox()` decides everything. Sandbox: no payment, SKU forced to
+  `KK-TEST-001`, `externalOrderId` random. Live: `txHash` required and re-verified server-side,
+  real SKU, `externalOrderId = gnars-<txHash>`.
+- **Double-spend safety** — the live `externalOrderId` is derived from the payment tx hash, and
+  KeepKey dedupes on `externalOrderId`, so one payment can never place two orders.
+- **Eligibility** — only SKUs in `DROPSHIP_CATALOG_SKUS` (`src/lib/store/fulfillment.ts`) get a
+  checkout. The tees carry `keepkey` + `KK-TEE-*` SKUs but are print-on-demand elsewhere, so
+  they stay "coming soon" (enforced on the CTA, the page, and the API).
+- **Trust boundary** — the client only supplies a tx hash; amount/recipient/token are re-read
+  from chain. Never trust a client-reported payment.
+
+### Code map
+
+- `src/app/[locale]/store/[slug]/checkout/page.tsx` — checkout route.
+- `src/components/store/CheckoutFlow.tsx` — form, payment, confirmation + status polling.
+- `src/hooks/use-usdc-payment.ts` — USDC transfer on Base via thirdweb.
+- `src/app/api/store/checkout/route.ts` — payment gate → fulfillment order.
+- `src/services/store-payment.ts` — on-chain payment verification (+ `.test.ts`).
+- `src/lib/schemas/checkout.ts`, `src/lib/store/fulfillment.ts` (+ `.test.ts`).
+
+### Environment
+
+`NEXT_PUBLIC_STORE_CHECKOUT_ADDRESS` — dedicated store wallet that receives USDC. Leave unset
+in sandbox (payment skipped); **required before live** or checkout errors out.
+
 ## Open decisions for Vlad
 
-1. **Payment token/recipient** — USDC (recommended) to treasury, or a dedicated checkout wallet?
+1. ~~Payment token/recipient~~ — decided: **USDC on Base → dedicated checkout wallet**
+   (`NEXT_PUBLIC_STORE_CHECKOUT_ADDRESS`).
 2. **Who operates settlement** — manual BTC deposit to KeepKey per order, or batched/automated?
 3. **Refund policy** — crypto refunds are manual; define window + who signs.
-4. **Order storage** — reuse the existing Postgres (`pg`) or a KV store.
+4. **Order storage** — reuse the existing Postgres (`pg`) or a KV store (Phase 1 defers it).
 5. **Merchant-of-record / legal** — needed before any card path (option B).
 
-## What's already testable
+## What's testable now
 
-The fulfillment half is live in sandbox on gnars.com. Use the **sandbox order tester** on a
-`/store/[slug]` device page (rendered only while `KEEPKEY_DROPSHIP_MODE=test`) to place a
-`KK-TEST-001` order and watch its status — no payment, no shipment. See
-`src/components/store/SandboxOrderTester.tsx`.
+In sandbox, the full customer flow works free: `/store/keepkey-hardware-wallet` → **Buy now**
+→ fill the form → **Place test order** → confirmation with a live-polled status. Nothing is
+charged and nothing ships. The older `SandboxOrderTester` panel on the device page still
+places a raw `KK-TEST-001` order without the form.

--- a/docs/features/store-checkout.md
+++ b/docs/features/store-checkout.md
@@ -117,8 +117,9 @@ a working checkout on gnars.com fastest.
 
 ### Environment
 
-`NEXT_PUBLIC_STORE_CHECKOUT_ADDRESS` — dedicated store wallet that receives USDC. Leave unset
-in sandbox (payment skipped); **required before live** or checkout errors out.
+`NEXT_PUBLIC_STORE_CHECKOUT_ADDRESS` — dedicated store wallet that receives USDC. Defaults to
+the Gnars store wallet hardcoded in `src/lib/config.ts` (`STORE_CHECKOUT.recipient`); set the
+env var only to override per-deploy. Only used in live mode (sandbox skips payment).
 
 ## Open decisions for Vlad
 

--- a/docs/integrations/keepkey-fulfillment.md
+++ b/docs/integrations/keepkey-fulfillment.md
@@ -3,17 +3,19 @@
 Status: **implemented, sandbox-verified.** The server-side fulfillment layer (client +
 API routes + webhook) is built and tested end-to-end against the KeepKey sandbox. It
 runs in **test mode by default** (`KEEPKEY_DROPSHIP_MODE=test`) — no real orders, credit,
-or shipments until that flips to `live`. The customer-facing **checkout/payment step is
-still not built**, so nothing calls the live order path in production yet.
+or shipments until that flips to `live`. The customer-facing **checkout is now built**
+(USDC on Base, `/store/[slug]/checkout`, real payment gated to live mode) — see
+`docs/features/store-checkout.md`.
 
 Docs (partner, auth-gated): https://affiliates.keepkey.com/dropship/docs
 
 ## Target flow
 
-Instagram Shop / Meta catalog → Gnars product page (`/store/[slug]`) → **Gnars checkout
-(payment — TODO)** → `POST /api/store/orders` → KeepKey Dropship API → KeepKey ships,
-then POSTs status webhooks back. The customer relationship stays entirely under Gnars;
-KeepKey is the dropship fulfiller.
+Instagram Shop / Meta catalog → Gnars product page (`/store/[slug]`) → **Gnars checkout**
+(`/store/[slug]/checkout`, USDC on Base) → `POST /api/store/checkout` (verifies payment) →
+`createDropshipOrder` → KeepKey Dropship API → KeepKey ships, then POSTs status webhooks
+back. The customer relationship stays entirely under Gnars; KeepKey is the dropship
+fulfiller.
 
 ## Money flow (important)
 
@@ -37,8 +39,9 @@ drawn against a **$500 credit line**. Sandbox orders return `settlement: null`. 
   - `POST /api/store/keepkey-webhook` — signed status webhook.
 - Tests — `src/services/keepkey-dropship.test.ts` (signature verification + externalOrderId lookup).
 - Product model — `src/types/store.ts`; catalog `src/data/store.json` via `src/services/store.ts`.
-- Still TODO: `TODO(checkout)` (`ProductDetail.tsx`), `TODO(inventory)` (order persistence /
-  customer notification in the webhook).
+- Checkout — `/store/[slug]/checkout` + `POST /api/store/checkout` (payment gate). See
+  `docs/features/store-checkout.md`.
+- Still TODO: `TODO(inventory)` (order persistence / customer notification in the webhook).
 
 ## API (as built)
 
@@ -179,7 +182,8 @@ Set real values in Vercel env / `.env.local`; they are gitignored and never comm
 
 ## Going live (checklist)
 
-1. Build Gnars checkout + payment; only call `POST /api/store/orders` **after** payment settles.
+1. ✅ Checkout + payment built (`/store/[slug]/checkout` → `POST /api/store/checkout`, USDC
+   on Base). Set `NEXT_PUBLIC_STORE_CHECKOUT_ADDRESS` (the store wallet) before going live.
 2. Set `KEEPKEY_DROPSHIP_LIVE_TOKEN`, `KEEPKEY_DROPSHIP_WEBHOOK_SECRET`,
    `KEEPKEY_DROPSHIP_INTERNAL_SECRET` in Vercel; flip `KEEPKEY_DROPSHIP_MODE=live`. Order the
    real SKU `KK-HW-001` (not `KK-TEST-001`); pass the color finish in `notes`.

--- a/env.example
+++ b/env.example
@@ -107,5 +107,10 @@ KEEPKEY_DROPSHIP_BASE_URL=
 # Secret KeepKey signs webhooks with (HMAC-SHA256, X-KeepKey-Signature header)
 KEEPKEY_DROPSHIP_WEBHOOK_SECRET=
 # Shared secret gating LIVE order creation via POST /api/store/orders (x-gnars-internal
-# header) until a real payment/checkout gate exists. Not needed for sandbox.
+# header). The /api/store/checkout payment gate does not need it. Not needed for sandbox.
 KEEPKEY_DROPSHIP_INTERNAL_SECRET=
+
+# Dedicated store checkout wallet — customers pay USDC on Base here; the server verifies
+# the transfer before forwarding the order to KeepKey. Public (recipient address). Leave
+# unset in sandbox (payment is skipped); required before going live.
+NEXT_PUBLIC_STORE_CHECKOUT_ADDRESS=

--- a/env.example
+++ b/env.example
@@ -111,6 +111,6 @@ KEEPKEY_DROPSHIP_WEBHOOK_SECRET=
 KEEPKEY_DROPSHIP_INTERNAL_SECRET=
 
 # Dedicated store checkout wallet — customers pay USDC on Base here; the server verifies
-# the transfer before forwarding the order to KeepKey. Public (recipient address). Leave
-# unset in sandbox (payment is skipped); required before going live.
+# the transfer before forwarding the order to KeepKey. Public (recipient address). Defaults
+# to the Gnars store wallet hardcoded in src/lib/config.ts; set only to override per-deploy.
 NEXT_PUBLIC_STORE_CHECKOUT_ADDRESS=

--- a/messages/en/store.json
+++ b/messages/en/store.json
@@ -34,8 +34,60 @@
     "backToStore": "Back to store",
     "finish": "Finish",
     "checkoutComingSoon": "Checkout coming soon",
+    "buyNow": "Buy now",
     "viewOnBrand": "View on {brand}",
     "fulfilledBy": "Fulfilled and shipped by {brand}."
+  },
+  "checkout": {
+    "title": "Checkout",
+    "optional": "optional",
+    "sandboxNotice": "Sandbox mode — no payment is taken and nothing ships. This places a test order so you can try the full flow.",
+    "sandboxFootnote": "Test order only. Never charged, never shipped.",
+    "payFootnote": "You'll pay in USDC on Base. Fulfilled and shipped by KeepKey.",
+    "placeSandbox": "Place test order",
+    "connectToPay": "Connect wallet to pay",
+    "payAmount": "Pay {amount} in USDC",
+    "connectTitle": "Connect to pay",
+    "paid": "Payment confirmed",
+    "fields": {
+      "name": "Full name",
+      "email": "Email",
+      "line1": "Address",
+      "line2": "Apartment, suite, etc.",
+      "city": "City",
+      "state": "State / Province",
+      "postalCode": "Postal code",
+      "country": "Country (ISO code)"
+    },
+    "errors": {
+      "name": "Enter your name",
+      "email": "Enter a valid email",
+      "line1": "Enter your street address",
+      "city": "Enter your city",
+      "postalCode": "Enter your postal code",
+      "country": "Use a 2-letter country code (e.g. US)",
+      "state": "State is required for US addresses",
+      "notConfigured": "Checkout isn't available yet — the store wallet isn't configured.",
+      "generic": "Something went wrong. Please try again."
+    },
+    "status": {
+      "received": "Received",
+      "processing": "Processing",
+      "shipped": "Shipped",
+      "cancelled": "Cancelled",
+      "failed": "Failed"
+    },
+    "success": {
+      "title": "Order placed",
+      "subtitle": "Your {title} order is in. We'll update the status below.",
+      "orderId": "Order ID",
+      "status": "Status",
+      "tracking": "Tracking",
+      "sandboxNote": "Sandbox order — nothing ships. Status stays \"received\".",
+      "liveNote": "You'll get tracking here once KeepKey ships it.",
+      "refresh": "Refresh status",
+      "backToStore": "Back to store"
+    }
   },
   "notFound": {
     "title": "Product Not Found",

--- a/messages/pt-br/store.json
+++ b/messages/pt-br/store.json
@@ -34,8 +34,60 @@
     "backToStore": "Voltar à loja",
     "finish": "Acabamento",
     "checkoutComingSoon": "Finalização de compra em breve",
+    "buyNow": "Comprar agora",
     "viewOnBrand": "Ver na {brand}",
     "fulfilledBy": "Enviado pela {brand}."
+  },
+  "checkout": {
+    "title": "Finalizar compra",
+    "optional": "opcional",
+    "sandboxNotice": "Modo sandbox — nenhum pagamento é cobrado e nada é enviado. Isso cria um pedido de teste para você experimentar o fluxo completo.",
+    "sandboxFootnote": "Apenas pedido de teste. Nunca cobrado, nunca enviado.",
+    "payFootnote": "Você paga em USDC na Base. Enviado pela KeepKey.",
+    "placeSandbox": "Criar pedido de teste",
+    "connectToPay": "Conecte a carteira para pagar",
+    "payAmount": "Pagar {amount} em USDC",
+    "connectTitle": "Conectar para pagar",
+    "paid": "Pagamento confirmado",
+    "fields": {
+      "name": "Nome completo",
+      "email": "E-mail",
+      "line1": "Endereço",
+      "line2": "Apartamento, bloco, etc.",
+      "city": "Cidade",
+      "state": "Estado / Província",
+      "postalCode": "CEP",
+      "country": "País (código ISO)"
+    },
+    "errors": {
+      "name": "Informe seu nome",
+      "email": "Informe um e-mail válido",
+      "line1": "Informe seu endereço",
+      "city": "Informe sua cidade",
+      "postalCode": "Informe seu CEP",
+      "country": "Use um código de país de 2 letras (ex.: US)",
+      "state": "O estado é obrigatório para endereços nos EUA",
+      "notConfigured": "A finalização ainda não está disponível — a carteira da loja não está configurada.",
+      "generic": "Algo deu errado. Tente novamente."
+    },
+    "status": {
+      "received": "Recebido",
+      "processing": "Em processamento",
+      "shipped": "Enviado",
+      "cancelled": "Cancelado",
+      "failed": "Falhou"
+    },
+    "success": {
+      "title": "Pedido realizado",
+      "subtitle": "Seu pedido de {title} foi registrado. Vamos atualizar o status abaixo.",
+      "orderId": "ID do pedido",
+      "status": "Status",
+      "tracking": "Rastreamento",
+      "sandboxNote": "Pedido sandbox — nada é enviado. O status permanece \"recebido\".",
+      "liveNote": "O rastreamento aparecerá aqui assim que a KeepKey enviar.",
+      "refresh": "Atualizar status",
+      "backToStore": "Voltar à loja"
+    }
   },
   "notFound": {
     "title": "Produto não encontrado",

--- a/src/app/[locale]/store/[slug]/checkout/page.tsx
+++ b/src/app/[locale]/store/[slug]/checkout/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from "next";
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import { notFound } from "next/navigation";
+import { CheckoutFlow } from "@/components/store/CheckoutFlow";
+import { isDropshipFulfillable } from "@/lib/store/fulfillment";
+import { isSandbox } from "@/services/keepkey-dropship";
+import { getProductBySlug } from "@/services/store";
+
+export const dynamic = "force-dynamic";
+
+interface CheckoutPageProps {
+  params: Promise<{ slug: string; locale: string }>;
+}
+
+export async function generateMetadata({ params }: CheckoutPageProps): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "store" });
+  return { title: `${t("checkout.title")} | Gnars Store`, robots: { index: false, follow: false } };
+}
+
+export default async function CheckoutPage({ params }: CheckoutPageProps) {
+  const { slug, locale } = await params;
+  setRequestLocale(locale);
+
+  const product = await getProductBySlug(slug);
+  // Only SKUs in KeepKey's dropship catalog have a real checkout today (see fulfillment.ts).
+  if (!product || !isDropshipFulfillable(product.fulfillmentSku)) {
+    notFound();
+  }
+
+  const finishes = (product.variants ?? []).map((v) => ({
+    id: v.id,
+    title: v.title,
+    disabled: v.availability === "out_of_stock",
+  }));
+
+  return (
+    <div className="py-12">
+      <CheckoutFlow
+        slug={product.slug}
+        title={product.title}
+        price={product.price}
+        currency={product.currency}
+        finishes={finishes}
+        sandbox={isSandbox()}
+      />
+    </div>
+  );
+}

--- a/src/app/api/store/checkout/route.ts
+++ b/src/app/api/store/checkout/route.ts
@@ -1,0 +1,131 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { checkoutInputSchema, type CheckoutResult } from "@/lib/schemas/checkout";
+import { isDropshipFulfillable } from "@/lib/store/fulfillment";
+import {
+  createDropshipOrder,
+  DROPSHIP_SANDBOX_SKU,
+  DropshipApiError,
+  isDropshipConfigured,
+  isSandbox,
+} from "@/services/keepkey-dropship";
+import { getProductBySlug } from "@/services/store";
+import { verifyUsdcPayment } from "@/services/store-payment";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * Customer checkout: verify payment (live) then forward a fulfillment order to KeepKey.
+ *
+ * - **Sandbox** (`KEEPKEY_DROPSHIP_MODE=test`): no payment is collected. Places a
+ *   `KK-TEST-001` sandbox order so the full UX is testable for free. Never ships.
+ * - **Live**: requires `txHash` of a USDC-on-Base payment to the store checkout wallet,
+ *   re-verified server-side for ≥ the retail price. The order's `externalOrderId` is
+ *   derived from the tx hash, so a given payment can only ever place one order (KeepKey
+ *   dedupes on `externalOrderId`).
+ *
+ * This route IS the payment gate the raw `/api/store/orders` live path warns about, so it
+ * calls the fulfillment client directly once payment checks out.
+ */
+export async function POST(request: NextRequest) {
+  if (!isDropshipConfigured()) {
+    return NextResponse.json(
+      { error: { code: "not_configured", message: "Store fulfillment is not configured" } },
+      { status: 503 },
+    );
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = checkoutInputSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: { code: "invalid_request", message: "Invalid checkout payload" },
+        issues: parsed.error.issues,
+      },
+      { status: 400 },
+    );
+  }
+  const input = parsed.data;
+
+  const product = await getProductBySlug(input.slug);
+  if (!product) {
+    return NextResponse.json(
+      { error: { code: "not_found", message: "Product not found" } },
+      { status: 404 },
+    );
+  }
+  if (!isDropshipFulfillable(product.fulfillmentSku)) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "unsupported_product",
+          message: "This product isn't available for checkout yet",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const sandbox = isSandbox();
+  let externalOrderId: string;
+
+  if (sandbox) {
+    // No payment in sandbox — random id is fine since nothing is charged or shipped.
+    externalOrderId = `gnars-web-sandbox-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  } else {
+    if (!input.txHash) {
+      return NextResponse.json(
+        { error: { code: "payment_required", message: "A payment transaction hash is required" } },
+        { status: 402 },
+      );
+    }
+    const payment = await verifyUsdcPayment(input.txHash, product.price);
+    if (!payment.ok) {
+      const status = payment.code === "not_configured" ? 503 : 402;
+      return NextResponse.json(
+        { error: { code: payment.code, message: payment.message } },
+        { status },
+      );
+    }
+    // Deterministic id from the payment → same tx can never place two orders.
+    externalOrderId = `gnars-${input.txHash}`;
+  }
+
+  // KeepKey's dropship catalog only stocks the base wallet; color finishes are cosmetic and
+  // fulfill as the same SKU, with the finish passed along in notes.
+  const sku = sandbox ? DROPSHIP_SANDBOX_SKU : product.fulfillmentSku;
+  const notes = input.finish ? `Finish: ${input.finish}` : undefined;
+
+  try {
+    const result = await createDropshipOrder({
+      externalOrderId,
+      customerName: input.customerName,
+      customerEmail: input.customerEmail,
+      shippingAddress: input.shippingAddress,
+      lineItems: [{ sku, quantity: 1 }],
+      shippingMethod: "standard",
+      notes,
+    });
+
+    const payload: CheckoutResult = {
+      keepKeyOrderId: result.keepKeyOrderId,
+      externalOrderId,
+      status: result.status,
+      sandbox: result.sandbox,
+    };
+    return NextResponse.json(payload, { status: 201 });
+  } catch (error) {
+    if (error instanceof DropshipApiError) {
+      return NextResponse.json(
+        { error: { code: error.code, message: error.message } },
+        { status: error.httpStatus },
+      );
+    }
+    console.error("store checkout order failed:", error);
+    return NextResponse.json(
+      { error: { code: "server_error", message: "Failed to place order" } },
+      { status: 502 },
+    );
+  }
+}

--- a/src/components/store/CheckoutFlow.tsx
+++ b/src/components/store/CheckoutFlow.tsx
@@ -1,0 +1,417 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+import Link from "next/link";
+import { ArrowLeft, CheckCircle2, Loader2, Package } from "lucide-react";
+import { toast } from "sonner";
+import { useConnectModal } from "thirdweb/react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useUsdcPayment } from "@/hooks/use-usdc-payment";
+import { useUserAddress } from "@/hooks/use-user-address";
+import { STORE_CHECKOUT } from "@/lib/config";
+import { getThirdwebClient } from "@/lib/thirdweb";
+import { THIRDWEB_AA_CONFIG, THIRDWEB_WALLETS } from "@/lib/thirdweb-wallets";
+import type { Currency } from "@/types/store";
+import { formatPrice } from "./shared";
+
+interface Finish {
+  id: string;
+  title: string;
+  disabled: boolean;
+}
+
+interface CheckoutFlowProps {
+  slug: string;
+  title: string;
+  price: number;
+  currency: Currency;
+  finishes: Finish[];
+  defaultFinish?: string;
+  /** True when KEEPKEY_DROPSHIP_MODE=test — payment is skipped, order never ships. */
+  sandbox: boolean;
+}
+
+interface OrderResult {
+  keepKeyOrderId: string;
+  externalOrderId: string;
+  status: string;
+  trackingNumber?: string | null;
+  trackingUrl?: string | null;
+  carrier?: string | null;
+}
+
+const TERMINAL = new Set(["shipped", "cancelled", "failed"]);
+
+const EMPTY_FORM = {
+  customerName: "",
+  customerEmail: "",
+  line1: "",
+  line2: "",
+  city: "",
+  state: "",
+  postalCode: "",
+  country: "US",
+};
+
+export function CheckoutFlow({
+  slug,
+  title,
+  price,
+  currency,
+  finishes,
+  defaultFinish,
+  sandbox,
+}: CheckoutFlowProps) {
+  const t = useTranslations("store");
+  const { isConnected } = useUserAddress();
+  const { connect: openConnectModal } = useConnectModal();
+  const { pay, isPaying } = useUsdcPayment();
+
+  const [form, setForm] = useState({ ...EMPTY_FORM });
+  const [finish, setFinish] = useState(
+    defaultFinish ?? finishes.find((f) => !f.disabled)?.title ?? "",
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const [order, setOrder] = useState<OrderResult | null>(null);
+
+  const set = (k: keyof typeof EMPTY_FORM, v: string) => setForm((p) => ({ ...p, [k]: v }));
+
+  const recipientConfigured = Boolean(STORE_CHECKOUT.recipient);
+
+  function validate(): string | null {
+    if (!form.customerName.trim()) return t("checkout.errors.name");
+    if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(form.customerEmail)) return t("checkout.errors.email");
+    if (!form.line1.trim()) return t("checkout.errors.line1");
+    if (!form.city.trim()) return t("checkout.errors.city");
+    if (!form.postalCode.trim()) return t("checkout.errors.postalCode");
+    if (form.country.trim().length !== 2) return t("checkout.errors.country");
+    if (form.country.toUpperCase() === "US" && !form.state.trim())
+      return t("checkout.errors.state");
+    return null;
+  }
+
+  async function placeOrder(txHash?: string) {
+    const res = await fetch("/api/store/checkout", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        slug,
+        finish,
+        customerName: form.customerName.trim(),
+        customerEmail: form.customerEmail.trim(),
+        shippingAddress: {
+          line1: form.line1.trim(),
+          line2: form.line2.trim(),
+          city: form.city.trim(),
+          state: form.state.trim(),
+          postalCode: form.postalCode.trim(),
+          country: form.country.trim().toUpperCase(),
+        },
+        ...(txHash ? { txHash } : {}),
+      }),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data?.error?.message || `HTTP ${res.status}`);
+    setOrder({
+      keepKeyOrderId: data.keepKeyOrderId,
+      externalOrderId: data.externalOrderId,
+      status: data.status,
+    });
+  }
+
+  async function onSubmit() {
+    const err = validate();
+    if (err) {
+      toast.error(err);
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      if (sandbox) {
+        await placeOrder();
+        return;
+      }
+
+      // Live: require a configured wallet + an on-chain USDC payment first.
+      if (!recipientConfigured) {
+        toast.error(t("checkout.errors.notConfigured"));
+        return;
+      }
+      if (!isConnected) {
+        const client = getThirdwebClient();
+        if (client) {
+          await openConnectModal({
+            client,
+            wallets: THIRDWEB_WALLETS,
+            accountAbstraction: THIRDWEB_AA_CONFIG,
+            size: "compact",
+            title: t("checkout.connectTitle"),
+          });
+        }
+        return;
+      }
+      const txHash = await pay({
+        to: STORE_CHECKOUT.recipient as `0x${string}`,
+        amountUsd: price,
+      });
+      toast.success(t("checkout.paid"));
+      await placeOrder(txHash);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : t("checkout.errors.generic"));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (order) {
+    return <OrderConfirmation order={order} title={title} sandbox={sandbox} />;
+  }
+
+  const busy = submitting || isPaying;
+  const payLabel = sandbox
+    ? t("checkout.placeSandbox")
+    : !isConnected
+      ? t("checkout.connectToPay")
+      : t("checkout.payAmount", { amount: formatPrice(price, currency) });
+
+  return (
+    <div className="mx-auto max-w-lg">
+      <Link
+        href={`/store/${slug}`}
+        className="mb-6 inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="h-4 w-4" /> {t("detail.backToStore")}
+      </Link>
+
+      <h1 className="text-2xl font-bold">{t("checkout.title")}</h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        {title} —{" "}
+        <span className="font-medium text-foreground">{formatPrice(price, currency)}</span>
+      </p>
+
+      {sandbox && (
+        <div className="mt-4 rounded-lg border border-dashed border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+          {t("checkout.sandboxNotice")}
+        </div>
+      )}
+
+      <div className="mt-6 space-y-4">
+        {finishes.length > 1 && (
+          <Field label={t("detail.finish")}>
+            <Select value={finish} onValueChange={setFinish}>
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {finishes.map((f) => (
+                  <SelectItem key={f.id} value={f.title} disabled={f.disabled}>
+                    {f.title}
+                    {f.disabled ? ` (${t("card.outOfStock")})` : ""}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Field>
+        )}
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <Field label={t("checkout.fields.name")}>
+            <Input
+              value={form.customerName}
+              onChange={(e) => set("customerName", e.target.value)}
+            />
+          </Field>
+          <Field label={t("checkout.fields.email")}>
+            <Input
+              type="email"
+              value={form.customerEmail}
+              onChange={(e) => set("customerEmail", e.target.value)}
+            />
+          </Field>
+        </div>
+
+        <Field label={t("checkout.fields.line1")}>
+          <Input value={form.line1} onChange={(e) => set("line1", e.target.value)} />
+        </Field>
+        <Field label={t("checkout.fields.line2")} optional>
+          <Input value={form.line2} onChange={(e) => set("line2", e.target.value)} />
+        </Field>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <Field label={t("checkout.fields.city")}>
+            <Input value={form.city} onChange={(e) => set("city", e.target.value)} />
+          </Field>
+          <Field label={t("checkout.fields.state")}>
+            <Input value={form.state} onChange={(e) => set("state", e.target.value)} />
+          </Field>
+          <Field label={t("checkout.fields.postalCode")}>
+            <Input value={form.postalCode} onChange={(e) => set("postalCode", e.target.value)} />
+          </Field>
+        </div>
+
+        <Field label={t("checkout.fields.country")}>
+          <Input
+            value={form.country}
+            maxLength={2}
+            onChange={(e) => set("country", e.target.value.toUpperCase())}
+            className="w-24"
+          />
+        </Field>
+      </div>
+
+      <Button size="lg" className="mt-6 w-full" onClick={onSubmit} disabled={busy}>
+        {busy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+        {payLabel}
+      </Button>
+
+      <p className="mt-3 text-center text-xs text-muted-foreground">
+        {sandbox ? t("checkout.sandboxFootnote") : t("checkout.payFootnote")}
+      </p>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  optional,
+  children,
+}: {
+  label: string;
+  optional?: boolean;
+  children: React.ReactNode;
+}) {
+  const t = useTranslations("store");
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-xs text-muted-foreground">
+        {label}
+        {optional ? ` (${t("checkout.optional")})` : ""}
+      </Label>
+      {children}
+    </div>
+  );
+}
+
+function OrderConfirmation({
+  order,
+  title,
+  sandbox,
+}: {
+  order: OrderResult;
+  title: string;
+  sandbox: boolean;
+}) {
+  const t = useTranslations("store");
+  const [current, setCurrent] = useState(order);
+  const timer = useRef<ReturnType<typeof setInterval>>(undefined);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `/api/store/orders?externalOrderId=${encodeURIComponent(order.externalOrderId)}`,
+      );
+      if (!res.ok) return;
+      const data = await res.json();
+      setCurrent({
+        keepKeyOrderId: data.keepKeyOrderId,
+        externalOrderId: data.externalOrderId,
+        status: data.status,
+        trackingNumber: data.trackingNumber,
+        trackingUrl: data.trackingUrl,
+        carrier: data.carrier,
+      });
+    } catch {
+      // transient — next tick retries
+    }
+  }, [order.externalOrderId]);
+
+  useEffect(() => {
+    if (TERMINAL.has(current.status)) return;
+    timer.current = setInterval(refresh, 12_000);
+    return () => clearInterval(timer.current);
+  }, [current.status, refresh]);
+
+  return (
+    <div className="mx-auto max-w-lg text-center">
+      <CheckCircle2 className="mx-auto h-12 w-12 text-green-500" />
+      <h1 className="mt-4 text-2xl font-bold">{t("checkout.success.title")}</h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        {t("checkout.success.subtitle", { title })}
+      </p>
+
+      <div className="mt-6 rounded-xl border border-border p-4 text-left">
+        <Row label={t("checkout.success.orderId")} value={current.keepKeyOrderId} mono />
+        <Row
+          label={t("checkout.success.status")}
+          value={
+            t.has(`checkout.status.${current.status}`)
+              ? t(`checkout.status.${current.status}`)
+              : current.status
+          }
+        />
+        {current.trackingNumber && (
+          <Row
+            label={current.carrier ?? t("checkout.success.tracking")}
+            value={current.trackingNumber}
+            href={current.trackingUrl ?? undefined}
+          />
+        )}
+      </div>
+
+      <p className="mt-4 flex items-center justify-center gap-1.5 text-xs text-muted-foreground">
+        <Package className="h-3.5 w-3.5" />
+        {sandbox ? t("checkout.success.sandboxNote") : t("checkout.success.liveNote")}
+      </p>
+
+      <div className="mt-6 flex justify-center gap-2">
+        <Button variant="outline" size="sm" onClick={refresh}>
+          {t("checkout.success.refresh")}
+        </Button>
+        <Button asChild size="sm">
+          <Link href="/store">{t("checkout.success.backToStore")}</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function Row({
+  label,
+  value,
+  mono,
+  href,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+  href?: string;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-b border-border/60 py-2 last:border-0">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      {href ? (
+        <a
+          href={href}
+          target="_blank"
+          rel="noreferrer"
+          className={`text-sm text-primary underline ${mono ? "font-mono" : ""}`}
+        >
+          {value}
+        </a>
+      ) : (
+        <span className={`text-sm ${mono ? "font-mono" : ""}`}>{value}</span>
+      )}
+    </div>
+  );
+}

--- a/src/components/store/ProductDetail.tsx
+++ b/src/components/store/ProductDetail.tsx
@@ -7,6 +7,7 @@ import { ArrowLeft, ExternalLink } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Link } from "@/i18n/navigation";
+import { isDropshipFulfillable } from "@/lib/store/fulfillment";
 import { cn } from "@/lib/utils";
 import type { Availability, Product, ProductVariant } from "@/types/store";
 import { ProductVisual } from "./ProductVisual";
@@ -25,20 +26,24 @@ function BackLink({ label }: { label: string }) {
   );
 }
 
-/** Purchase CTA + fulfillment note, shared by both layouts. Checkout is not built yet. */
+/** Purchase CTA + fulfillment note, shared by both layouts. */
 function PurchaseActions({ product, soldOut }: { product: Product; soldOut: boolean }) {
   const t = useTranslations("store");
+  // Only SKUs actually in KeepKey's dropship catalog can be ordered. The tees are marked
+  // `keepkey` but are print-on-demand elsewhere, so they stay "coming soon".
+  const canCheckout = isDropshipFulfillable(product.fulfillmentSku);
   return (
     <>
-      {/*
-        TODO(checkout): wire the primary CTA to a real checkout flow.
-        Flow: Gnars checkout → fulfillment provider API (e.g. KeepKey) → provider ships.
-        See docs/integrations/keepkey-fulfillment.md. Disabled until payment exists.
-      */}
       <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-        <Button size="lg" disabled>
-          {soldOut ? t("card.outOfStock") : t("detail.checkoutComingSoon")}
-        </Button>
+        {canCheckout && !soldOut ? (
+          <Button asChild size="lg">
+            <Link href={`/store/${product.slug}/checkout`}>{t("detail.buyNow")}</Link>
+          </Button>
+        ) : (
+          <Button size="lg" disabled>
+            {soldOut ? t("card.outOfStock") : t("detail.checkoutComingSoon")}
+          </Button>
+        )}
         {product.externalProductUrl && (
           <Button asChild size="lg" variant="outline">
             <a href={product.externalProductUrl} target="_blank" rel="noopener noreferrer">

--- a/src/hooks/use-usdc-payment.ts
+++ b/src/hooks/use-usdc-payment.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { getContract, prepareContractCall, sendTransaction, waitForReceipt } from "thirdweb";
+import { base } from "thirdweb/chains";
+import { parseUnits, type Address, type Hex } from "viem";
+import { useWriteAccount } from "@/hooks/use-write-account";
+import { STORE_CHECKOUT } from "@/lib/config";
+import { getThirdwebClient } from "@/lib/thirdweb";
+import { ensureOnChain } from "@/lib/thirdweb-tx";
+
+/**
+ * Pay a fixed USDC amount on Base to a recipient and wait for the receipt.
+ *
+ * Used by the /store checkout to collect the retail price before an order is forwarded to
+ * KeepKey. Signs via `useWriteAccount()` so it respects the user's EOA/SA view mode, like
+ * every other write in the app. Returns the confirmed tx hash for server-side verification.
+ */
+export function useUsdcPayment() {
+  const writer = useWriteAccount();
+  const [isPaying, setIsPaying] = useState(false);
+
+  const pay = useCallback(
+    async ({ to, amountUsd }: { to: Address; amountUsd: number }): Promise<Hex> => {
+      const client = getThirdwebClient();
+      if (!client) throw new Error("Wallet client not configured");
+      if (!writer) throw new Error("Connect your wallet first");
+
+      setIsPaying(true);
+      try {
+        await ensureOnChain(writer.wallet, base);
+
+        const usdc = getContract({ client, chain: base, address: STORE_CHECKOUT.usdc });
+        const tx = prepareContractCall({
+          contract: usdc,
+          method: "function transfer(address to, uint256 amount) returns (bool)",
+          params: [to, parseUnits(amountUsd.toString(), STORE_CHECKOUT.usdcDecimals)],
+        });
+
+        const { transactionHash } = await sendTransaction({
+          account: writer.account,
+          transaction: tx,
+        });
+        await waitForReceipt({ client, chain: base, transactionHash });
+        return transactionHash as Hex;
+      } finally {
+        setIsPaying(false);
+      }
+    },
+    [writer],
+  );
+
+  return { pay, isPaying, canPay: Boolean(writer) };
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -98,15 +98,17 @@ export const TREASURY_TOKEN_ALLOWLIST = {
 export const TREASURY_TOKEN_ADDRESSES = Object.values(TREASURY_TOKEN_ALLOWLIST);
 
 /**
- * /store checkout config. Customers pay USDC on Base to `CHECKOUT_RECIPIENT`; the server
- * verifies that transfer before forwarding the order to the fulfillment provider (KeepKey).
- * `CHECKOUT_RECIPIENT` is a dedicated store wallet set via env — leave unset until going
- * live (sandbox orders skip payment). USDC on Base has 6 decimals.
+ * /store checkout config. Customers pay USDC on Base to `recipient`; the server verifies that
+ * transfer before forwarding the order to the fulfillment provider (KeepKey). `recipient` is
+ * the dedicated Gnars store wallet — hardcoded here (public address, safe to commit) with an
+ * env override for other deploys. Secrets (KeepKey tokens/webhook) stay in env. USDC on Base
+ * has 6 decimals. Sandbox orders skip payment, so this is only used in live mode.
  */
 export const STORE_CHECKOUT = {
   usdc: TREASURY_TOKEN_ALLOWLIST.USDC as `0x${string}`,
   usdcDecimals: 6,
-  recipient: (process.env.NEXT_PUBLIC_STORE_CHECKOUT_ADDRESS || "") as `0x${string}` | "",
+  recipient: (process.env.NEXT_PUBLIC_STORE_CHECKOUT_ADDRESS ||
+    "0x8Bf5941d27176242745B716251943Ae4892a3C26") as `0x${string}`,
 } as const;
 
 export const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://www.gnars.com";

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -97,4 +97,16 @@ export const TREASURY_TOKEN_ALLOWLIST = {
 
 export const TREASURY_TOKEN_ADDRESSES = Object.values(TREASURY_TOKEN_ALLOWLIST);
 
+/**
+ * /store checkout config. Customers pay USDC on Base to `CHECKOUT_RECIPIENT`; the server
+ * verifies that transfer before forwarding the order to the fulfillment provider (KeepKey).
+ * `CHECKOUT_RECIPIENT` is a dedicated store wallet set via env — leave unset until going
+ * live (sandbox orders skip payment). USDC on Base has 6 decimals.
+ */
+export const STORE_CHECKOUT = {
+  usdc: TREASURY_TOKEN_ALLOWLIST.USDC as `0x${string}`,
+  usdcDecimals: 6,
+  recipient: (process.env.NEXT_PUBLIC_STORE_CHECKOUT_ADDRESS || "") as `0x${string}` | "",
+} as const;
+
 export const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://www.gnars.com";

--- a/src/lib/schemas/checkout.ts
+++ b/src/lib/schemas/checkout.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+import { shippingAddressSchema } from "@/lib/schemas/dropship";
+
+/**
+ * Storefront checkout payload — the customer-facing side of the /store flow.
+ *
+ * The client collects contact + shipping details and (in live mode) pays USDC on Base,
+ * then POSTs this to `/api/store/checkout`. The server re-verifies the on-chain payment
+ * before forwarding a fulfillment order to KeepKey. See docs/features/store-checkout.md.
+ */
+export const checkoutInputSchema = z.object({
+  /** Product slug from the catalog (src/data/store.json). */
+  slug: z.string().min(1),
+  /** Selected finish/variant title (cosmetic; passed to KeepKey in `notes`). */
+  finish: z.string().optional().default(""),
+  customerName: z.string().min(1, "Name is required"),
+  customerEmail: z.string().email("Enter a valid email"),
+  shippingAddress: shippingAddressSchema,
+  /**
+   * Base tx hash of the customer's USDC payment. Required in live mode (the server
+   * verifies it); ignored in sandbox mode, where no payment is collected.
+   */
+  txHash: z
+    .string()
+    .regex(/^0x[0-9a-fA-F]{64}$/, "Invalid transaction hash")
+    .optional(),
+});
+
+export type CheckoutInput = z.infer<typeof checkoutInputSchema>;
+
+export interface CheckoutResult {
+  keepKeyOrderId: string;
+  externalOrderId: string;
+  status: string;
+  sandbox: boolean;
+}

--- a/src/lib/store/fulfillment.test.ts
+++ b/src/lib/store/fulfillment.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import storeCatalog from "@/data/store.json";
+import type { Product } from "@/types/store";
+import { isDropshipFulfillable } from "./fulfillment";
+
+describe("isDropshipFulfillable", () => {
+  it("accepts the hardware wallet SKU", () => {
+    expect(isDropshipFulfillable("KK-HW-001")).toBe(true);
+  });
+
+  it("rejects the tee SKUs — they carry a keepkey provider but aren't in the dropship catalog", () => {
+    expect(isDropshipFulfillable("KK-TEE-LASER")).toBe(false);
+    expect(isDropshipFulfillable("KK-TEE-ETHDEN")).toBe(false);
+  });
+
+  it("rejects the sandbox SKU (never checkout-eligible; the server substitutes it)", () => {
+    expect(isDropshipFulfillable("KK-TEST-001")).toBe(false);
+  });
+
+  it("rejects missing/empty SKUs", () => {
+    expect(isDropshipFulfillable(undefined)).toBe(false);
+    expect(isDropshipFulfillable(null)).toBe(false);
+    expect(isDropshipFulfillable("")).toBe(false);
+  });
+
+  it("marks exactly one product in the live catalog as checkout-eligible", () => {
+    const products = (storeCatalog.products ?? []) as Product[];
+    const eligible = products.filter((p) => isDropshipFulfillable(p.fulfillmentSku));
+    expect(eligible.map((p) => p.slug)).toEqual(["keepkey-hardware-wallet"]);
+  });
+});

--- a/src/lib/store/fulfillment.ts
+++ b/src/lib/store/fulfillment.ts
@@ -1,0 +1,16 @@
+/**
+ * Which store SKUs can actually be ordered through KeepKey's dropship API.
+ *
+ * Per docs/integrations/keepkey-fulfillment.md, KeepKey's dropship catalog only stocks the
+ * base hardware wallet (`KK-HW-001`); the color finishes are cosmetic and fulfill as that
+ * same SKU. The tees carry `KK-TEE-*` SKUs but are print-on-demand elsewhere — they are NOT
+ * dropship-fulfillable, so checkout must stay disabled for them until a fulfiller exists.
+ *
+ * Kept dependency-free (no `server-only`, no fetch) so both the client CTA and the server
+ * checkout route can share one source of truth. Extend the list when KeepKey adds SKUs.
+ */
+export const DROPSHIP_CATALOG_SKUS = ["KK-HW-001"] as const;
+
+export function isDropshipFulfillable(sku?: string | null): boolean {
+  return Boolean(sku && (DROPSHIP_CATALOG_SKUS as readonly string[]).includes(sku));
+}

--- a/src/services/store-payment.test.ts
+++ b/src/services/store-payment.test.ts
@@ -1,0 +1,114 @@
+import { encodeAbiParameters, parseUnits, type Hex } from "viem";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+// Imported after mocks are registered.
+import { verifyUsdcPayment } from "./store-payment";
+
+// Hoisted so the vi.mock factories (also hoisted) can reference them.
+const { RECIPIENT, OTHER, FROM, USDC, TRANSFER_TOPIC, getTransactionReceipt, getBlockNumber } =
+  vi.hoisted(() => ({
+    RECIPIENT: "0x1111111111111111111111111111111111111111",
+    OTHER: "0x2222222222222222222222222222222222222222",
+    FROM: "0x3333333333333333333333333333333333333333",
+    USDC: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913", // Base USDC (matches config)
+    TRANSFER_TOPIC: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+    getTransactionReceipt: vi.fn(),
+    getBlockNumber: vi.fn(),
+  }));
+
+vi.mock("@/lib/config", () => ({
+  STORE_CHECKOUT: { usdc: USDC, usdcDecimals: 6, recipient: RECIPIENT },
+}));
+
+vi.mock("@/lib/rpc", () => ({
+  serverPublicClient: { getTransactionReceipt, getBlockNumber },
+}));
+
+function addrTopic(addr: string): Hex {
+  return `0x${addr.slice(2).toLowerCase().padStart(64, "0")}` as Hex;
+}
+
+function transferLog(to: string, amountUsd: string, token = USDC) {
+  return {
+    address: token,
+    topics: [TRANSFER_TOPIC, addrTopic(FROM), addrTopic(to)],
+    data: encodeAbiParameters([{ type: "uint256" }], [parseUnits(amountUsd, 6)]),
+  };
+}
+
+const TX = "0x" + "a".repeat(64);
+
+describe("verifyUsdcPayment", () => {
+  beforeEach(() => {
+    getBlockNumber.mockResolvedValue(1000n);
+    getTransactionReceipt.mockReset();
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it("accepts an exact-amount USDC transfer to the checkout wallet", async () => {
+    getTransactionReceipt.mockResolvedValue({
+      status: "success",
+      blockNumber: 999n,
+      logs: [transferLog(RECIPIENT, "59.95")],
+    });
+    const res = await verifyUsdcPayment(TX, 59.95);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.amount).toBe(parseUnits("59.95", 6));
+  });
+
+  it("accepts an overpayment", async () => {
+    getTransactionReceipt.mockResolvedValue({
+      status: "success",
+      blockNumber: 999n,
+      logs: [transferLog(RECIPIENT, "60")],
+    });
+    expect((await verifyUsdcPayment(TX, 59.95)).ok).toBe(true);
+  });
+
+  it("rejects an underpayment", async () => {
+    getTransactionReceipt.mockResolvedValue({
+      status: "success",
+      blockNumber: 999n,
+      logs: [transferLog(RECIPIENT, "59.94")],
+    });
+    const res = await verifyUsdcPayment(TX, 59.95);
+    expect(res).toMatchObject({ ok: false, code: "no_matching_transfer" });
+  });
+
+  it("rejects a transfer to a different address", async () => {
+    getTransactionReceipt.mockResolvedValue({
+      status: "success",
+      blockNumber: 999n,
+      logs: [transferLog(OTHER, "59.95")],
+    });
+    expect((await verifyUsdcPayment(TX, 59.95)).ok).toBe(false);
+  });
+
+  it("rejects the right amount in the wrong token", async () => {
+    getTransactionReceipt.mockResolvedValue({
+      status: "success",
+      blockNumber: 999n,
+      logs: [transferLog(RECIPIENT, "59.95", OTHER)],
+    });
+    expect((await verifyUsdcPayment(TX, 59.95)).ok).toBe(false);
+  });
+
+  it("rejects a reverted transaction", async () => {
+    getTransactionReceipt.mockResolvedValue({ status: "reverted", blockNumber: 999n, logs: [] });
+    expect(await verifyUsdcPayment(TX, 59.95)).toMatchObject({ ok: false, code: "reverted" });
+  });
+
+  it("rejects a not-yet-mined transaction", async () => {
+    getTransactionReceipt.mockRejectedValue(new Error("not found"));
+    expect(await verifyUsdcPayment(TX, 59.95)).toMatchObject({ ok: false, code: "not_found" });
+  });
+
+  it("rejects when not enough confirmations", async () => {
+    getBlockNumber.mockResolvedValue(999n);
+    getTransactionReceipt.mockResolvedValue({
+      status: "success",
+      blockNumber: 1000n, // ahead of head → 0 confirmations
+      logs: [transferLog(RECIPIENT, "59.95")],
+    });
+    expect(await verifyUsdcPayment(TX, 59.95)).toMatchObject({ ok: false, code: "not_confirmed" });
+  });
+});

--- a/src/services/store-payment.ts
+++ b/src/services/store-payment.ts
@@ -1,0 +1,101 @@
+import "server-only";
+import { getAddress, parseEventLogs, parseUnits, type Address, type Hex } from "viem";
+import { STORE_CHECKOUT } from "@/lib/config";
+import { serverPublicClient } from "@/lib/rpc";
+
+/**
+ * Verify a customer's on-chain USDC payment for a /store order.
+ *
+ * Trust nothing from the client except the tx hash: we re-read the receipt on Base and
+ * confirm an actual USDC `Transfer` to our checkout wallet for at least the retail amount.
+ * The caller derives the order's idempotency key from the tx hash, so the same payment can
+ * never place two orders. See docs/features/store-checkout.md.
+ *
+ * NEVER import into client code.
+ */
+
+const ERC20_TRANSFER_EVENT = [
+  {
+    type: "event",
+    name: "Transfer",
+    inputs: [
+      { name: "from", type: "address", indexed: true },
+      { name: "to", type: "address", indexed: true },
+      { name: "value", type: "uint256", indexed: false },
+    ],
+  },
+] as const;
+
+/** Confirmations required before we treat a payment as final (Base blocks are ~2s). */
+const MIN_CONFIRMATIONS = 1n;
+
+export type PaymentVerification =
+  | { ok: true; from: Address; amount: bigint; txHash: Hex }
+  | { ok: false; code: PaymentErrorCode; message: string };
+
+export type PaymentErrorCode =
+  | "not_configured"
+  | "not_found"
+  | "not_confirmed"
+  | "reverted"
+  | "no_matching_transfer";
+
+/**
+ * @param txHash        Base tx hash the customer says paid.
+ * @param amountUsd     Retail price in USD (e.g. 59.95); converted to 6-decimal USDC.
+ */
+export async function verifyUsdcPayment(
+  txHash: string,
+  amountUsd: number,
+): Promise<PaymentVerification> {
+  const recipient = STORE_CHECKOUT.recipient;
+  if (!recipient) {
+    return {
+      ok: false,
+      code: "not_configured",
+      message: "Store checkout wallet (NEXT_PUBLIC_STORE_CHECKOUT_ADDRESS) is not set",
+    };
+  }
+
+  const hash = txHash as Hex;
+  const minAmount = parseUnits(amountUsd.toString(), STORE_CHECKOUT.usdcDecimals);
+
+  let receipt;
+  try {
+    receipt = await serverPublicClient.getTransactionReceipt({ hash });
+  } catch {
+    return { ok: false, code: "not_found", message: "Transaction not found or not yet mined" };
+  }
+
+  if (receipt.status !== "success") {
+    return { ok: false, code: "reverted", message: "Payment transaction reverted" };
+  }
+
+  const currentBlock = await serverPublicClient.getBlockNumber();
+  if (currentBlock - receipt.blockNumber + 1n < MIN_CONFIRMATIONS) {
+    return { ok: false, code: "not_confirmed", message: "Payment not yet confirmed" };
+  }
+
+  const wantRecipient = getAddress(recipient);
+  const transfers = parseEventLogs({
+    abi: ERC20_TRANSFER_EVENT,
+    eventName: "Transfer",
+    logs: receipt.logs,
+  }).filter(
+    (log) =>
+      getAddress(log.address) === getAddress(STORE_CHECKOUT.usdc) &&
+      getAddress(log.args.to) === wantRecipient &&
+      log.args.value >= minAmount,
+  );
+
+  const match = transfers[0];
+  if (!match) {
+    return {
+      ok: false,
+      code: "no_matching_transfer",
+      message: `No USDC transfer of ≥ $${amountUsd} to the checkout wallet in this tx`,
+    };
+  }
+
+  return { ok: true, from: getAddress(match.args.from), amount: match.args.value, txHash: hash };
+}


### PR DESCRIPTION
## Summary

- Builds the customer-facing **checkout** — the missing left side of the KeepKey flow, so a wallet can actually be purchased on gnars.com.
- Real payment (USDC on Base) is **gated to live mode**; in sandbox the flow skips payment and places a free `KK-TEST-001` order, so the full UX is testable now with no money.
- Recipient is a **dedicated store wallet** (`NEXT_PUBLIC_STORE_CHECKOUT_ADDRESS`), not the treasury.

## Flow

`/store/[slug]` → **Buy now** → `/store/[slug]/checkout` (form) → `POST /api/store/checkout` → (live: verify USDC tx) → `createDropshipOrder` → confirmation with status polled via `GET /api/store/orders?externalOrderId=…`.

## Changes

- `src/app/[locale]/store/[slug]/checkout/page.tsx` — checkout route.
- `src/components/store/CheckoutFlow.tsx` — form + payment + confirmation/status polling.
- `src/hooks/use-usdc-payment.ts` — USDC transfer on Base (thirdweb, honors EOA/SA view mode).
- `src/app/api/store/checkout/route.ts` — payment gate → fulfillment order.
- `src/services/store-payment.ts` — on-chain payment verification (+ tests).
- `src/lib/store/fulfillment.ts` — checkout eligibility (`KK-HW-001` only; tees stay "coming soon") (+ tests).
- `src/lib/schemas/checkout.ts`, `src/lib/config.ts` (`STORE_CHECKOUT`), CTA wiring in `ProductDetail.tsx`.
- i18n EN + PT-BR; `env.example`; docs (`store-checkout.md`, `keepkey-fulfillment.md`, `INDEX.md`).

## Security notes

- Client supplies only the tx hash; amount/recipient/token are re-read from chain (`verifyUsdcPayment`). No client-reported payment is trusted.
- Live `externalOrderId = gnars-<txHash>` + KeepKey dedup → one payment cannot place two orders.

## Test plan

- [x] `pnpm test` — 115 passing (13 new: payment verification + eligibility)
- [x] `pnpm lint` + `prettier` clean, no `tsc` src errors
- [x] Sandbox e2e: Buy now → form → order → poll (`received`)
- [x] Tee correctly rejected: API 400 `unsupported_product`, page 404, CTA disabled
- [ ] Before live: set `NEXT_PUBLIC_STORE_CHECKOUT_ADDRESS` + flip `KEEPKEY_DROPSHIP_MODE=live`, then do one real order

Generated with [Claude Code](https://claude.com/claude-code)