### PR TITLE
feat(migrate): Farcaster mini app embed

### DIFF
--- a/src/app/[locale]/migrate/miniapp-image/route.tsx
+++ b/src/app/[locale]/migrate/miniapp-image/route.tsx
@@ -1,0 +1,133 @@
+import { ImageResponse } from "next/og";
+import { MINIAPP_SIZE, OG_COLORS, OG_FONTS } from "@/lib/og-utils";
+
+export const alt = "Migrate your Zora coins into $gnars";
+export const size = MINIAPP_SIZE;
+export const contentType = "image/png";
+export const runtime = "edge";
+
+export async function GET() {
+  const logoUrl =
+    "https://wsrv.nl/?url=https%3A%2F%2Fgnars.com%2Fgnars.webp&w=180&h=180&fit=cover&output=png";
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: "100%",
+          width: "100%",
+          display: "flex",
+          flexDirection: "column",
+          backgroundColor: OG_COLORS.background,
+          fontFamily: OG_FONTS.family,
+          padding: "80px",
+          position: "relative",
+        }}
+      >
+        {/* Eyebrow */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "16px",
+            fontSize: 22,
+            fontWeight: 700,
+            letterSpacing: "0.18em",
+            textTransform: "uppercase",
+            color: OG_COLORS.muted,
+            marginBottom: "40px",
+          }}
+        >
+          <span>Migration</span>
+          <span style={{ color: OG_COLORS.cardBorder }}>·</span>
+          <span
+            style={{
+              backgroundColor: "#132044",
+              color: "#5b9cf6",
+              padding: "6px 14px",
+              borderRadius: "6px",
+              fontSize: 18,
+              letterSpacing: "0.04em",
+            }}
+          >
+            BASE
+          </span>
+        </div>
+
+        {/* Headline */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "12px",
+            marginBottom: "auto",
+          }}
+        >
+          <div
+            style={{
+              fontSize: 116,
+              fontWeight: 100,
+              color: OG_COLORS.foreground,
+              letterSpacing: "-5px",
+              lineHeight: 1,
+            }}
+          >
+            ZORA COINS → GNARS
+          </div>
+          <div
+            style={{
+              fontSize: 32,
+              color: OG_COLORS.muted,
+              maxWidth: "920px",
+              lineHeight: 1.3,
+              marginTop: "12px",
+            }}
+          >
+            Consolidate your scattered Zora coins into $gnars — one token, deeper liquidity.
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            paddingTop: "24px",
+            borderTop: `1px solid ${OG_COLORS.cardBorder}`,
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: "16px" }}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={logoUrl}
+              alt="Gnars"
+              width={56}
+              height={56}
+              style={{ width: 56, height: 56, objectFit: "cover" }}
+            />
+            <div
+              style={{
+                fontSize: 28,
+                fontWeight: 700,
+                color: OG_COLORS.foreground,
+              }}
+            >
+              gnars.com / migrate
+            </div>
+          </div>
+          <div
+            style={{
+              fontSize: 20,
+              color: OG_COLORS.muted,
+              letterSpacing: "0.04em",
+            }}
+          >
+            Powered by Zora
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/src/app/[locale]/migrate/page.tsx
+++ b/src/app/[locale]/migrate/page.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { BASE_URL } from "@/lib/config";
+import { MIGRATE_MINIAPP_EMBED_CONFIG } from "@/lib/miniapp-config";
 import { MigrateTabs } from "./MigrateTabs";
+
+const miniappImage = `${BASE_URL}/migrate/miniapp-image`;
 
 export async function generateMetadata({
   params,
@@ -26,9 +29,22 @@ export async function generateMetadata({
     openGraph: {
       title: t("title"),
       description: t("description"),
+      images: [miniappImage],
       url: `${BASE_URL}/migrate`,
       type: "website",
       locale: locale === "pt-br" ? "pt_BR" : "en_US",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: t("title"),
+      description: t("description"),
+      images: [miniappImage],
+    },
+    // Farcaster mini app embed metadata — a cast linking to /migrate renders
+    // the migration cover + a "Migrate to $gnars" launch button. The global
+    // MiniAppReady (in [locale]/layout.tsx) handles sdk.actions.ready().
+    other: {
+      "fc:miniapp": JSON.stringify(MIGRATE_MINIAPP_EMBED_CONFIG),
     },
   };
 }

--- a/src/lib/miniapp-config.ts
+++ b/src/lib/miniapp-config.ts
@@ -316,3 +316,22 @@ export const SWAP_MINIAPP_EMBED_CONFIG = {
     },
   },
 };
+
+/**
+ * Embed metadata for the Gnars Migration mini app (`/migrate`).
+ * Lets a cast that links to /migrate render a "Migrate to $gnars" launch button.
+ */
+export const MIGRATE_MINIAPP_EMBED_CONFIG = {
+  version: "1",
+  imageUrl: `${BASE_URL}/migrate/miniapp-image`,
+  button: {
+    title: "Migrate to $gnars",
+    action: {
+      type: "launch_miniapp" as const,
+      name: "Gnars Migration",
+      url: `${BASE_URL}/migrate`,
+      splashImageUrl: `${BASE_URL}/gnars-splash-200.png`,
+      splashBackgroundColor: "#000000",
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- Makes `/migrate` shareable/launchable as a **Farcaster mini app**.
- Adds `MIGRATE_MINIAPP_EMBED_CONFIG` + `fc:miniapp` meta on the migrate page (button: "Migrate to \$gnars", launches `/migrate`).
- New `/migrate/miniapp-image` OG cover route (ZORA COINS → GNARS), mirroring `/swap`.
- `sdk.actions.ready()` is already handled globally by `MiniAppReady` in `[locale]/layout.tsx`.

## Test plan
- [x] tsc/eslint/prettier clean
- [x] `fc:miniapp` meta present on `/en/migrate`; `/migrate/miniapp-image` returns 200 image/png and renders correctly
- [ ] Validate embed in Farcaster (base.dev preview / cast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)