### PR TITLE
chore(migrate): trade-referrer config, drop fake burn, kompreni handoff

### DIFF
--- a/docs/strategy/gnars-migration-handoff.md
+++ b/docs/strategy/gnars-migration-handoff.md
@@ -1,74 +1,93 @@
-# Gnars Migration — handoff for review / completion
+# Gnars Migration — handoff for kompreni
 
-For @kompreni / @niftytime (Upgrader / Onchain Inc) to review or complete the gnars.com side of the
-migration. Companion docs: `gnars-migration-implementation.md` (verified facts),
-`gnars-token-migration.md` (strategy), `gnars-migration-decisions.md` (open decisions).
+Hey kompreni 👋 — this is the gnars.com side of the Zora → Clanker $gnars migration. It's built,
+merged to `main`, and live as a **hidden route** (`/migrate`, unlisted in nav) for testing. Below is
+what we built, what we need from you, and copy-paste prompts for your AI to finish the two remaining
+pieces on our repo.
 
-## TL;DR
+Repo: `r4topunk/gnars-website` · Route: `/migrate` (Next.js 16 App Router, thirdweb v5 + wagmi + `@zoralabs/coins-sdk`).
 
-Branch `feat/gnars-migration` adds a `/migrate` page. The **on-ramp** (convert Zora coins → old
-$gnars — quotes + sequential execution), the **Get $GNARS** buy, and a **guide** are built and
-working. The remaining piece is the **self-hosted Upgrader deposit/claim portal**, which is blocked
-only on kompreni scheduling the upgrade (needs the `upgradeId` + new-token address) — that's the part
-to complete after the new token exists.
+## What we built (working today)
 
-## Run locally
+A `/migrate` hub with three tabs:
 
-```bash
-pnpm install
-pnpm dev            # http://localhost:3000/en/migrate
-```
+- **Consolidate** — pulls the user's Zora coins from Zora's indexer (`getProfileBalances`, `excludeHidden`)
+  so only real coins show (scams/airdrops/random ERC-20s are filtered out). Multi-select, live quotes,
+  a step-by-step **route map**, and **sequential execution** that converts the selected coins into old
+  **$gnars**. Routing is per coin: **gnars-paired coins swap straight to $gnars (one hop); everything
+  else goes coin → ZORA → then one ΣZORA → $gnars.**
+- **Get $GNARS** — buy old $gnars with ETH (via the Zora router — works where 0x/Matcha can't route the
+  V4 creator-coin pool).
+- **Guide** — a 4-step tutorial (Convert → Hold → Deposit → Claim), EN + PT-BR.
 
-Env needed: `NEXT_PUBLIC_ZORA_API_KEY`, `NEXT_PUBLIC_THIRDWEB_CLIENT_ID` (see `.env.example`).
-Optional: `NEXT_PUBLIC_MIGRATION_MULTISIG` (interim recipient; defaults to the verified aux
-Safe `0xBe6C3D651d2F6e9eFA562b5a7CDf411304cad076`).
+Swaps sign via `useWriteAccount` → the user's **EOA** for external wallets (not the sponsored-but-empty
+smart account). **Verified on-chain:** a real run converted LUNCH/KCFPFD/GDROP/GNARgentina2 directly to
+$gnars and mlibty via ZORA→$gnars, all in clean single txns.
 
-## What's built (working)
+Key files:
 
-| Area                                                                                                                                            | File                                              | State                                                                 |
-| ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- | --------------------------------------------------------------------- |
-| Route + tabs (Consolidate / Get $GNARS / Guide)                                                                                                 | `src/app/[locale]/migrate/{page,MigrateTabs}.tsx` | done                                                                  |
-| Consolidate: Zora-only, scam-filtered holdings; multi-select; live quotes coin→ZORA→$gnars; per-coin + grouped route map; burn/slippage preview | `src/app/[locale]/migrate/MigrationWidget.tsx`    | done (read/quote)                                                     |
-| Consolidate **execution** — sequential: each coin → ZORA, then ΣZORA → $gnars, with per-step progress                                           | `src/hooks/use-execute-migration.ts`              | done (sequential; untested with real funds — needs a live smoke test) |
-| Get $GNARS: buy old $gnars with ETH (Zora router)                                                                                               | `src/app/[locale]/migrate/GetGnarsWidget.tsx`     | done                                                                  |
-| Guide: 4-step tutorial, EN + PT-BR                                                                                                              | `messages/{en,pt-br}/migrate.json`                | done                                                                  |
-| Data layer (holdings, quotes, route model)                                                                                                      | `src/hooks/use-gnars-migration.ts`                | done                                                                  |
-| Config (addresses, burn bps, temp multisig)                                                                                                     | `src/lib/config.ts`                               | done                                                                  |
+- `src/app/[locale]/migrate/{page,MigrateTabs,MigrationWidget,GetGnarsWidget}.tsx`
+- `src/hooks/{use-gnars-migration,use-execute-migration,use-trade-creator-coin}.ts`
+- `src/lib/config.ts` — addresses + `MIGRATION_MULTISIG` + `MIGRATION_TRADE_REFERRER`
+- messages: `messages/{en,pt-br}/migrate.json`
 
