### PR TITLE
chore(store): make dropship mode config-only (drop env read)

### DIFF
--- a/docs/integrations/keepkey-fulfillment.md
+++ b/docs/integrations/keepkey-fulfillment.md
@@ -2,8 +2,8 @@
 
 Status: **implemented, sandbox-verified.** The server-side fulfillment layer (client +
 API routes + webhook) is built and tested end-to-end against the KeepKey sandbox. It
-runs in **test mode by default** (`KEEPKEY_DROPSHIP_MODE=test`) — no real orders, credit,
-or shipments until that flips to `live`. The customer-facing **checkout is now built**
+runs in **test mode by default** (`KEEPKEY_DROPSHIP_MODE` in `src/lib/config.ts`) — no real
+orders, credit, or shipments until that flips to `live`. The customer-facing **checkout is now built**
 (USDC on Base, `/store/[slug]/checkout`, real payment gated to live mode) — see
 `docs/features/store-checkout.md`.
 
@@ -169,24 +169,28 @@ Use the `kk_ds_test_…` token against the same base URL. Every write is flagged
 
 ## Environment (server-only — never `NEXT_PUBLIC_`)
 
-| Var                                | Purpose                                                                                                                         |
-| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `KEEPKEY_DROPSHIP_MODE`            | `test` (default) or `live` — selects which token is used; default lives in `config.ts` (`KEEPKEY_DROPSHIP_MODE`), env overrides |
-| `KEEPKEY_DROPSHIP_TEST_TOKEN`      | sandbox bearer token                                                                                                            |
-| `KEEPKEY_DROPSHIP_LIVE_TOKEN`      | live bearer token                                                                                                               |
-| `KEEPKEY_DROPSHIP_BASE_URL`        | optional override (defaults to the base URL above)                                                                              |
-| `KEEPKEY_DROPSHIP_WEBHOOK_SECRET`  | HMAC secret for verifying webhooks                                                                                              |
-| `KEEPKEY_DROPSHIP_INTERNAL_SECRET` | gates live order creation until checkout exists                                                                                 |
+| Var                                | Purpose                                            |
+| ---------------------------------- | -------------------------------------------------- |
+| `KEEPKEY_DROPSHIP_TEST_TOKEN`      | sandbox bearer token                               |
+| `KEEPKEY_DROPSHIP_LIVE_TOKEN`      | live bearer token                                  |
+| `KEEPKEY_DROPSHIP_BASE_URL`        | optional override (defaults to the base URL above) |
+| `KEEPKEY_DROPSHIP_WEBHOOK_SECRET`  | HMAC secret for verifying webhooks                 |
+| `KEEPKEY_DROPSHIP_INTERNAL_SECRET` | gates the raw `POST /api/store/orders` live path   |
 
 Set real values in Vercel env / `.env.local`; they are gitignored and never committed.
+
+**Mode is not an env var.** `test` vs `live` is set in code at `src/lib/config.ts`
+(`KEEPKEY_DROPSHIP_MODE`, read via `isSandbox()`). To go live, change it there and ship —
+no Vercel change flips it.
 
 ## Going live (checklist)
 
 1. ✅ Checkout + payment built (`/store/[slug]/checkout` → `POST /api/store/checkout`, USDC
    on Base). Set `NEXT_PUBLIC_STORE_CHECKOUT_ADDRESS` (the store wallet) before going live.
 2. Set `KEEPKEY_DROPSHIP_LIVE_TOKEN`, `KEEPKEY_DROPSHIP_WEBHOOK_SECRET`,
-   `KEEPKEY_DROPSHIP_INTERNAL_SECRET` in Vercel; flip `KEEPKEY_DROPSHIP_MODE=live`. Order the
-   real SKU `KK-HW-001` (not `KK-TEST-001`); pass the color finish in `notes`.
+   `KEEPKEY_DROPSHIP_INTERNAL_SECRET` in Vercel, then set `KEEPKEY_DROPSHIP_MODE = "live"` in
+   `src/lib/config.ts` and ship. Orders then use the real SKU `KK-HW-001` (not `KK-TEST-001`);
+   the color finish rides along in `notes`.
 3. Do one **recommended first live order** (1× `KK-HW-001` to a real address via the
    internal-secret gate), confirm `sandbox:false` + a non-null `settlement`, verify the
    signed `order.received` webhook arrives, then pay the settlement early to prove the BTC

--- a/env.example
+++ b/env.example
@@ -97,9 +97,8 @@ USDC_BASE=0x833589fCD6EDb6E08f4c7C32D4f71b54bdA02913
 # Vercel env / .env.local — do not commit them.
 # ===========================================
 
-# Which token the fulfillment client uses: "test" (sandbox) or "live". Defaults to "test"
-# in src/lib/config.ts (KEEPKEY_DROPSHIP_MODE); set here only to override (e.g. live).
-KEEPKEY_DROPSHIP_MODE=test
+# NOTE: the fulfillment mode (test/live) is NOT an env var — it's set in code at
+# src/lib/config.ts (`KEEPKEY_DROPSHIP_MODE`). Change it there to go live.
 # Bearer tokens (kk_ds_live_… / kk_ds_test_…)
 KEEPKEY_DROPSHIP_LIVE_TOKEN=
 KEEPKEY_DROPSHIP_TEST_TOKEN=

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -112,16 +112,13 @@ export const STORE_CHECKOUT = {
 } as const;
 
 /**
- * KeepKey dropship fulfillment mode. `test` (sandbox) draws no credit and never ships;
- * `live` places real orders that draw the credit line and owe crypto settlement.
+ * KeepKey dropship fulfillment mode — the single control for going live.
  *
- * Default stays `test` on purpose — going live is a deliberate act, never a side effect of
- * a deploy. The env var (`KEEPKEY_DROPSHIP_MODE`, NOT `NEXT_PUBLIC_`) overrides it in Vercel.
- * Read only server-side via `isSandbox()` — do not branch on this in client code (the env
- * value is not exposed to the browser, so it would always read `test` there).
+ * `test` (sandbox) draws no credit and never ships; `live` places real orders that draw the
+ * credit line and owe crypto settlement. **To go live, change this to `"live"` and ship it**
+ * — it is not read from any env var, so no Vercel change is needed (or possible). Consumed
+ * server-side via `isSandbox()`.
  */
