### PR TITLE
feat(store): go live + payment-readiness preflight

### DIFF
--- a/messages/en/store.json
+++ b/messages/en/store.json
@@ -69,6 +69,7 @@
       "state": "State / province is required",
       "address": "That shipping address was rejected. Check the street, city, postal code, and state/province.",
       "notConfigured": "Checkout isn't available yet — the store wallet isn't configured.",
+      "unavailable": "Checkout is temporarily unavailable — fulfillment isn't ready. No payment was taken.",
       "generic": "Something went wrong. Please try again."
     },
     "status": {

--- a/messages/pt-br/store.json
+++ b/messages/pt-br/store.json
@@ -69,6 +69,7 @@
       "state": "Estado / província é obrigatório",
       "address": "O endereço de entrega foi recusado. Confira rua, cidade, CEP e estado/província.",
       "notConfigured": "A finalização ainda não está disponível — a carteira da loja não está configurada.",
+      "unavailable": "A finalização está temporariamente indisponível — o fulfillment não está pronto. Nenhum pagamento foi cobrado.",
       "generic": "Algo deu errado. Tente novamente."
     },
     "status": {

--- a/src/app/api/store/checkout/route.ts
+++ b/src/app/api/store/checkout/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
+import { STORE_CHECKOUT } from "@/lib/config";
 import { sendOrderReceiptEmail } from "@/lib/email/order-receipt";
 import { checkoutInputSchema, type CheckoutResult } from "@/lib/schemas/checkout";
 import { isDropshipFulfillable } from "@/lib/store/fulfillment";
@@ -14,6 +15,18 @@ import { verifyUsdcPayment } from "@/services/store-payment";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+
+/**
+ * Checkout readiness preflight. The client MUST call this before prompting an on-chain
+ * payment: payment happens client-side first, so if fulfillment isn't configured we'd
+ * otherwise take money and be unable to place the order. `ready:false` → client aborts
+ * before charging. Live needs the KeepKey token + a payment recipient; sandbox needs neither.
+ */
+export async function GET() {
+  const sandbox = isSandbox();
+  const ready = sandbox || (isDropshipConfigured() && Boolean(STORE_CHECKOUT.recipient));
+  return NextResponse.json({ ready, sandbox });
+}
 
 /**
  * Customer checkout: verify payment (live) then forward a fulfillment order to KeepKey.

--- a/src/components/store/CheckoutFlow.tsx
+++ b/src/components/store/CheckoutFlow.tsx
@@ -154,6 +154,15 @@ export function CheckoutFlow({
         toast.error(t("checkout.errors.notConfigured"));
         return;
       }
+      // Preflight: never prompt payment unless fulfillment is actually ready to place the
+      // order — payment is irreversible and happens before the order call.
+      const pre = await fetch("/api/store/checkout")
+        .then((r) => r.json())
+        .catch(() => null);
+      if (!pre?.ready) {
+        toast.error(t("checkout.errors.unavailable"));
+        return;
+      }
       if (!isConnected) {
         const client = getThirdwebClient();
         if (client) {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -119,6 +119,6 @@ export const STORE_CHECKOUT = {
  * — it is not read from any env var, so no Vercel change is needed (or possible). Consumed
  * server-side via `isSandbox()`.
  */
-export const KEEPKEY_DROPSHIP_MODE: "test" | "live" = "test";
+export const KEEPKEY_DROPSHIP_MODE: "test" | "live" = "live";
 
 export const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://www.gnars.com";


### PR DESCRIPTION
## Summary

- Flips `KEEPKEY_DROPSHIP_MODE` to **live** — real USDC checkout + real KeepKey orders.
- Adds a **payment-readiness preflight** to close the one real risk: payment happens client-side *before* the order is placed, so if fulfillment weren't configured we'd take money and fail to fulfill. Now the client checks readiness first and never prompts payment unless the backend can place the order.

## Changes

- `GET /api/store/checkout` — `{ ready, sandbox }`. Live requires KeepKey token + payment recipient.
- `CheckoutFlow` — preflight before payment; `ready:false` → "checkout unavailable, no payment taken".
- `KEEPKEY_DROPSHIP_MODE = "live"`; i18n EN + PT-BR.

## Payment recipient

USDC → `0x8Bf5941d27176242745B716251943Ae4892a3C26` (confirmed store wallet, in config).

## Requires in Vercel (secrets)

- `KEEPKEY_DROPSHIP_LIVE_TOKEN`, `KEEPKEY_DROPSHIP_WEBHOOK_SECRET` — checkout shows "unavailable" (no charge) until set.
- `EMAIL_USER` / `EMAIL_PASS` — for the receipt email (optional; skipped if unset).

## Test plan

- [x] Readiness returns `ready:false` in live mode with no token → payment blocked
- [x] 126 unit tests pass; lint/tsc clean
- [ ] Post-deploy: one controlled first live order to self, confirm `order.received` webhook, pay BTC settlement early (KeepKey's recommended go-live check)

Generated with [Claude Code](https://claude.com/claude-code)