### PR TITLE
feat(migrate): clearer Guide tab — explain the ETH presale

### DIFF
--- a/messages/en/migrate.json
+++ b/messages/en/migrate.json
@@ -17,27 +17,27 @@
     "slippageNote": "The $gnars pool is thin, so larger buys move the price. Start small and check the amount you receive."
   },
   "guide": {
-    "title": "How to migrate into $gnars",
-    "intro": "The plan: get everyone into old $gnars before the upgrade, then the upgrade portal is simply old $gnars in, new $gnars out.",
+    "title": "How the $gnars migration works",
+    "intro": "There are two ways to take part — convert your Zora coins into $gnars, or bring fresh ETH to the launch. Both get you into the new $gnars when the DAO runs the upgrade.",
     "steps": [
       {
-        "title": "Convert your Zora coins",
-        "body": "Use the Consolidate tab to swap your Zora content/creator coins into old $gnars, or the Get $GNARS tab to buy in with ETH."
+        "title": "Choose how you join",
+        "body": "Convert your Zora coins into old $gnars (Consolidate tab), buy in with ETH (Get $GNARS tab), or set ETH aside to contribute directly at launch. Fresh ETH is the strongest contribution — it becomes real liquidity backing the new token, which scattered coins can't provide."
       },
       {
-        "title": "Hold old $gnars",
-        "body": "Old $gnars is the Zora creator coin at 0x0cf0…b23b. Holding it is your ticket into the upgrade."
+        "title": "Deposit when the upgrade opens",
+        "body": "When the DAO opens the upgrade, deposit your old $gnars and/or ETH into the portal (it will appear right here). There's no fixed on-chain deadline — watch the official Gnars channels for the date."
       },
       {
-        "title": "Deposit in the upgrade portal",
-        "body": "When the deposit period opens, deposit your old $gnars into the Upgrader. Watch the DAO's channels for the exact date and link."
+        "title": "The upgrade runs — one shared price",
+        "body": "In a single transaction, all deposits are sold, the new $gnars is deployed on Clanker (paired with ETH), and everyone buys in at the same snipe-proof price. Your ETH is what puts real liquidity into the new pool."
       },
       {
-        "title": "Claim new $gnars",
-        "body": "After the upgrade runs, claim your new $gnars on Clanker — allocated proportionally to your share. That's the token going forward."
+        "title": "Claim your new $gnars",
+        "body": "After the upgrade runs, claim your new $gnars — allocated proportionally to what you contributed. That's the token going forward: ETH ↔ $gnars ↔ content coins."
       }
     ],
-    "footnote": "Amounts you receive depend on live liquidity and can change. Only migrate what you're comfortable with, and always verify links in official Gnars channels."
+    "footnote": "The ETH presale is what gives the new token real backing — migrating dust is optional and mostly symbolic. Amounts depend on live liquidity and can change; only contribute what you're comfortable with, and always verify links in official Gnars channels."
   },
   "noCoins": "No migratable Zora coins found in this wallet.",
   "safetyHint": "Only verified Zora coins are shown — non-Zora and scam/airdrop tokens are filtered out.",

--- a/messages/pt-br/migrate.json
+++ b/messages/pt-br/migrate.json
@@ -17,27 +17,27 @@
     "slippageNote": "O pool de $gnars é raso, então compras maiores movem o preço. Comece pequeno e confira quanto você recebe."
   },
   "guide": {
-    "title": "Como migrar para $gnars",
-    "intro": "O plano: colocar todos no $gnars antigo antes do upgrade; então o portal de upgrade é simplesmente $gnars antigo entra, $gnars novo sai.",
+    "title": "Como funciona a migração do $gnars",
+    "intro": "Há duas formas de participar — converter suas coins da Zora em $gnars, ou trazer ETH novo para o lançamento. As duas te colocam no novo $gnars quando a DAO rodar o upgrade.",
     "steps": [
       {
-        "title": "Converta suas coins da Zora",
-        "body": "Use a aba Consolidar para trocar suas content/creator coins da Zora por $gnars antigo, ou a aba Obter $GNARS para entrar com ETH."
+        "title": "Escolha como participar",
+        "body": "Converta suas coins da Zora em $gnars antigo (aba Consolidar), compre com ETH (aba Obter $GNARS), ou separe ETH para contribuir direto no lançamento. ETH novo é a contribuição mais forte — vira liquidez real que sustenta o novo token, algo que coins espalhadas não conseguem."
       },
       {
-        "title": "Segure o $gnars antigo",
-        "body": "O $gnars antigo é a creator coin da Zora em 0x0cf0…b23b. Segurá-lo é seu ingresso para o upgrade."
+        "title": "Deposite quando o upgrade abrir",
+        "body": "Quando a DAO abrir o upgrade, deposite seu $gnars antigo e/ou ETH no portal (ele vai aparecer aqui). Não há prazo fixo on-chain — acompanhe os canais oficiais da Gnars para a data."
       },
       {
-        "title": "Deposite no portal de upgrade",
-        "body": "Quando o período de depósito abrir, deposite seu $gnars antigo no Upgrader. Acompanhe os canais da DAO para a data e o link exatos."
+        "title": "O upgrade roda — um preço único",
+        "body": "Em uma única transação, todos os depósitos são vendidos, o novo $gnars é lançado na Clanker (pareado com ETH), e todos entram pelo mesmo preço à prova de sniper. Seu ETH é o que coloca liquidez real no novo pool."
       },
       {
-        "title": "Resgate o novo $gnars",
-        "body": "Após o upgrade rodar, resgate seu novo $gnars na Clanker — alocado proporcionalmente à sua parte. Esse é o token daqui pra frente."
+        "title": "Resgate seu novo $gnars",
+        "body": "Depois que o upgrade rodar, resgate seu novo $gnars — alocado proporcionalmente ao que você contribuiu. Esse é o token daqui pra frente: ETH ↔ $gnars ↔ content coins."
       }
     ],
-    "footnote": "Os valores recebidos dependem da liquidez ao vivo e podem mudar. Migre apenas o que você se sentir confortável e sempre verifique os links nos canais oficiais da Gnars."
+    "footnote": "O pré-venda em ETH é o que dá lastro real ao novo token — migrar poeira é opcional e mais simbólico. Os valores dependem da liquidez ao vivo e podem mudar; contribua só com o que se sentir confortável e sempre verifique os links nos canais oficiais da Gnars."
   },
   "noCoins": "Nenhuma coin da Zora migrável encontrada nesta carteira.",
   "safetyHint": "Apenas coins da Zora verificadas são exibidas — tokens não-Zora e de golpe/airdrop são filtrados.",


### PR DESCRIPTION
Rewrites the Guide tab to explain the migration flow + ETH presale clearly: two ways to join (convert coins or bring ETH), deposit → one-shared-price launch → claim, and that ETH is what backs the new token. EN + PT-BR. Verified rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)