### PR TITLE
fix(store): wait for tx receipt on server (RPC propagation race)

### DIFF
--- a/src/services/store-payment.test.ts
+++ b/src/services/store-payment.test.ts
@@ -4,23 +4,23 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { verifyUsdcPayment } from "./store-payment";
 
 // Hoisted so the vi.mock factories (also hoisted) can reference them.
-const { RECIPIENT, OTHER, FROM, USDC, TRANSFER_TOPIC, getTransactionReceipt, getBlockNumber } =
-  vi.hoisted(() => ({
+const { RECIPIENT, OTHER, FROM, USDC, TRANSFER_TOPIC, waitForTransactionReceipt } = vi.hoisted(
+  () => ({
     RECIPIENT: "0x1111111111111111111111111111111111111111",
     OTHER: "0x2222222222222222222222222222222222222222",
     FROM: "0x3333333333333333333333333333333333333333",
     USDC: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913", // Base USDC (matches config)
     TRANSFER_TOPIC: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-    getTransactionReceipt: vi.fn(),
-    getBlockNumber: vi.fn(),
-  }));
+    waitForTransactionReceipt: vi.fn(),
+  }),
+);
 
 vi.mock("@/lib/config", () => ({
   STORE_CHECKOUT: { usdc: USDC, usdcDecimals: 6, recipient: RECIPIENT },
 }));
 
 vi.mock("@/lib/rpc", () => ({
-  serverPublicClient: { getTransactionReceipt, getBlockNumber },
+  serverPublicClient: { waitForTransactionReceipt },
 }));
 
 function addrTopic(addr: string): Hex {
@@ -35,80 +35,55 @@ function transferLog(to: string, amountUsd: string, token = USDC) {
   };
 }
 
