### PR TITLE
feat(migrate): receive-as-ETH option

### DIFF
--- a/messages/en/migrate.json
+++ b/messages/en/migrate.json
@@ -59,9 +59,12 @@
     "unroutable": "{count} no liquidity",
     "youReceive": "You receive (estimated)",
     "slippageWarning": "The $gnars pool is thin — large migrations move the price. Estimates include slippage and can change before the transaction confirms.",
-    "migrateCta": "Migrate {count} coins to $gnars",
+    "migrateCta": "Migrate {count} coins to {token}",
     "executing": "Migrating…",
-    "executionNote": "Runs one swap per coin, then a final swap into $gnars — approve each in your wallet. Tip: test with a single low-value coin first."
+    "executionNote": "Runs one swap per coin — approve each in your wallet. Tip: test with a single low-value coin first.",
+    "receiveAs": "Receive as",
+    "targetGnars": "$GNARS",
+    "targetEth": "ETH"
   },
   "editorial": {
     "tagline": "One token, deeper liquidity",

--- a/messages/pt-br/migrate.json
+++ b/messages/pt-br/migrate.json
@@ -59,9 +59,12 @@
     "unroutable": "{count} sem liquidez",
     "youReceive": "Você recebe (estimado)",
     "slippageWarning": "O pool de $gnars é raso — migrações grandes movem o preço. As estimativas incluem slippage e podem mudar antes da confirmação da transação.",
-    "migrateCta": "Migrar {count} coins para $gnars",
+    "migrateCta": "Migrar {count} coins para {token}",
     "executing": "Migrando…",
-    "executionNote": "Faz uma troca por coin e, no fim, uma troca para $gnars — aprove cada uma na sua carteira. Dica: teste primeiro com uma coin de baixo valor."
+    "executionNote": "Faz uma troca por coin — aprove cada uma na sua carteira. Dica: teste primeiro com uma coin de baixo valor.",
+    "receiveAs": "Receber como",
+    "targetGnars": "$GNARS",
+    "targetEth": "ETH"
   },
   "editorial": {
     "tagline": "Um token, mais liquidez",

--- a/src/app/[locale]/migrate/MigrationWidget.tsx
+++ b/src/app/[locale]/migrate/MigrationWidget.tsx
@@ -19,6 +19,7 @@ import {
   useGnarsOutputQuote,
   useMigratableCoins,
   type MigratableCoin,
+  type MigrationTarget,
   type RouteHop,
 } from "@/hooks/use-gnars-migration";
 import { useUserAddress } from "@/hooks/use-user-address";
@@ -30,6 +31,7 @@ export function MigrationWidget() {
 
   // Selection is keyed by lowercase address.
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
+  const [target, setTarget] = React.useState<MigrationTarget>("gnars");
 
   const selectedCoins = React.useMemo(
     () => coins.filter((c) => selected.has(c.address.toLowerCase())),
@@ -72,7 +74,41 @@ export function MigrationWidget() {
         onClearAll={clearAll}
       />
       {selectedCoins.length > 0 && <RouteMap coins={selectedCoins} />}
-      {selectedCoins.length > 0 && <MigrationPreview coins={selectedCoins} sender={address} />}
+      {selectedCoins.length > 0 && (
+        <MigrationPreview
+          coins={selectedCoins}
+          sender={address}
+          target={target}
+          onTargetChange={setTarget}
+        />
+      )}
+    </div>
+  );
+}
+
+/** Segmented toggle for the migration target ($GNARS vs ETH). */
+function TargetToggle({
+  target,
+  onChange,
+}: {
+  target: MigrationTarget;
+  onChange: (t: MigrationTarget) => void;
+}) {
+  const t = useTranslations("migrate");
+  return (
+    <div className="inline-flex rounded-lg border p-0.5">
+      {(["gnars", "eth"] as const).map((opt) => (
+        <button
+          key={opt}
+          type="button"
+          onClick={() => onChange(opt)}
+          className={`cursor-pointer rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+            target === opt ? "bg-primary text-primary-foreground" : "text-muted-foreground"
+          }`}
+        >
+          {opt === "gnars" ? t("preview.targetGnars") : t("preview.targetEth")}
+        </button>
+      ))}
     </div>
   );
 }
@@ -267,22 +303,31 @@ function HoldingsList({
 function MigrationPreview({
   coins,
   sender,
+  target,
+  onTargetChange,
 }: {
   coins: MigratableCoin[];
   sender: string | undefined;
+  target: MigrationTarget;
+  onTargetChange: (t: MigrationTarget) => void;
 }) {
   const t = useTranslations("migrate");
   const {
     quotes,
     totalZoraOut,
     directGnarsOut,
+    totalEthOut,
     isLoading: quotesLoading,
-  } = useCoinQuotes(coins, sender);
+  } = useCoinQuotes(coins, sender, target);
   const { totalGnars, isLoading: gnarsLoading } = useGnarsOutputQuote(
     totalZoraOut,
     directGnarsOut,
     sender,
   );
+
+  const isEth = target === "eth";
+  const total = isEth ? totalEthOut : totalGnars;
+  const unit = isEth ? "ETH" : "$GNARS";
 
   const { execute, isRunning, steps } = useExecuteMigration();
 
@@ -303,13 +348,18 @@ function MigrationPreview({
       pairedWith: c.pairedWith?.address ?? null,
     }));
 
-  const onMigrate = () => execute(routableCoins);
+  const onMigrate = () => execute(routableCoins, target);
 
   return (
     <Card className="space-y-4 p-5">
       <div className="flex items-center justify-between">
         <span className="text-sm font-medium">{t("preview.title")}</span>
         {loading && <Spinner className="size-4" />}
+      </div>
+
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-sm text-muted-foreground">{t("preview.receiveAs")}</span>
+        <TargetToggle target={target} onChange={onTargetChange} />
       </div>
 
       <div className="flex items-center justify-between text-sm">
@@ -339,7 +389,8 @@ function MigrationPreview({
           {t("preview.youReceive")}
         </div>
         <div className="mt-1 text-2xl font-bold">
-          {loading ? "…" : formatCoinAmount(totalGnars)} <span className="text-base">$GNARS</span>
+          {loading ? "…" : formatCoinAmount(total, 18, isEth ? 6 : 4)}{" "}
+          <span className="text-base">{unit}</span>
         </div>
       </div>
 
@@ -353,7 +404,9 @@ function MigrationPreview({
         disabled={loading || isRunning || routableCount === 0}
         onClick={onMigrate}
       >
-        {isRunning ? t("preview.executing") : t("preview.migrateCta", { count: routableCount })}
+        {isRunning
+          ? t("preview.executing")
+          : t("preview.migrateCta", { count: routableCount, token: unit })}
       </Button>
       <p className="text-center text-[11px] text-muted-foreground">{t("preview.executionNote")}</p>
     </Card>

--- a/src/hooks/use-execute-migration.ts
+++ b/src/hooks/use-execute-migration.ts
@@ -21,6 +21,7 @@ import { toast } from "sonner";
 import { viemAdapter } from "thirdweb/adapters/viem";
 import { base } from "thirdweb/chains";
 import { erc20Abi, type Address, type PublicClient, type WalletClient } from "viem";
+import type { MigrationTarget } from "@/hooks/use-gnars-migration";
 import { useWriteAccount } from "@/hooks/use-write-account";
 import { GNARS_CREATOR_COIN, ZORA_TOKEN_BASE } from "@/lib/config";
 import { getThirdwebClient } from "@/lib/thirdweb";
@@ -58,7 +59,11 @@ export function useExecuteMigration() {
   // spend from an empty smart wallet → OutOfFunds.
   const writer = useWriteAccount();
 
-  const execute = async (coins: CoinToMigrate[], slippage = 0.15) => {
+  const execute = async (
+    coins: CoinToMigrate[],
+    target: MigrationTarget = "gnars",
+    slippage = 0.15,
+  ) => {
     if (coins.length === 0) return;
     if (!writer) {
       toast.error("Please connect your wallet");
@@ -73,17 +78,20 @@ export function useExecuteMigration() {
 
     setIsRunning(true);
 
-    // Route per coin: gnars-paired coins swap straight to $gnars (one hop);
-    // everything else goes to ZORA, then a single consolidated ZORA→$gnars hop.
+    const toEth = target === "eth";
+    // Route per coin. ETH target: every coin sells straight to ETH (the SDK
+    // routes content→creator→ZORA→ETH), no consolidation hop. $gnars target:
+    // gnars-paired coins go straight to $gnars (one hop); the rest go to ZORA,
+    // then a single consolidated ZORA→$gnars hop.
     const plan = coins.map((c) => ({
       coin: c,
-      direct: c.pairedWith?.toLowerCase() === GNARS_LOWER,
+      direct: !toEth && c.pairedWith?.toLowerCase() === GNARS_LOWER,
     }));
-    const hasViaZora = plan.some((p) => !p.direct);
+    const hasViaZora = !toEth && plan.some((p) => !p.direct);
 
     const initial: MigrationStep[] = [
       ...plan.map((p) => ({
-        label: `${p.coin.symbol} → ${p.direct ? "$GNARS" : "ZORA"}`,
+        label: `${p.coin.symbol} → ${toEth ? "ETH" : p.direct ? "$GNARS" : "ZORA"}`,
         status: "pending" as StepStatus,
       })),
       ...(hasViaZora ? [{ label: "ZORA → $GNARS", status: "pending" as StepStatus }] : []),
@@ -120,32 +128,37 @@ export function useExecuteMigration() {
       }
     };
 
-    const toastId = toast.loading("Migrating into $gnars…");
+    const targetLabel = toEth ? "ETH" : "$gnars";
+    const toastId = toast.loading(`Migrating into ${targetLabel}…`);
     try {
       const zoraBefore = hasViaZora ? await readZora() : 0n;
 
-      // Sell each coin toward its target: direct → $gnars, or → ZORA.
+      // Sell each coin toward its immediate target: ETH, direct $gnars, or ZORA.
       let anyViaZoraSold = false;
-      let anyDirectDone = false;
+      let anyTerminalDone = false; // reached the final asset (ETH or $gnars) directly
       for (let i = 0; i < plan.length; i++) {
         setStatus(i, "active");
         try {
-          const buyAddress = plan[i].direct ? (GNARS_CREATOR_COIN as Address) : ZORA_TOKEN_BASE;
-          const params: TradeParameters = {
-            sell: { type: "erc20", address: plan[i].coin.address },
-            buy: { type: "erc20", address: buyAddress },
-            amountIn: BigInt(plan[i].coin.balance),
-            slippage,
-            sender,
-          };
+          const buy: TradeParameters["buy"] = toEth
+            ? { type: "eth" }
+            : {
+                type: "erc20",
+                address: plan[i].direct ? (GNARS_CREATOR_COIN as Address) : ZORA_TOKEN_BASE,
+              };
           await tradeCoin({
-            tradeParameters: params,
+            tradeParameters: {
+              sell: { type: "erc20", address: plan[i].coin.address },
+              buy,
+              amountIn: BigInt(plan[i].coin.balance),
+              slippage,
+              sender,
+            },
             walletClient,
             account: walletClient.account!,
             publicClient,
           });
           setStatus(i, "done");
-          if (plan[i].direct) anyDirectDone = true;
+          if (toEth || plan[i].direct) anyTerminalDone = true;
           else anyViaZoraSold = true;
         } catch (err) {
           console.error(`[migration] swap failed for ${plan[i].coin.symbol}`, err);
@@ -153,7 +166,7 @@ export function useExecuteMigration() {
         }
       }
 
-      // Consolidate any ZORA gained from the non-direct coins into $gnars.
+      // $gnars target only: consolidate the ZORA gained from non-direct coins.
       if (hasViaZora) {
         if (!anyViaZoraSold) throw new Error("None of the coins could be sold to ZORA");
         setStatus(finalIdx, "active");
@@ -172,11 +185,11 @@ export function useExecuteMigration() {
           publicClient,
         });
         setStatus(finalIdx, "done");
-      } else if (!anyDirectDone) {
+      } else if (!anyTerminalDone) {
         throw new Error("No coins could be migrated");
       }
 
-      toast.success("Migrated into $gnars!", { id: toastId });
+      toast.success(`Migrated into ${targetLabel}!`, { id: toastId });
       return true;
     } catch (err) {
       if (finalIdx >= 0) setStatus(finalIdx, "failed");

--- a/src/hooks/use-gnars-migration.ts
+++ b/src/hooks/use-gnars-migration.ts
@@ -198,44 +198,49 @@ export function isGnarsPaired(coin: MigratableCoin): boolean {
   return coin.pairedWith?.address?.toLowerCase() === GNARS;
 }
 
+/** What the user converts their coins into. */
+export type MigrationTarget = "gnars" | "eth";
+
 export interface CoinQuote {
   address: Address;
-  /** True when the SDK found a route to the coin's target (ZORA, or $gnars if gnars-paired). */
+  /** True when the SDK found a route to the target. */
   routable: boolean;
-  /** Estimated output (raw, 18 decimals): $gnars if `direct`, otherwise ZORA. */
+  /** Estimated output (raw, 18 decimals): ETH, $gnars if `direct`, else ZORA. */
   out: bigint;
-  /** True when quoted straight to $gnars (a gnars-paired coin — single hop). */
+  /** True when quoted straight to $gnars (a gnars-paired coin — single hop; gnars target only). */
   direct: boolean;
   error?: string;
 }
 
 /**
- * Quotes each selected coin's full balance toward $gnars, running the requests
- * concurrently (React Query dedupes + caches). Routing depends on the coin's
- * pool pairing:
- *   - gnars-paired coin → quote straight to $gnars (one hop)
- *   - everything else   → quote to ZORA (the hub), consolidated to $gnars after
- * Forcing every coin through ZORA breaks gnars-paired content coins (they have
- * no ZORA pool), which is why they must be routed directly.
+ * Quotes each selected coin's full balance toward the chosen target.
+ *   - target "gnars": gnars-paired coins quote straight to $gnars (one hop);
+ *     everything else quotes to ZORA (hub), consolidated to $gnars afterwards.
+ *   - target "eth": every coin quotes straight to ETH (the SDK routes
+ *     content→creator→ZORA→ETH under the hood); no consolidation hop needed.
  */
 export function useCoinQuotes(
   coins: MigratableCoin[],
   sender: string | undefined,
+  target: MigrationTarget = "gnars",
   slippage = 0.15,
 ) {
   const results = useQueries({
     queries: coins.map((coin) => {
-      const direct = isGnarsPaired(coin);
-      const buyAddress = (direct ? GNARS_CREATOR_COIN : ZORA_TOKEN_BASE) as Address;
+      const useEth = target === "eth";
+      const direct = !useEth && isGnarsPaired(coin);
+      const buy: TradeParameters["buy"] = useEth
+        ? { type: "eth" }
+        : { type: "erc20", address: (direct ? GNARS_CREATOR_COIN : ZORA_TOKEN_BASE) as Address };
       return {
-        queryKey: ["migration-quote", coin.address.toLowerCase(), coin.balance, sender, direct],
+        queryKey: ["migration-quote", coin.address.toLowerCase(), coin.balance, sender, target],
         enabled: apiKeyReady && Boolean(sender) && BigInt(coin.balance) > 0n,
         staleTime: 30_000,
         retry: false,
         queryFn: async (): Promise<CoinQuote> => {
           const params: TradeParameters = {
             sell: { type: "erc20", address: coin.address },
-            buy: { type: "erc20", address: buyAddress },
+            buy,
             amountIn: BigInt(coin.balance),
             slippage,
             sender: sender as Address,
@@ -270,18 +275,29 @@ export function useCoinQuotes(
     [results],
   );
   const isLoading = results.some((r) => r.isLoading);
-  // ZORA gathered from non-direct coins (still needs a final ZORA→$gnars hop).
+  // gnars target: ZORA gathered from non-direct coins (needs a final ZORA→$gnars hop).
   const totalZoraOut = useMemo(
-    () => quotes.reduce((sum, q) => sum + (q.routable && !q.direct ? q.out : 0n), 0n),
-    [quotes],
+    () =>
+      target === "gnars"
+        ? quotes.reduce((sum, q) => sum + (q.routable && !q.direct ? q.out : 0n), 0n)
+        : 0n,
+    [quotes, target],
   );
-  // $gnars already obtained directly from gnars-paired coins.
+  // gnars target: $gnars obtained directly from gnars-paired coins.
   const directGnarsOut = useMemo(
-    () => quotes.reduce((sum, q) => sum + (q.routable && q.direct ? q.out : 0n), 0n),
-    [quotes],
+    () =>
+      target === "gnars"
+        ? quotes.reduce((sum, q) => sum + (q.routable && q.direct ? q.out : 0n), 0n)
+        : 0n,
+    [quotes, target],
+  );
+  // eth target: total ETH out across all coins (each already yields ETH).
+  const totalEthOut = useMemo(
+    () => (target === "eth" ? quotes.reduce((sum, q) => sum + (q.routable ? q.out : 0n), 0n) : 0n),
+    [quotes, target],
   );
 
-  return { quotes, totalZoraOut, directGnarsOut, isLoading };
+  return { quotes, totalZoraOut, directGnarsOut, totalEthOut, isLoading };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds a **$GNARS / ETH** target toggle to the Consolidate tab.
- ETH target sells each coin straight to ETH (SDK routes content→creator→ZORA→ETH), no consolidation hop; quotes, execution, and step labels are target-aware.

## Why
Large/thin positions (e.g. skatehacker) can't route to the shallow $gnars pool but route fine to ETH (ZORA→ETH is deep). Verified in-app: skatehacker shows "no liquidity" to $gnars but ~0.0339 ETH to ETH.

## Test plan
- [x] tsc/eslint/prettier clean; toggle verified at runtime (render)
- [ ] Smoke-test an actual ETH swap with a small position

🤖 Generated with [Claude Code](https://claude.com/claude-code)