### PR TITLE
chore(nav): unlist /create-coin during migration + campaign copy

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -39,6 +39,7 @@ This is the canonical entry point for project documentation. Everything below sh
 - `docs/strategy/gnars-migration-decisions.md` — Decision checklist (7 areas) to review with Vlad before any proposal or technical work
 - `docs/strategy/gnars-migration-implementation.md` — `/migrate` build state + verified on-chain facts (Upgrader contract, Zora V4 routing, WETH pairing, temp multisig, open team asks)
 - `docs/strategy/gnars-migration-handoff.md` — handoff for the Upgrader team to review/complete the gnars.com side (run steps, file map, what's built vs pending, coordination items)
+- `docs/strategy/gnars-migration-campaign-copy.md` — ready-to-post Farcaster cast copy for the `/migrate` mini app
 
 ## Specs
 

--- a/docs/strategy/gnars-migration-campaign-copy.md
+++ b/docs/strategy/gnars-migration-campaign-copy.md
@@ -1,0 +1,42 @@
+# Gnars Migration — campaign cast copy
+
+Ready-to-post Farcaster copy for the `/migrate` mini app. On Farcaster, **paste the URL**
+(`https://gnars.com/migrate`) — the mini-app embed (cover + "Migrate to $gnars" button) renders
+automatically. Don't attach the cover image manually.
+
+Before casting: validate the embed at base.dev/preview (paste the URL), and confirm the site has
+deployed the mini-app changes. `/migrate` stays unlisted in the nav — the cast is how people find it.
+
+## Primary launch cast
+
+> gm gnars 🛹
+>
+> got Zora coins scattered across a dozen dead pools? bring them home.
+>
+> the migration hub is live — consolidate your creator + content coins into **$gnars**, or grab
+> $gnars ahead of the upgrade to new gnars. one token, one community.
+>
+> ⌐◨-◨
+>
+> https://gnars.com/migrate
+
+## Punchy one-liner (alt)
+
+> Sweep your scattered Zora dust into $gnars. 🛹 The migration hub is live ⌐◨-◨
+>
+> https://gnars.com/migrate
+
+## Thread version (bigger push)
+
+1. gnars is consolidating. 🛹 instead of value scattered across dozens of creator + content coins
+   nobody trades, we're bringing it into one token the whole community backs: **$gnars**.
+2. step one is live: a migration hub that sweeps your Zora coins into $gnars (or into ETH, if a coin's
+   pool is too thin to route). it uses Zora's own router — so it works where Matcha/0x can't touch
+   these V4 pools.
+3. get into $gnars now, and you're set for the upgrade to new gnars on Clanker. tap in ⌐◨-◨
+   https://gnars.com/migrate
+
+## Tone guardrail
+
+Frame it as **consolidation into one strong token**, not a pump play — that's honest, it ages well,
+and it's what actually builds the token. Avoid promising price gains in copy or replies.

--- a/src/components/layout/DaoHeader.tsx
+++ b/src/components/layout/DaoHeader.tsx
@@ -25,7 +25,6 @@ import Image from "next/image";
 import {
   ArrowLeftRight,
   BookOpen,
-  Coins,
   Gavel,
   Gift,
   Home,
@@ -206,13 +205,17 @@ function buildNavigationItems(t: NavTranslations) {
           description: t("items.community.droposals.description"),
           badge: "NEW!",
         },
-        {
-          title: t("items.community.createCoin.title"),
-          href: "/create-coin",
-          icon: Coins,
-          description: t("items.community.createCoin.description"),
-          badge: "NEW!",
-        },
+        // NOTE: /create-coin is intentionally unlisted during the $gnars
+        // migration — we don't want new Zora content coins spun up while we're
+        // consolidating into one token. The route still exists (reachable by
+        // URL); re-add this entry once the migration is complete.
+        // {
+        //   title: t("items.community.createCoin.title"),
+        //   href: "/create-coin",
+        //   icon: Coins,
+        //   description: t("items.community.createCoin.description"),
+        //   badge: "NEW!",
+        // },
       ],
     },
   ] as const;


### PR DESCRIPTION
## Summary
- Unlists **/create-coin** from the navbar during the $gnars migration (route still reachable by URL) so no new Zora content coins are created while consolidating. Re-add the entry post-migration.
- Adds `docs/strategy/gnars-migration-campaign-copy.md` — ready-to-post Farcaster cast copy for the `/migrate` mini app.

## Test plan
- [x] eslint/tsc/prettier clean (removed now-unused `Coins` import)
- [x] `/create-coin` no longer in nav; route still returns 200 by direct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)