+// A confirmed, successful receipt carrying the given transfer logs.
+function receipt(logs: ReturnType<typeof transferLog>[], status = "success") {
+  return { status, blockNumber: 999n, logs };
+}
+
 const TX = "0x" + "a".repeat(64);
 
 describe("verifyUsdcPayment", () => {
-  beforeEach(() => {
-    getBlockNumber.mockResolvedValue(1000n);
-    getTransactionReceipt.mockReset();
-  });
+  beforeEach(() => waitForTransactionReceipt.mockReset());
   afterEach(() => vi.clearAllMocks());
 
   it("accepts an exact-amount USDC transfer to the checkout wallet", async () => {
-    getTransactionReceipt.mockResolvedValue({
-      status: "success",
-      blockNumber: 999n,
-      logs: [transferLog(RECIPIENT, "59.95")],
-    });
+    waitForTransactionReceipt.mockResolvedValue(receipt([transferLog(RECIPIENT, "59.95")]));
     const res = await verifyUsdcPayment(TX, 59.95);
     expect(res.ok).toBe(true);
     if (res.ok) expect(res.amount).toBe(parseUnits("59.95", 6));
   });
 
   it("accepts an overpayment", async () => {
-    getTransactionReceipt.mockResolvedValue({
-      status: "success",
-      blockNumber: 999n,
-      logs: [transferLog(RECIPIENT, "60")],
-    });
+    waitForTransactionReceipt.mockResolvedValue(receipt([transferLog(RECIPIENT, "60")]));
     expect((await verifyUsdcPayment(TX, 59.95)).ok).toBe(true);
   });
 
   it("rejects an underpayment", async () => {
-    getTransactionReceipt.mockResolvedValue({
-      status: "success",
-      blockNumber: 999n,
-      logs: [transferLog(RECIPIENT, "59.94")],
+    waitForTransactionReceipt.mockResolvedValue(receipt([transferLog(RECIPIENT, "59.94")]));
+    expect(await verifyUsdcPayment(TX, 59.95)).toMatchObject({
+      ok: false,
+      code: "no_matching_transfer",
     });
-    const res = await verifyUsdcPayment(TX, 59.95);
-    expect(res).toMatchObject({ ok: false, code: "no_matching_transfer" });
   });
 
   it("rejects a transfer to a different address", async () => {
-    getTransactionReceipt.mockResolvedValue({
-      status: "success",
-      blockNumber: 999n,
-      logs: [transferLog(OTHER, "59.95")],
-    });
+    waitForTransactionReceipt.mockResolvedValue(receipt([transferLog(OTHER, "59.95")]));
     expect((await verifyUsdcPayment(TX, 59.95)).ok).toBe(false);
   });
 
   it("rejects the right amount in the wrong token", async () => {
-    getTransactionReceipt.mockResolvedValue({
-      status: "success",
-      blockNumber: 999n,
-      logs: [transferLog(RECIPIENT, "59.95", OTHER)],
-    });
+    waitForTransactionReceipt.mockResolvedValue(receipt([transferLog(RECIPIENT, "59.95", OTHER)]));
     expect((await verifyUsdcPayment(TX, 59.95)).ok).toBe(false);
   });
 
   it("rejects a reverted transaction", async () => {
-    getTransactionReceipt.mockResolvedValue({ status: "reverted", blockNumber: 999n, logs: [] });
+    waitForTransactionReceipt.mockResolvedValue(receipt([], "reverted"));
     expect(await verifyUsdcPayment(TX, 59.95)).toMatchObject({ ok: false, code: "reverted" });
   });
 
-  it("rejects a not-yet-mined transaction", async () => {
-    getTransactionReceipt.mockRejectedValue(new Error("not found"));
+  it("rejects a tx that never appears/confirms within the timeout", async () => {
+    // viem's waitForTransactionReceipt throws on timeout / not found.
+    waitForTransactionReceipt.mockImplementationOnce(() => Promise.reject(new Error("timeout")));
     expect(await verifyUsdcPayment(TX, 59.95)).toMatchObject({ ok: false, code: "not_found" });
-  });
-
-  it("rejects when not enough confirmations", async () => {
-    getBlockNumber.mockResolvedValue(999n);
-    getTransactionReceipt.mockResolvedValue({
-      status: "success",
-      blockNumber: 1000n, // ahead of head → 0 confirmations
-      logs: [transferLog(RECIPIENT, "59.95")],
-    });
-    expect(await verifyUsdcPayment(TX, 59.95)).toMatchObject({ ok: false, code: "not_confirmed" });
   });
 });

--- a/src/services/store-payment.ts
+++ b/src/services/store-payment.ts
@@ -27,18 +27,23 @@ const ERC20_TRANSFER_EVENT = [
 ] as const;
 
 /** Confirmations required before we treat a payment as final (Base blocks are ~2s). */
-const MIN_CONFIRMATIONS = 1n;
+const MIN_CONFIRMATIONS = 1;
+
+/**
+ * How long the server waits for the tx to appear + confirm on its own RPC. The client has
+ * already mined it (it waited for the receipt before POSTing), but the server hits a
+ * different RPC node that can lag a few seconds behind — without this wait, a valid payment
+ * is falsely rejected as "not found" and the buyer retries (and pays again). ~25s covers the
+ * propagation gap while staying within the serverless function budget.
+ */
+const RECEIPT_TIMEOUT_MS = 25_000;
+const RECEIPT_POLL_MS = 2_000;
 
 export type PaymentVerification =
   | { ok: true; from: Address; amount: bigint; txHash: Hex }
   | { ok: false; code: PaymentErrorCode; message: string };
 
-export type PaymentErrorCode =
-  | "not_configured"
-  | "not_found"
-  | "not_confirmed"
-  | "reverted"
-  | "no_matching_transfer";
+export type PaymentErrorCode = "not_configured" | "not_found" | "reverted" | "no_matching_transfer";
 
 /**
  * @param txHash        Base tx hash the customer says paid.
@@ -60,20 +65,22 @@ export async function verifyUsdcPayment(
   const hash = txHash as Hex;
   const minAmount = parseUnits(amountUsd.toString(), STORE_CHECKOUT.usdcDecimals);
 
+  // Poll until the tx is on the server's RPC and has the required confirmations, absorbing
+  // the client↔server RPC propagation lag (the client already waited for the receipt).
   let receipt;
   try {
-    receipt = await serverPublicClient.getTransactionReceipt({ hash });
+    receipt = await serverPublicClient.waitForTransactionReceipt({
+      hash,
+      confirmations: MIN_CONFIRMATIONS,
+      timeout: RECEIPT_TIMEOUT_MS,
+      pollingInterval: RECEIPT_POLL_MS,
+    });
   } catch {
     return { ok: false, code: "not_found", message: "Transaction not found or not yet mined" };
   }
 
   if (receipt.status !== "success") {
     return { ok: false, code: "reverted", message: "Payment transaction reverted" };
-  }
-
-  const currentBlock = await serverPublicClient.getBlockNumber();
-  if (currentBlock - receipt.blockNumber + 1n < MIN_CONFIRMATIONS) {
-    return { ok: false, code: "not_confirmed", message: "Payment not yet confirmed" };
   }
 
   const wantRecipient = getAddress(recipient);


### PR DESCRIPTION
## Summary

Fixes duplicate payments at checkout. `verifyUsdcPayment` did a single `getTransactionReceipt`, but the client mines the tx and POSTs immediately while the server's RPC node lags a few seconds — so a valid payment was rejected as `not_found` (402). Buyers retried and **paid again**.

Observed live: three duplicate 59.95 USDC payments in ~50 min, **none created an order** (all rejected by the race). USDC was self-transfer (net zero) so no funds lost, but real buyers would lose money.

## Fix

Use viem `waitForTransactionReceipt` (poll up to ~25s, 1 confirmation) so the server waits for the tx to appear + confirm on its own RPC before giving up. Removes the manual `getBlockNumber` confirmation check and the `not_confirmed` code (a timeout now returns `not_found`).

## Test plan

- [x] `pnpm test` — 127 passing; lint/tsc clean
- [x] Payment verification: success / over / under / wrong-addr / wrong-token / reverted / timeout→not_found
- [ ] Post-deploy: pay once → single order created, no "tx not found" bounce

Generated with [Claude Code](https://claude.com/claude-code)