### PR TITLE
feat(store): collect shipping phone (Shopify Managed Markets)

### DIFF
--- a/docs/integrations/keepkey-fulfillment.md
+++ b/docs/integrations/keepkey-fulfillment.md
@@ -85,7 +85,8 @@ anywhere KeepKey normally ships) or an array of ISO country codes.
     "city": "Denver",
     "state": "CO",
     "postalCode": "80202",
-    "country": "US"
+    "country": "US",
+    "phone": "+1 555 010 1234"
   },
   "lineItems": [{ "sku": "KK-HW-001", "quantity": 1 }],
   "shippingMethod": "standard",
@@ -95,7 +96,9 @@ anywhere KeepKey normally ships) or an array of ISO country codes.
 
 **`shippingMethod` is required** (KeepKey 400s without it) — our schema defaults it to
 `"standard"`. The address is validated per-country server-side (empty `state` on a US
-address → `invalid_address`). Response:
+address → `invalid_address`). **`shippingAddress.phone` is required for fulfillment** —
+KeepKey's Shopify backend rejects Managed Markets orders without a shipping phone (+ email),
+so the checkout collects phone as required. Response:
 
 ```json
 {

--- a/messages/en/store.json
+++ b/messages/en/store.json
@@ -56,6 +56,7 @@
     "fields": {
       "name": "Full name",
       "email": "Email",
+      "phone": "Phone number",
       "line1": "Address",
       "line2": "Apartment, suite, etc.",
       "city": "City",
@@ -66,6 +67,7 @@
     "errors": {
       "name": "Enter your name",
       "email": "Enter a valid email",
+      "phone": "Enter a valid phone number (required for shipping)",
       "line1": "Enter your street address",
       "city": "Enter your city",
       "postalCode": "Enter your postal code",

--- a/messages/pt-br/store.json
+++ b/messages/pt-br/store.json
@@ -56,6 +56,7 @@
     "fields": {
       "name": "Nome completo",
       "email": "E-mail",
+      "phone": "Telefone",
       "line1": "Endereço",
       "line2": "Apartamento, bloco, etc.",
       "city": "Cidade",
@@ -66,6 +67,7 @@
     "errors": {
       "name": "Informe seu nome",
       "email": "Informe um e-mail válido",
+      "phone": "Informe um telefone válido (obrigatório para envio)",
       "line1": "Informe seu endereço",
       "city": "Informe sua cidade",
       "postalCode": "Informe seu CEP",

--- a/src/components/store/CheckoutFlow.tsx
+++ b/src/components/store/CheckoutFlow.tsx
@@ -56,6 +56,7 @@ const TERMINAL = new Set(["shipped", "cancelled", "failed"]);
 const EMPTY_FORM = {
   customerName: "",
   customerEmail: "",
+  phone: "",
   line1: "",
   line2: "",
   city: "",
@@ -134,6 +135,8 @@ export function CheckoutFlow({
   function validate(): string | null {
     if (!form.customerName.trim()) return t("checkout.errors.name");
     if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(form.customerEmail)) return t("checkout.errors.email");
+    // Shopify requires a shipping phone; want at least a few digits.
+    if (form.phone.replace(/\D/g, "").length < 7) return t("checkout.errors.phone");
     if (!form.line1.trim()) return t("checkout.errors.line1");
     if (!form.city.trim()) return t("checkout.errors.city");
     if (!form.postalCode.trim()) return t("checkout.errors.postalCode");
@@ -160,6 +163,7 @@ export function CheckoutFlow({
           state: form.state.trim(),
           postalCode: form.postalCode.trim(),
           country: form.country.trim().toUpperCase(),
+          phone: form.phone.trim(),
         },
         ...(txHash ? { txHash } : {}),
       }),
@@ -333,6 +337,16 @@ export function CheckoutFlow({
             />
           </Field>
         </div>
+
+        <Field label={t("checkout.fields.phone")}>
+          <Input
+            type="tel"
+            name="tel"
+            autoComplete="tel"
+            value={form.phone}
+            onChange={(e) => set("phone", e.target.value)}
+          />
+        </Field>
 
         <Field label={t("checkout.fields.line1")}>
           <Input

--- a/src/lib/email/order-receipt.test.ts
+++ b/src/lib/email/order-receipt.test.ts
@@ -22,6 +22,7 @@ const base: OrderReceiptInput = {
     state: "CO",
     postalCode: "80202",
     country: "US",
+    phone: "+1 555 010 1234",
   },
   sandbox: true,
 };

--- a/src/lib/schemas/dropship.ts
+++ b/src/lib/schemas/dropship.ts
@@ -84,6 +84,10 @@ export const shippingAddressSchema = z.object({
   state: z.string().optional().default(""),
   postalCode: z.string().min(1),
   country: z.string().length(2, "ISO 3166-1 alpha-2 country code"),
+  // Shopify (KeepKey's fulfiller) requires a shipping phone on Managed Markets orders —
+  // without it the order is rejected at fulfillment. Optional here so sandbox/legacy callers
+  // don't break; the checkout collects it as required.
+  phone: z.string().optional().default(""),
 });
 
 export type ShippingAddress = z.infer<typeof shippingAddressSchema>;


### PR DESCRIPTION
## Summary

KeepKey's Shopify backend rejected our first live order: *"Add customer's email, shipping phone number, and shipping address for Managed Markets orders."* We collected **no phone** anywhere — this adds it.

## Changes

- `shippingAddressSchema` — optional `phone` (sandbox/legacy callers unaffected); checkout collects it **required** (≥7 digits) and sends `shippingAddress.phone` → forwarded to KeepKey.
- Phone input (`autoComplete="tel"`), i18n EN + PT-BR, docs.

## ⚠️ Needs KeepKey confirmation

Confirm KeepKey forwards `shippingAddress.phone` to Shopify (exact field path) before the next live order — otherwise adjust to their expected field.

## Test plan

- [x] `pnpm test` — 127 passing; lint/tsc clean
- [x] Phone field renders on checkout (`autoComplete="tel"`)
- [ ] Post-deploy: US order with phone → passes Shopify fulfillment

Generated with [Claude Code](https://claude.com/claude-code)