-export const KEEPKEY_DROPSHIP_MODE = (process.env.KEEPKEY_DROPSHIP_MODE || "test") as
-  | "test"
-  | "live";
+export const KEEPKEY_DROPSHIP_MODE: "test" | "live" = "test";
 
 export const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://www.gnars.com";

--- a/src/services/keepkey-dropship.test.ts
+++ b/src/services/keepkey-dropship.test.ts
@@ -6,6 +6,15 @@ import {
   WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS,
 } from "./keepkey-dropship";
 
+// The dropship mode now lives in config (not env). Mock it with a mutable holder so tests
+// can drive isSandbox() by setting `mode.value` instead of an env var.
+const mode = vi.hoisted(() => ({ value: "test" as "test" | "live" }));
+vi.mock("@/lib/config", () => ({
+  get KEEPKEY_DROPSHIP_MODE() {
+    return mode.value;
+  },
+}));
+
 const SECRET = "whsec_test_secret";
 const NOW_MS = 1_800_000_000_000; // fixed clock for deterministic timestamp checks
 const NOW_S = Math.floor(NOW_MS / 1000);
@@ -19,12 +28,12 @@ describe("verifyWebhookSignature", () => {
   const body = JSON.stringify({ eventType: "order.received", keepKeyOrderId: "kk_1" });
 
   beforeEach(() => {
-    process.env.KEEPKEY_DROPSHIP_MODE = "live";
+    mode.value = "live";
     process.env.KEEPKEY_DROPSHIP_WEBHOOK_SECRET = SECRET;
   });
   afterEach(() => {
     delete process.env.KEEPKEY_DROPSHIP_WEBHOOK_SECRET;
-    delete process.env.KEEPKEY_DROPSHIP_MODE;
+    mode.value = "test";
   });
 
   it("accepts a correctly signed, fresh payload", () => {
@@ -83,7 +92,7 @@ describe("verifyWebhookSignature", () => {
 
   it("allows (unverified) in sandbox mode when no secret is configured", () => {
     delete process.env.KEEPKEY_DROPSHIP_WEBHOOK_SECRET;
-    process.env.KEEPKEY_DROPSHIP_MODE = "test";
+    mode.value = "test";
     expect(verifyWebhookSignature(body, null, NOW_MS)).toEqual({
       valid: true,
       reason: "unverified-sandbox-no-secret",
@@ -93,24 +102,21 @@ describe("verifyWebhookSignature", () => {
 
 describe("getDropshipOrderByExternalId", () => {
   beforeEach(() => {
-    process.env.KEEPKEY_DROPSHIP_MODE = "test";
+    mode.value = "test";
     process.env.KEEPKEY_DROPSHIP_TEST_TOKEN = "kk_ds_test_x";
   });
   afterEach(() => {
     vi.restoreAllMocks();
     delete process.env.KEEPKEY_DROPSHIP_TEST_TOKEN;
-    delete process.env.KEEPKEY_DROPSHIP_MODE;
   });
 
   function mockFetch(json: unknown) {
-    return vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(
-        new Response(JSON.stringify(json), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      );
+    return vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(json), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
   }
 
   it("unwraps a single-record response and encodes the query", async () => {

--- a/src/services/keepkey-dropship.ts
+++ b/src/services/keepkey-dropship.ts
@@ -24,9 +24,8 @@ const DEFAULT_BASE_URL = "https://affiliates.keepkey.com/api/dropship/v1";
 export const DROPSHIP_SANDBOX_SKU = "KK-TEST-001";
 
 export function isSandbox(): boolean {
-  // Env wins at call-time (so Vercel can flip live/test without a redeploy, and tests can
-  // override per-case); the config const supplies the default when the env var is unset.
-  return (process.env.KEEPKEY_DROPSHIP_MODE || KEEPKEY_DROPSHIP_MODE) !== "live";
+  // Config is the single source of truth for the mode — see KEEPKEY_DROPSHIP_MODE in config.ts.
+  return KEEPKEY_DROPSHIP_MODE !== "live";
 }
 
 function baseUrl(): string {


### PR DESCRIPTION
## Summary

- Per request: the KeepKey dropship mode is now controlled **only** by `KEEPKEY_DROPSHIP_MODE` in `src/lib/config.ts`. The Vercel env var is no longer read.
- To go live: set `KEEPKEY_DROPSHIP_MODE = "live"` in config and ship. Default stays `"test"`.

## Changes

- `src/lib/config.ts` — `KEEPKEY_DROPSHIP_MODE` is a plain hardcoded const (no env read).
- `src/services/keepkey-dropship.ts` — `isSandbox()` reads the config const only.
- `src/services/keepkey-dropship.test.ts` — mode driven via a mocked config value (not env).
- `env.example`, `docs/integrations/keepkey-fulfillment.md` — mode noted as code-set, removed from env list.

## Test plan

- [x] `pnpm test` — 115 passing
- [x] `pnpm lint` + `tsc` clean

Generated with [Claude Code](https://claude.com/claude-code)