### PR TITLE
fix(stake): correct factory event ABIs so vault deploy completes

### DIFF
--- a/src/components/stake/StakeAdminPanel.tsx
+++ b/src/components/stake/StakeAdminPanel.tsx
@@ -111,7 +111,9 @@ export function StakeAdminPanel() {
                 )}
               </div>
 
-              {busy && phase === "error" && error && <p className="mt-2 text-xs text-destructive">{error}</p>}
+              {activeId === r.id && phase === "error" && error && (
+                <p className="mt-2 text-xs text-destructive">{error}</p>
+              )}
 
               {done && (
                 <div className="mt-2 space-y-0.5 font-mono text-[11px] text-muted-foreground">

--- a/src/hooks/use-deploy-sponsorship-vault.ts
+++ b/src/hooks/use-deploy-sponsorship-vault.ts
@@ -90,7 +90,7 @@ export function useDeploySponsorshipVault() {
         hash = (await sendTransaction({ account, transaction: tx })).transactionHash;
         receipt = await waitForReceipt({ client, chain: base, transactionHash: hash });
         const vault = parseEventLogs({ abi: vaultFactoryAbi, eventName: "CreateVaultV2", logs: receipt.logs })[0]
-          ?.args.vaultV2 as Address | undefined;
+          ?.args.newVaultV2 as Address | undefined;
         if (!vault) throw new Error("Não achei o endereço do vault no recibo.");
 
         // 3. adapter -------------------------------------------------------

--- a/src/lib/sponsorship-vaults.ts
+++ b/src/lib/sponsorship-vaults.ts
@@ -49,11 +49,12 @@ export const vaultFactoryAbi = [{
   inputs: [{ name: "owner", type: "address" }, { name: "asset", type: "address" }, { name: "salt", type: "bytes32" }],
   outputs: [{ type: "address" }],
 }, {
+  // On-chain signature: owner/asset/newVaultV2 are all indexed.
   type: "event", name: "CreateVaultV2", inputs: [
-    { name: "owner", type: "address", indexed: false },
-    { name: "asset", type: "address", indexed: false },
+    { name: "owner", type: "address", indexed: true },
+    { name: "asset", type: "address", indexed: true },
     { name: "salt", type: "bytes32", indexed: false },
-    { name: "vaultV2", type: "address", indexed: false },
+    { name: "newVaultV2", type: "address", indexed: true },
   ],
 }] as const;
 
@@ -62,10 +63,11 @@ export const adapterFactoryAbi = [{
   inputs: [{ name: "parentVault", type: "address" }, { name: "morphoVaultV1", type: "address" }],
   outputs: [{ type: "address" }],
 }, {
+  // On-chain signature: all three addresses are indexed.
   type: "event", name: "CreateMorphoVaultV1Adapter", inputs: [
-    { name: "parentVault", type: "address", indexed: false },
-    { name: "morphoVaultV1", type: "address", indexed: false },
-    { name: "morphoVaultV1Adapter", type: "address", indexed: false },
+    { name: "parentVault", type: "address", indexed: true },
+    { name: "morphoVaultV1", type: "address", indexed: true },
+    { name: "morphoVaultV1Adapter", type: "address", indexed: true },
   ],
 }] as const;
 
@@ -82,12 +84,15 @@ export const splitFactoryAbi = [{
   inputs: [splitParamsTuple, { name: "_owner", type: "address" }, { name: "_creator", type: "address" }],
   outputs: [{ type: "address" }],
 }, {
-  // SplitFactoryV2 announces the new proxy address here.
+  // SplitFactoryV2 announces the new proxy address here. On-chain signature
+  // carries a trailing `nonce` — omitting it makes topic0 mismatch and the log
+  // won't decode.
   type: "event", name: "SplitCreated", inputs: [
     { name: "split", type: "address", indexed: true },
     splitParamsTuple,
     { name: "owner", type: "address", indexed: false },
     { name: "creator", type: "address", indexed: false },
+    { name: "nonce", type: "uint256", indexed: false },
   ],
 }] as const;
 


### PR DESCRIPTION
Hotfix on top of #156. The 3 factory event decoders didn't match the real on-chain signatures, so `parseEventLogs` matched nothing and the deploy errored right after the split — never creating the vault/adapter.

- **CreateVaultV2**: `owner`/`asset`/`newVaultV2` are all `indexed`; the address field is `newVaultV2` (was non-indexed / `vaultV2`).
- **CreateMorphoVaultV1Adapter**: all three addresses are `indexed`.
- **SplitCreated**: carries a trailing `uint256 nonce` (omitting it changes topic0 → won't decode).

Also surfaces the deploy error in the panel (it was gated on `busy`, false once `phase === "error"`).

Verified against live factory logs on Base. Build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)