-Wallet layer: thirdweb v5 for writes (`useWriteAccount`, sponsored SA), wagmi for reads.
-Holdings via Zora `getProfileBalances(excludeHidden)`. Quotes via `@zoralabs/coins-sdk`
-`createTradeCall`.
+## What we need from you (the Upgrader / Clanker side)
 
-## What's NOT built — the main task for kompreni to finish
+1. **`schedule` + `execute` the upgrade** for old $gnars (`0x0cf0c3b75d522290d7d12c74d7f1f0cc47ccb23b`).
+   You confirmed you'll do this — let's coordinate a date/time (no on-chain deadline, so it's social).
+2. **Register the sell route** `gnars → ZORA → WETH` (V4 hooked pool, hook `0xd61A675F8a0c67A73DC3B54FB7318B4D91409040`).
+   Confirm 2-hop chaining works.
+3. **Add the WETH deposit lane** so people can contribute fresh ETH/WETH (the "party" capital path).
+4. **Tokenomics** (we'll confirm final numbers): swap fee **1%**, treasury/vault **30%**, vesting **7 days**,
+   **founder-vault beneficiary = our temp multisig `0xBe6C3D651d2F6e9eFA562b5a7CDf411304cad076`**
+   (verified Safe 3-of-N on Base; it sweeps to the DAO treasury at the end).
+5. Give us the **`upgradeId`** once scheduled, and the **new $gnars token address** after `execute`.
 
-**Self-hosted Upgrader deposit/claim portal.** kompreni confirmed: host it here (not upgrader.co),
-and he'll `schedule` + `execute` the upgrade himself. **Blocked only on the new token existing** —
-once kompreni schedules the upgrade you get an `upgradeId`, and after `execute` the new $gnars address.
-Then build against the verified Upgrader `0x999Cd4Dcb412A8272a62BeeB271662d1C72d3c7e`
-(reader `0x76a51fBC42e932ed3a5e1Ec413a7E03a3EC800AE`):
+## Two tasks to finish on our repo — prompts for your AI
 
-- deposit = `ERC20.approve(upgrader, amt)` → `deposit(upgradeId, user, token, amt, false)`
-- `withdraw(...)` pre-execute; `claim(upgradeId, user)` post-execute
-- status via `getBuyToken/getSellProceeds/getBuyProceeds/getUserClaim`; UI data via `UpgraderReader`
-- add it as a 4th tab on `/migrate` (mirror the existing tab pattern in `MigrateTabs.tsx`)
+Both are scoped so your AI can pick them up in `r4topunk/gnars-website`. Please follow the repo
+conventions (bottom of this doc).
 
-Also pending: **atomic one-tx batching** of the Consolidate sells (currently sequential — one
-signature per coin). Optimization via thirdweb SA `sendBatchTransaction` + Permit2, not required for v1.
+### Task A — Upgrader deposit/claim portal (needs the `upgradeId`)
 
-## kompreni's confirmed answers (gnars ⇄ upgrader chat)
+> In the gnars-website repo, add a 4th tab "Deposit" to `src/app/[locale]/migrate/MigrateTabs.tsx`
+> that lets users deposit old $gnars into the Upgrader and claim the new token, self-hosted (kompreni
+> wants it here, not upgrader.co). Use the verified Upgrader contract on Base
+> `0x999Cd4Dcb412A8272a62BeeB271662d1C72d3c7e` and the reader `0x76a51fBC42e932ed3a5e1Ec413a7E03a3EC800AE`.
+> Flow: `ERC20.approve(upgrader, amount)` → `deposit(upgradeId, user, token, amount, false)`;
+> `withdraw(...)` before execute; `claim(upgradeId, user)` after. Read status with
+> `getBuyToken/getSellProceeds/getBuyProceeds/getUserClaim` and per-user data via `UpgraderReader`.
+> Take the `upgradeId` from an env/config constant. Sign via `useWriteAccount` (see
+> `src/hooks/use-execute-migration.ts` for the thirdweb + viem pattern). Mirror the existing tab UI.
+> ⚠️ Show a warning: unsold leftovers are stuck forever, so steer thin holders to the WETH lane.
 
-1. **gnars→ZORA→WETH route** — kompreni registers it **closer to launch**.
-2. **Partial fills** — ⚠️ **leftover unsold tokens are stuck in the Upgrader forever.** So depositing
-   thin content coins raw risks permanent loss of the unsold portion → steer users to convert to old
-   $gnars first (our tool) and/or contribute via the WETH lane (sells fully). Reflect this in the deposit UI.
-3. **WETH deposit lane** — yes, will be added (fresh-capital path).
-4. **Tokenomics to finalize (DAO decision):** swap fee **~1%** (standard), **~30%** of supply to
-   treasury/vault (standard), vesting **~7 days**. Vault beneficiary = temp multisig `MIGRATION_MULTISIG`
-   (`0xBe6C3D651d2F6e9eFA562b5a7CDf411304cad076`, verified Safe 3-of-N on Base).
-5. **Ops** — kompreni does `schedule`/`execute`; coordinate date/time; self-hosting the UI is welcome.
+Grab the full Upgrader ABI from the contract on Basescan/Blockscout (it's verified).
+
+### Task B — capture the Zora trade-referrer fee → fund $gnars buyback/burn
+
+> In gnars-website, make the migration + Get-$GNARS swaps attribute a Zora **trade referrer** so the
+> fee accrues to `MIGRATION_TRADE_REFERRER` (in `src/lib/config.ts`, = haxixe.eth). Problem: the Zora
+> SDK's `tradeCoin`/`createTradeCall` do NOT forward a referrer. So POST directly to
+> `https://api-sdk.zora.engineering/quote` with `referrer` in the body (the `PostQuoteData.body.referrer`
+> field), then execute the returned `call` ({target,value,data} + permits) via the viem walletClient —
+> handling the Permit2 signatures for ERC-20 sells (ETH sells need no permit). Replace the internal
+> `tradeCoin` calls in `use-execute-migration.ts` and `use-trade-creator-coin.ts` with this referred
+> path, keeping the current behavior as a fallback if the referred quote fails. Test with a tiny amount.
+
+Context on the buyback: we removed the old per-trade "1% burn" (it was never implemented — misleading).
+The intended flywheel is now: **referrer fees accrue to haxixe.eth → periodically claim in Zora → buy
+$gnars → burn.** That's DAO revenue from Zora's fee, not a tax on migrators. Per-trade buying is too
+gas-heavy; batch it.
+
+(Optional Task C: atomic one-tx batching of the Consolidate sells — thirdweb SA
+`sendBatchTransaction` with Permit2, so it's one signature instead of one per coin.)
 
 ## Repo conventions (please follow)
 
-PR to `main` (no direct commits); `pnpm lint` + `pnpm format:check` before PR; new UI strings go
-through next-intl in **both** en + pt-br; verify at runtime (`pnpm dev`) before marking done.
-Full guide: `CLAUDE.md`.
+- Branch from `main`, open a **PR** (no direct commits to `main`).
+- `pnpm lint` + `pnpm format:check` before PR; new UI strings via next-intl in **both** en + pt-br.
+- Verify at runtime (`pnpm dev` → `/en/migrate`) before marking done.
+- Full guide: `CLAUDE.md`. Companion docs: `gnars-migration-implementation.md` (verified on-chain facts),
+  `gnars-token-migration.md` (strategy), `gnars-migration-decisions.md` (open decisions).
+
+Thanks 🙏 — ping Vlad (haxixe.eth) to coordinate the schedule/execute timing.

--- a/messages/en/migrate.json
+++ b/messages/en/migrate.json
@@ -58,7 +58,6 @@
     "routable": "With a route to $gnars",
     "unroutable": "{count} no liquidity",
     "youReceive": "You receive (estimated)",
-    "burn": "Includes {amount} $GNARS ({pct}%) bought & burned to strengthen liquidity",
     "slippageWarning": "The $gnars pool is thin — large migrations move the price. Estimates include slippage and can change before the transaction confirms.",
     "migrateCta": "Migrate {count} coins to $gnars",
     "executing": "Migrating…",
@@ -66,6 +65,6 @@
   },
   "editorial": {
     "tagline": "One token, deeper liquidity",
-    "body": "Every Zora coin you migrate routes through ZORA into $gnars, and a slice of each migration is burned. The result: fragmented dust becomes concentrated, healthier $gnars liquidity."
+    "body": "Every Zora coin you migrate is consolidated into $gnars. The result: fragmented dust becomes concentrated, healthier $gnars liquidity."
   }
 }

--- a/messages/pt-br/migrate.json
+++ b/messages/pt-br/migrate.json
@@ -58,7 +58,6 @@
     "routable": "Com rota para $gnars",
     "unroutable": "{count} sem liquidez",
     "youReceive": "Você recebe (estimado)",
-    "burn": "Inclui {amount} $GNARS ({pct}%) comprados e queimados para fortalecer a liquidez",
     "slippageWarning": "O pool de $gnars é raso — migrações grandes movem o preço. As estimativas incluem slippage e podem mudar antes da confirmação da transação.",
     "migrateCta": "Migrar {count} coins para $gnars",
     "executing": "Migrando…",
@@ -66,6 +65,6 @@
   },
   "editorial": {
     "tagline": "Um token, mais liquidez",
-    "body": "Cada coin da Zora que você migra passa pela ZORA até $gnars, e uma parte de cada migração é queimada. O resultado: poeira fragmentada vira liquidez concentrada e mais saudável em $gnars."
+    "body": "Cada coin da Zora que você migra é consolidada em $gnars. O resultado: poeira fragmentada vira liquidez concentrada e mais saudável em $gnars."
   }
 }

