### PR TITLE
feat(migrate): quote-verified Smart Select

### DIFF
--- a/messages/en/migrate.json
+++ b/messages/en/migrate.json
@@ -69,5 +69,14 @@
   "editorial": {
     "tagline": "One token, deeper liquidity",
     "body": "Every Zora coin you migrate is consolidated into $gnars. The result: fragmented dust becomes concentrated, healthier $gnars liquidity."
+  },
+  "smart": {
+    "button": "Smart Select ✨",
+    "title": "Smart migration plan",
+    "hint": "We quote every coin and route each to its best destination — $gnars where it routes, ETH otherwise, and we skip coins with no route.",
+    "toGnars": "To $GNARS",
+    "toEth": "To ETH",
+    "skipped": "Skipped (no route)",
+    "migrateCta": "Migrate {count} coins"
   }
 }

--- a/messages/pt-br/migrate.json
+++ b/messages/pt-br/migrate.json
@@ -69,5 +69,14 @@
   "editorial": {
     "tagline": "Um token, mais liquidez",
     "body": "Cada coin da Zora que você migra é consolidada em $gnars. O resultado: poeira fragmentada vira liquidez concentrada e mais saudável em $gnars."
+  },
+  "smart": {
+    "button": "Seleção inteligente ✨",
+    "title": "Plano de migração inteligente",
+    "hint": "Cotamos cada coin e roteamos para o melhor destino — $gnars quando há rota, ETH caso contrário, e ignoramos as coins sem rota.",
+    "toGnars": "Para $GNARS",
+    "toEth": "Para ETH",
+    "skipped": "Ignoradas (sem rota)",
+    "migrateCta": "Migrar {count} coins"
   }
 }

