### PR TITLE
chore(store): centralize KeepKey dropship mode default in config

### DIFF
--- a/docs/integrations/keepkey-fulfillment.md
+++ b/docs/integrations/keepkey-fulfillment.md
@@ -169,14 +169,14 @@ Use the `kk_ds_test_…` token against the same base URL. Every write is flagged
 
 ## Environment (server-only — never `NEXT_PUBLIC_`)
 
-| Var                                | Purpose                                                  |
-| ---------------------------------- | -------------------------------------------------------- |
-| `KEEPKEY_DROPSHIP_MODE`            | `test` (default) or `live` — selects which token is used |
-| `KEEPKEY_DROPSHIP_TEST_TOKEN`      | sandbox bearer token                                     |
-| `KEEPKEY_DROPSHIP_LIVE_TOKEN`      | live bearer token                                        |
-| `KEEPKEY_DROPSHIP_BASE_URL`        | optional override (defaults to the base URL above)       |
-| `KEEPKEY_DROPSHIP_WEBHOOK_SECRET`  | HMAC secret for verifying webhooks                       |
-| `KEEPKEY_DROPSHIP_INTERNAL_SECRET` | gates live order creation until checkout exists          |
+| Var                                | Purpose                                                                                                                         |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `KEEPKEY_DROPSHIP_MODE`            | `test` (default) or `live` — selects which token is used; default lives in `config.ts` (`KEEPKEY_DROPSHIP_MODE`), env overrides |
+| `KEEPKEY_DROPSHIP_TEST_TOKEN`      | sandbox bearer token                                                                                                            |
+| `KEEPKEY_DROPSHIP_LIVE_TOKEN`      | live bearer token                                                                                                               |
+| `KEEPKEY_DROPSHIP_BASE_URL`        | optional override (defaults to the base URL above)                                                                              |
+| `KEEPKEY_DROPSHIP_WEBHOOK_SECRET`  | HMAC secret for verifying webhooks                                                                                              |
+| `KEEPKEY_DROPSHIP_INTERNAL_SECRET` | gates live order creation until checkout exists                                                                                 |
 
 Set real values in Vercel env / `.env.local`; they are gitignored and never committed.
 

--- a/env.example
+++ b/env.example
@@ -97,7 +97,8 @@ USDC_BASE=0x833589fCD6EDb6E08f4c7C32D4f71b54bdA02913
 # Vercel env / .env.local — do not commit them.
 # ===========================================
 
-# Which token the fulfillment client uses: "test" (sandbox) or "live"
+# Which token the fulfillment client uses: "test" (sandbox) or "live". Defaults to "test"
+# in src/lib/config.ts (KEEPKEY_DROPSHIP_MODE); set here only to override (e.g. live).
 KEEPKEY_DROPSHIP_MODE=test
 # Bearer tokens (kk_ds_live_… / kk_ds_test_…)
 KEEPKEY_DROPSHIP_LIVE_TOKEN=

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -111,4 +111,17 @@ export const STORE_CHECKOUT = {
     "0x8Bf5941d27176242745B716251943Ae4892a3C26") as `0x${string}`,
 } as const;
 
+/**
+ * KeepKey dropship fulfillment mode. `test` (sandbox) draws no credit and never ships;
+ * `live` places real orders that draw the credit line and owe crypto settlement.
+ *
+ * Default stays `test` on purpose — going live is a deliberate act, never a side effect of
+ * a deploy. The env var (`KEEPKEY_DROPSHIP_MODE`, NOT `NEXT_PUBLIC_`) overrides it in Vercel.
+ * Read only server-side via `isSandbox()` — do not branch on this in client code (the env
+ * value is not exposed to the browser, so it would always read `test` there).
+ */
+export const KEEPKEY_DROPSHIP_MODE = (process.env.KEEPKEY_DROPSHIP_MODE || "test") as
+  | "test"
+  | "live";
+
 export const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://www.gnars.com";

--- a/src/services/keepkey-dropship.ts
+++ b/src/services/keepkey-dropship.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { createHmac, timingSafeEqual } from "node:crypto";
+import { KEEPKEY_DROPSHIP_MODE } from "@/lib/config";
 import {
   dropshipOrderInputSchema,
   type DropshipOrderInput,
@@ -23,7 +24,9 @@ const DEFAULT_BASE_URL = "https://affiliates.keepkey.com/api/dropship/v1";
 export const DROPSHIP_SANDBOX_SKU = "KK-TEST-001";
 
 export function isSandbox(): boolean {
-  return (process.env.KEEPKEY_DROPSHIP_MODE ?? "test") !== "live";
+  // Env wins at call-time (so Vercel can flip live/test without a redeploy, and tests can
+  // override per-case); the config const supplies the default when the env var is unset.
+  return (process.env.KEEPKEY_DROPSHIP_MODE || KEEPKEY_DROPSHIP_MODE) !== "live";
 }
 
 function baseUrl(): string {


### PR DESCRIPTION
## Summary

- Follow-up to putting the store checkout wallet in config: `KEEPKEY_DROPSHIP_MODE` now has its default in `src/lib/config.ts`, mirroring `STORE_CHECKOUT.recipient`.
- `isSandbox()` still reads the env var at call-time (so Vercel can flip live/test without a redeploy), with the config const as the fallback default.
- **Default stays `test` deliberately** — going live is an env flip, never a side effect of a deploy.

## Changes

- `src/lib/config.ts` — new `KEEPKEY_DROPSHIP_MODE` const (env override → `"test"` default).
- `src/services/keepkey-dropship.ts` — `isSandbox()` uses env ?? config default.
- `env.example`, `docs/integrations/keepkey-fulfillment.md` — note the config default.

## Test plan

- [x] `pnpm test` — 115 passing (mode-dependent webhook tests still flip via env)
- [x] Sanity: no env → `test`; `KEEPKEY_DROPSHIP_MODE=live` → `live`
- [x] `pnpm lint` + `tsc` clean

Generated with [Claude Code](https://claude.com/claude-code)