--- a/src/app/[locale]/migrate/MigrationWidget.tsx
+++ b/src/app/[locale]/migrate/MigrationWidget.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { useTranslations } from "next-intl";
-import { ArrowDown, Check, ChevronRight, Flame, ShieldCheck, X } from "lucide-react";
+import { ArrowDown, Check, ChevronRight, ShieldCheck, X } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -22,7 +22,6 @@ import {
   type RouteHop,
 } from "@/hooks/use-gnars-migration";
 import { useUserAddress } from "@/hooks/use-user-address";
-import { MIGRATION_BURN_BPS } from "@/lib/config";
 
 export function MigrationWidget() {
   const t = useTranslations("migrate");
@@ -279,11 +278,11 @@ function MigrationPreview({
     directGnarsOut,
     isLoading: quotesLoading,
   } = useCoinQuotes(coins, sender);
-  const {
-    burnGnars,
-    netGnars,
-    isLoading: gnarsLoading,
-  } = useGnarsOutputQuote(totalZoraOut, directGnarsOut, sender);
+  const { totalGnars, isLoading: gnarsLoading } = useGnarsOutputQuote(
+    totalZoraOut,
+    directGnarsOut,
+    sender,
+  );
 
   const { execute, isRunning, steps } = useExecuteMigration();
 
@@ -340,14 +339,7 @@ function MigrationPreview({
           {t("preview.youReceive")}
         </div>
         <div className="mt-1 text-2xl font-bold">
-          {loading ? "…" : formatCoinAmount(netGnars)} <span className="text-base">$GNARS</span>
-        </div>
-        <div className="mt-2 flex items-center gap-1.5 text-xs text-muted-foreground">
-          <Flame className="size-3.5" />
-          {t("preview.burn", {
-            amount: formatCoinAmount(burnGnars),
-            pct: (MIGRATION_BURN_BPS / 100).toString(),
-          })}
+          {loading ? "…" : formatCoinAmount(totalGnars)} <span className="text-base">$GNARS</span>
         </div>
       </div>
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -60,6 +60,15 @@ export const MIGRATION_BURN_BPS = 100 as const;
 export const MIGRATION_MULTISIG = (process.env.NEXT_PUBLIC_MIGRATION_MULTISIG ||
   "0xBe6C3D651d2F6e9eFA562b5a7CDf411304cad076") as `0x${string}`;
 
+// Trade referrer for the migration/buy swaps — earns a share of the Zora trade
+// fee, claimable in Zora by this account. Set to haxixe.eth (Vlad's personal
+// account) so rewards are easy to claim.
+// ⚠️ Not yet wired: the Zora SDK's tradeCoin/createTradeCall do NOT forward a
+// referrer. Capturing it requires POSTing to the quote endpoint with `referrer`
+// in the body and executing the returned call ourselves (see handoff doc).
+export const MIGRATION_TRADE_REFERRER = (process.env.NEXT_PUBLIC_MIGRATION_TRADE_REFERRER ||
+  "0x8Bf5941d27176242745B716251943Ae4892a3C26") as `0x${string}`;
+
 // Creator allowlist — Zora handles that bypass the NFT qualification gate.
 // Use for known community members whose wallets are fragmented across profiles.
 export const GNARS_CREATOR_ALLOWLIST: readonly string[] = [


### PR DESCRIPTION
## Summary

- Adds `MIGRATION_TRADE_REFERRER` (= haxixe.eth) — the Zora trade referrer that will collect swap-fee rewards once wired.
- **Removes the per-trade "1% burn"** from the preview UI + copy — it was never implemented on-chain (misleading). Buyback/burn will instead be funded by referrer rewards (claim → buy → burn), not a tax on migrators.
- Rewrites `docs/strategy/gnars-migration-handoff.md` to address **kompreni directly**: what we built, what he needs to do, and copy-paste AI prompts for the deposit portal + referrer wiring.

## Test plan

- [x] tsc / eslint / prettier clean
- [x] `/en/migrate` renders (200); Consolidate preview shows full $GNARS estimate, no burn line

🤖 Generated with [Claude Code](https://claude.com/claude-code)