--- a/src/app/[locale]/migrate/MigrationWidget.tsx
+++ b/src/app/[locale]/migrate/MigrationWidget.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { useTranslations } from "next-intl";
-import { ArrowDown, Check, ChevronRight, ShieldCheck, X } from "lucide-react";
+import { ArrowDown, Check, ChevronRight, ShieldCheck, Sparkles, X } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -11,13 +11,18 @@ import { ConnectButton } from "@/components/ui/ConnectButton";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
-import { useExecuteMigration, type MigrationStep } from "@/hooks/use-execute-migration";
+import {
+  useExecuteMigration,
+  type CoinToMigrate,
+  type MigrationStep,
+} from "@/hooks/use-execute-migration";
 import {
   buildRoute,
   formatCoinAmount,
   useCoinQuotes,
   useGnarsOutputQuote,
   useMigratableCoins,
+  useSmartPlan,
   type MigratableCoin,
   type MigrationTarget,
   type RouteHop,
@@ -32,6 +37,7 @@ export function MigrationWidget() {
   // Selection is keyed by lowercase address.
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [target, setTarget] = React.useState<MigrationTarget>("gnars");
+  const [smartMode, setSmartMode] = React.useState(false);
 
   const selectedCoins = React.useMemo(
     () => coins.filter((c) => selected.has(c.address.toLowerCase())),
@@ -61,27 +67,141 @@ export function MigrationWidget() {
 
   return (
     <div className="space-y-6">
-      <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
-        <ShieldCheck className="size-3.5 shrink-0" />
-        {t("safetyHint")}
-      </p>
-      <HoldingsList
-        coins={coins}
-        isLoading={isLoading}
-        selected={selected}
-        onToggle={toggle}
-        onSelectAll={selectAll}
-        onClearAll={clearAll}
-      />
-      {selectedCoins.length > 0 && <RouteMap coins={selectedCoins} />}
-      {selectedCoins.length > 0 && (
-        <MigrationPreview
-          coins={selectedCoins}
-          sender={address}
-          target={target}
-          onTargetChange={setTarget}
-        />
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <ShieldCheck className="size-3.5 shrink-0" />
+          {t("safetyHint")}
+        </p>
+        {coins.length > 0 && (
+          <Button
+            variant={smartMode ? "default" : "outline"}
+            size="sm"
+            className="gap-1.5"
+            onClick={() => setSmartMode((m) => !m)}
+          >
+            <Sparkles className="size-4" />
+            {t("smart.button")}
+          </Button>
+        )}
+      </div>
+
+      {smartMode ? (
+        <SmartMigratePanel coins={coins} sender={address} />
+      ) : (
+        <>
+          <HoldingsList
+            coins={coins}
+            isLoading={isLoading}
+            selected={selected}
+            onToggle={toggle}
+            onSelectAll={selectAll}
+            onClearAll={clearAll}
+          />
+          {selectedCoins.length > 0 && <RouteMap coins={selectedCoins} />}
+          {selectedCoins.length > 0 && (
+            <MigrationPreview
+              coins={selectedCoins}
+              sender={address}
+              target={target}
+              onTargetChange={setTarget}
+            />
+          )}
+        </>
       )}
+    </div>
+  );
+}
+
+/**
+ * Quote-verified Smart Select: quotes every coin and routes each to its best
+ * destination ($gnars where it routes, ETH otherwise, skip if neither), then
+ * migrates them as one mixed batch with per-coin targets.
+ */
+function SmartMigratePanel({
+  coins,
+  sender,
+}: {
+  coins: MigratableCoin[];
+  sender: string | undefined;
+}) {
+  const t = useTranslations("migrate");
+  const { assignments, isLoading } = useSmartPlan(coins, sender);
+  const { execute, isRunning, steps } = useExecuteMigration();
+
+  const byAddr = new Map(coins.map((c) => [c.address.toLowerCase(), c]));
+  const toGnars = assignments.filter((a) => a.target === "gnars");
+  const toEth = assignments.filter((a) => a.target === "eth");
+  const skipped = assignments.filter((a) => !a.target);
+  const gnarsOut = toGnars.reduce((s, a) => s + a.out, 0n);
+  const ethOut = toEth.reduce((s, a) => s + a.out, 0n);
+
+  const migrateCoins: CoinToMigrate[] = [];
+  for (const a of [...toGnars, ...toEth]) {
+    const c = byAddr.get(a.address.toLowerCase());
+    if (!c || !a.target) continue;
+    migrateCoins.push({
+      address: c.address,
+      symbol: c.symbol,
+      balance: c.balance,
+      pairedWith: c.pairedWith?.address ?? null,
+      target: a.target,
+    });
+  }
+
+  return (
+    <Card className="space-y-4 p-5">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium">{t("smart.title")}</span>
+        {isLoading && <Spinner className="size-4" />}
+      </div>
+      <p className="text-xs text-muted-foreground">{t("smart.hint")}</p>
+
+      <div className="space-y-2 text-sm">
+        <SmartRow
+          label={t("smart.toGnars")}
+          count={toGnars.length}
+          amount={`${formatCoinAmount(gnarsOut)} $GNARS`}
+        />
+        <SmartRow
+          label={t("smart.toEth")}
+          count={toEth.length}
+          amount={`${formatCoinAmount(ethOut, 18, 6)} ETH`}
+        />
+        {skipped.length > 0 && <SmartRow label={t("smart.skipped")} count={skipped.length} muted />}
+      </div>
+
+      {steps.length > 0 && <StepList steps={steps} />}
+
+      <Button
+        className="w-full"
+        size="lg"
+        disabled={isLoading || isRunning || migrateCoins.length === 0}
+        onClick={() => execute(migrateCoins)}
+      >
+        {isRunning ? t("preview.executing") : t("smart.migrateCta", { count: migrateCoins.length })}
+      </Button>
+      <p className="text-center text-[11px] text-muted-foreground">{t("preview.executionNote")}</p>
+    </Card>
+  );
+}
+
+function SmartRow({
+  label,
+  count,
+  amount,
+  muted,
+}: {
+  label: string;
+  count: number;
+  amount?: string;
+  muted?: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between">
+      <span className={muted ? "text-muted-foreground" : ""}>
+        {label} · {count}
+      </span>
+      {amount && <span className="text-muted-foreground">{amount}</span>}
     </div>
   );
 }

--- a/src/hooks/use-execute-migration.ts
+++ b/src/hooks/use-execute-migration.ts
@@ -41,6 +41,12 @@ export interface CoinToMigrate {
   balance: string;
   /** Pool pairing address — used to pick the route (direct to $gnars vs via ZORA). */
   pairedWith: string | null;
+  /**
+   * Per-coin target. When set (Smart Select), this coin routes to its own
+   * target regardless of the batch default — enabling a mixed batch where some
+   * coins go to $gnars and others to ETH. Falls back to the batch `target`.
+   */
+  target?: MigrationTarget;
 }
 
 export type StepStatus = "pending" | "active" | "done" | "failed";
@@ -78,20 +84,19 @@ export function useExecuteMigration() {
 
     setIsRunning(true);
 
-    const toEth = target === "eth";
-    // Route per coin. ETH target: every coin sells straight to ETH (the SDK
-    // routes content→creator→ZORA→ETH), no consolidation hop. $gnars target:
-    // gnars-paired coins go straight to $gnars (one hop); the rest go to ZORA,
-    // then a single consolidated ZORA→$gnars hop.
-    const plan = coins.map((c) => ({
-      coin: c,
-      direct: !toEth && c.pairedWith?.toLowerCase() === GNARS_LOWER,
-    }));
-    const hasViaZora = !toEth && plan.some((p) => !p.direct);
+    // Route per coin using its own target (Smart Select) or the batch default.
+    // ETH: coin sells straight to ETH (SDK routes content→creator→ZORA→ETH), no
+    // consolidation hop. $gnars: gnars-paired coins go straight to $gnars (one
+    // hop); the rest go to ZORA, then a single consolidated ZORA→$gnars hop.
+    const plan = coins.map((c) => {
+      const toEth = (c.target ?? target) === "eth";
+      return { coin: c, toEth, direct: !toEth && c.pairedWith?.toLowerCase() === GNARS_LOWER };
+    });
+    const hasViaZora = plan.some((p) => !p.toEth && !p.direct);
 
     const initial: MigrationStep[] = [
       ...plan.map((p) => ({
-        label: `${p.coin.symbol} → ${toEth ? "ETH" : p.direct ? "$GNARS" : "ZORA"}`,
+        label: `${p.coin.symbol} → ${p.toEth ? "ETH" : p.direct ? "$GNARS" : "ZORA"}`,
         status: "pending" as StepStatus,
       })),
       ...(hasViaZora ? [{ label: "ZORA → $GNARS", status: "pending" as StepStatus }] : []),
@@ -128,7 +133,9 @@ export function useExecuteMigration() {
       }
     };
 
-    const targetLabel = toEth ? "ETH" : "$gnars";
+    const allEth = plan.every((p) => p.toEth);
+    const allGnars = plan.every((p) => !p.toEth);
+    const targetLabel = allEth ? "ETH" : allGnars ? "$gnars" : "$gnars + ETH";
     const toastId = toast.loading(`Migrating into ${targetLabel}…`);
     try {
       const zoraBefore = hasViaZora ? await readZora() : 0n;
@@ -139,7 +146,7 @@ export function useExecuteMigration() {
       for (let i = 0; i < plan.length; i++) {
         setStatus(i, "active");
         try {
-          const buy: TradeParameters["buy"] = toEth
+          const buy: TradeParameters["buy"] = plan[i].toEth
             ? { type: "eth" }
             : {
                 type: "erc20",
@@ -158,7 +165,7 @@ export function useExecuteMigration() {
             publicClient,
           });
           setStatus(i, "done");
-          if (toEth || plan[i].direct) anyTerminalDone = true;
+          if (plan[i].toEth || plan[i].direct) anyTerminalDone = true;
           else anyViaZoraSold = true;
         } catch (err) {
           console.error(`[migration] swap failed for ${plan[i].coin.symbol}`, err);

--- a/src/hooks/use-gnars-migration.ts
+++ b/src/hooks/use-gnars-migration.ts
@@ -344,6 +344,69 @@ export function useGnarsOutputQuote(
   };
 }
 
+/** A Smart Select assignment: the target chosen for a coin (or null = skip). */
+export interface SmartAssignment {
+  address: Address;
+  /** null when neither $gnars nor ETH has a route (dead/dust) → skip. */
+  target: MigrationTarget | null;
+  /** Estimated output (raw 18dp) in the chosen target's units. */
+  out: bigint;
+}
+
+/**
+ * Quote-verified Smart Select: for each coin, decide the best target by actually
+ * quoting it.
+ *   - gnars-paired coin → verify a route to $gnars; if it routes, target $gnars;
+ *     otherwise fall back to ETH.
+ *   - everything else → target ETH (verified routable), which avoids the thin
+ *     $gnars pool. If neither routes → skip.
+ * gnars-assigned coins are always gnars-paired, so execution sends them straight
+ * to $gnars (no thin-pool ZORA→$gnars hop).
+ */
+export function useSmartPlan(coins: MigratableCoin[], sender: string | undefined, slippage = 0.15) {
+  const results = useQueries({
+    queries: coins.map((coin) => ({
+      queryKey: ["smart-plan", coin.address.toLowerCase(), coin.balance, sender],
+      enabled: apiKeyReady && Boolean(sender) && BigInt(coin.balance) > 0n,
+      staleTime: 30_000,
+      retry: false,
+      queryFn: async (): Promise<SmartAssignment> => {
+        const amountIn = BigInt(coin.balance);
+        const quote = async (buy: TradeParameters["buy"]): Promise<bigint | null> => {
+          try {
+            const r = await createTradeCall({
+              sell: { type: "erc20", address: coin.address },
+              buy,
+              amountIn,
+              slippage,
+              sender: sender as Address,
+            });
+            return r?.success && r.quote?.amountOut ? BigInt(r.quote.amountOut) : null;
+          } catch {
+            return null;
+          }
+        };
+        // gnars-paired coins: verify the one-hop $gnars route first.
+        if (isGnarsPaired(coin)) {
+          const g = await quote({ type: "erc20", address: GNARS_CREATOR_COIN as Address });
+          if (g !== null) return { address: coin.address, target: "gnars", out: g };
+        }
+        // Otherwise (or if the $gnars route failed): route to ETH if it exists.
+        const e = await quote({ type: "eth" });
+        if (e !== null) return { address: coin.address, target: "eth", out: e };
+        return { address: coin.address, target: null, out: 0n };
+      },
+    })),
+  });
+
+  const assignments = useMemo(
+    () => results.map((r) => r.data).filter((a): a is SmartAssignment => Boolean(a)),
+    [results],
+  );
+  const isLoading = results.some((r) => r.isLoading);
+  return { assignments, isLoading };
+}
+
 /** Format a raw 18-decimal amount for display (trims to a sane precision). */
 export function formatCoinAmount(raw: bigint, decimals = 18, maxFrac = 4): string {
   const s = formatUnits(raw, decimals);


### PR DESCRIPTION
Adds Smart Select: quotes every coin and routes each to its best target ($gnars where it routes, ETH otherwise, skip if neither), migrated as one mixed per-coin-target batch. Verified in-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)