### PR TITLE
feat(migrate): Smart Select per-coin breakdown + reasons

### DIFF
--- a/messages/en/migrate.json
+++ b/messages/en/migrate.json
@@ -77,6 +77,14 @@
     "toGnars": "To $GNARS",
     "toEth": "To ETH",
     "skipped": "Skipped (no route)",
-    "migrateCta": "Migrate {count} coins"
+    "migrateCta": "Migrate {count} coins",
+    "checking": "Checking…",
+    "noRoute": "No route",
+    "reason": {
+      "gnars": "paired with $gnars",
+      "eth-not-paired": "not $gnars-paired → cleaner via ETH",
+      "eth-fallback": "$gnars pool too thin → ETH",
+      "none": "no route"
+    }
   }
 }

--- a/messages/pt-br/migrate.json
+++ b/messages/pt-br/migrate.json
@@ -77,6 +77,14 @@
     "toGnars": "Para $GNARS",
     "toEth": "Para ETH",
     "skipped": "Ignoradas (sem rota)",
-    "migrateCta": "Migrar {count} coins"
+    "migrateCta": "Migrar {count} coins",
+    "checking": "Verificando…",
+    "noRoute": "Sem rota",
+    "reason": {
+      "gnars": "pareada com $gnars",
+      "eth-not-paired": "não pareada com $gnars → melhor via ETH",
+      "eth-fallback": "pool de $gnars raso demais → ETH",
+      "none": "sem rota"
+    }
   }
 }

--- a/src/app/[locale]/migrate/MigrationWidget.tsx
+++ b/src/app/[locale]/migrate/MigrationWidget.tsx
@@ -129,6 +129,7 @@ function SmartMigratePanel({
   const { execute, isRunning, steps } = useExecuteMigration();
 
   const byAddr = new Map(coins.map((c) => [c.address.toLowerCase(), c]));
+  const assignByAddr = new Map(assignments.map((a) => [a.address.toLowerCase(), a]));
   const toGnars = assignments.filter((a) => a.target === "gnars");
   const toEth = assignments.filter((a) => a.target === "eth");
   const skipped = assignments.filter((a) => !a.target);
@@ -155,6 +156,55 @@ function SmartMigratePanel({
         {isLoading && <Spinner className="size-4" />}
       </div>
       <p className="text-xs text-muted-foreground">{t("smart.hint")}</p>
+
+      {/* Per-coin breakdown — every coin stays visible with its verdict. */}
+      <ul className="max-h-[360px] divide-y overflow-y-auto rounded-lg border">
+        {coins.map((coin) => {
+          const a = assignByAddr.get(coin.address.toLowerCase());
+          return (
+            <li key={coin.address} className="flex items-center gap-3 p-3">
+              <CoinAvatar src={coin.logoUrl} symbol={coin.symbol} />
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-sm font-medium">{coin.symbol}</div>
+                <div className="truncate text-xs text-muted-foreground">
+                  {formatCoinAmount(BigInt(coin.balance), coin.decimals)} {coin.symbol}
+                </div>
+              </div>
+              <div className="shrink-0 text-right">
+                {!a ? (
+                  <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                    <Spinner className="size-3" /> {t("smart.checking")}
+                  </span>
+                ) : a.target === "gnars" ? (
+                  <>
+                    <Badge className="bg-primary/15 text-primary">→ $GNARS</Badge>
+                    <div className="mt-0.5 text-xs text-muted-foreground">
+                      ≈ {formatCoinAmount(a.out)}
+                    </div>
+                    <div className="text-[10px] text-muted-foreground/80">
+                      {t(`smart.reason.${a.reason}`)}
+                    </div>
+                  </>
+                ) : a.target === "eth" ? (
+                  <>
+                    <Badge variant="secondary">→ ETH</Badge>
+                    <div className="mt-0.5 text-xs text-muted-foreground">
+                      ≈ {formatCoinAmount(a.out, 18, 6)}
+                    </div>
+                    <div className="text-[10px] text-muted-foreground/80">
+                      {t(`smart.reason.${a.reason}`)}
+                    </div>
+                  </>
+                ) : (
+                  <span className="text-xs text-muted-foreground">{t("smart.noRoute")}</span>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+
+      <Separator />
 
       <div className="space-y-2 text-sm">
         <SmartRow

--- a/src/hooks/use-gnars-migration.ts
+++ b/src/hooks/use-gnars-migration.ts
@@ -10,8 +10,8 @@
  *   each coin ──tradeCoin──▶ ZORA   (V4 hooks auto-route content → creator → ZORA)
  *   Σ ZORA    ──tradeCoin──▶ $gnars (supported creator-coin ⇄ ZORA trade)
  *
- * A small % of the output $gnars is burned on every migration (see
- * MIGRATION_BURN_BPS) — buy-and-burn to tighten $gnars supply.
+ * Users can also target ETH instead of $gnars, and Smart Select quote-verifies
+ * the best target per coin.
  *
  * This hook only READS and QUOTES. Execution lives in use-execute-migration.ts.
  */
@@ -344,6 +344,13 @@ export function useGnarsOutputQuote(
   };
 }
 
+/** Why Smart Select chose a coin's target — surfaced in the UI. */
+export type SmartReason =
+  | "gnars" // gnars-paired: routes to $gnars in one clean hop
+  | "eth-not-paired" // not gnars-paired: ETH avoids the thin $gnars pool
+  | "eth-fallback" // gnars-paired but the $gnars route failed → ETH
+  | "none"; // no route to either → skipped
+
 /** A Smart Select assignment: the target chosen for a coin (or null = skip). */
 export interface SmartAssignment {
   address: Address;
@@ -351,6 +358,8 @@ export interface SmartAssignment {
   target: MigrationTarget | null;
   /** Estimated output (raw 18dp) in the chosen target's units. */
   out: bigint;
+  /** Why this target was chosen. */
+  reason: SmartReason;
 }
 
 /**
@@ -389,12 +398,19 @@ export function useSmartPlan(coins: MigratableCoin[], sender: string | undefined
         // gnars-paired coins: verify the one-hop $gnars route first.
         if (isGnarsPaired(coin)) {
           const g = await quote({ type: "erc20", address: GNARS_CREATOR_COIN as Address });
-          if (g !== null) return { address: coin.address, target: "gnars", out: g };
+          if (g !== null)
+            return { address: coin.address, target: "gnars", out: g, reason: "gnars" };
+          // Paired with $gnars but the route failed (e.g. pool too thin for the size) → ETH.
+          const e = await quote({ type: "eth" });
+          if (e !== null)
+            return { address: coin.address, target: "eth", out: e, reason: "eth-fallback" };
+          return { address: coin.address, target: null, out: 0n, reason: "none" };
         }
-        // Otherwise (or if the $gnars route failed): route to ETH if it exists.
+        // Not gnars-paired: ETH avoids routing into the thin $gnars pool.
         const e = await quote({ type: "eth" });
-        if (e !== null) return { address: coin.address, target: "eth", out: e };
-        return { address: coin.address, target: null, out: 0n };
+        if (e !== null)
+          return { address: coin.address, target: "eth", out: e, reason: "eth-not-paired" };
+        return { address: coin.address, target: null, out: 0n, reason: "none" };
       },
     })),
   });


### PR DESCRIPTION
Smart Select now shows every coin with its target, estimated output, and the reason for the decision — instead of collapsing to counts. Makes the $gnars-vs-ETH routing transparent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)