### PR TITLE
feat(stake): reuse an already-deployed split instead of creating another

### DIFF
--- a/src/components/stake/StakeAdminPanel.tsx
+++ b/src/components/stake/StakeAdminPanel.tsx
@@ -60,9 +60,9 @@ export function StakeAdminPanel() {
     );
   }
 
-  async function onDeploy(id: RiderId, wallet: string) {
+  async function onDeploy(id: RiderId, wallet: string, existingSplit?: string) {
     setActiveId(id);
-    const out = await deploy(wallet as `0x${string}`, id);
+    const out = await deploy(wallet as `0x${string}`, id, existingSplit as `0x${string}` | undefined);
     if (out) {
       setResults((r) => ({ ...r, [id]: out }));
       toast.success(`Vault de ${id} deployado`, { description: "Aprove o batch no Safe da SOPA pra ativar." });
@@ -102,7 +102,7 @@ export function StakeAdminPanel() {
                   </div>
                 </div>
                 {!done && r.wallet && (
-                  <Button size="sm" disabled={isDeploying} onClick={() => onDeploy(r.id, r.wallet!)}>
+                  <Button size="sm" disabled={isDeploying} onClick={() => onDeploy(r.id, r.wallet!, r.split)}>
                     {busy ? PHASE_LABEL[phase] : "Deploy vault"}
                   </Button>
                 )}

--- a/src/hooks/use-deploy-sponsorship-vault.ts
+++ b/src/hooks/use-deploy-sponsorship-vault.ts
@@ -53,7 +53,7 @@ export function useDeploySponsorshipVault() {
   const [result, setResult] = useState<DeployResult | null>(null);
 
   const deploy = useCallback(
-    async (athlete: Address, handle: string): Promise<DeployResult | null> => {
+    async (athlete: Address, handle: string, existingSplit?: Address): Promise<DeployResult | null> => {
       const client = getThirdwebClient();
       if (!client) { setError("Thirdweb client não configurado."); setPhase("error"); return null; }
       if (!writer) { setError("Conecte a carteira."); setPhase("error"); return null; }
@@ -67,18 +67,23 @@ export function useDeploySponsorshipVault() {
       try {
         await ensureOnChain(writer.wallet, base);
 
-        // 1. split ---------------------------------------------------------
-        setPhase("split");
-        const splitData = encodeFunctionData({
-          abi: splitFactoryAbi, functionName: "createSplit",
-          args: [splitParamsFor(athlete), SOPA_SAFE, account.address as Address],
-        });
-        let tx = prepareTransaction({ client, chain: base, to: PULL_SPLIT_FACTORY, data: splitData });
-        let hash = (await sendTransaction({ account, transaction: tx })).transactionHash;
-        let receipt = await waitForReceipt({ client, chain: base, transactionHash: hash });
-        const split = parseEventLogs({ abi: splitFactoryAbi, eventName: "SplitCreated", logs: receipt.logs })[0]
-          ?.args.split as Address | undefined;
-        if (!split) throw new Error("Não achei o endereço do split no recibo.");
+        // 1. split — reuse the rider's already-deployed split when the config
+        // carries one, so retrying after a partial run doesn't orphan another
+        // split contract (and doesn't cost another signature).
+        let split = existingSplit;
+        if (!split) {
+          setPhase("split");
+          const splitData = encodeFunctionData({
+            abi: splitFactoryAbi, functionName: "createSplit",
+            args: [splitParamsFor(athlete), SOPA_SAFE, account.address as Address],
+          });
+          const splitTx = prepareTransaction({ client, chain: base, to: PULL_SPLIT_FACTORY, data: splitData });
+          const splitHash = (await sendTransaction({ account, transaction: splitTx })).transactionHash;
+          const splitReceipt = await waitForReceipt({ client, chain: base, transactionHash: splitHash });
+          split = parseEventLogs({ abi: splitFactoryAbi, eventName: "SplitCreated", logs: splitReceipt.logs })[0]
+            ?.args.split as Address | undefined;
+          if (!split) throw new Error("Não achei o endereço do split no recibo.");
+        }
 
         // 2. vault ---------------------------------------------------------
         setPhase("vault");
@@ -86,10 +91,10 @@ export function useDeploySponsorshipVault() {
         const vaultData = encodeFunctionData({
           abi: vaultFactoryAbi, functionName: "createVaultV2", args: [SOPA_SAFE, USDC, salt],
         });
-        tx = prepareTransaction({ client, chain: base, to: VAULT_V2_FACTORY, data: vaultData });
-        hash = (await sendTransaction({ account, transaction: tx })).transactionHash;
-        receipt = await waitForReceipt({ client, chain: base, transactionHash: hash });
-        const vault = parseEventLogs({ abi: vaultFactoryAbi, eventName: "CreateVaultV2", logs: receipt.logs })[0]
+        const vaultTx = prepareTransaction({ client, chain: base, to: VAULT_V2_FACTORY, data: vaultData });
+        const vaultHash = (await sendTransaction({ account, transaction: vaultTx })).transactionHash;
+        const vaultReceipt = await waitForReceipt({ client, chain: base, transactionHash: vaultHash });
+        const vault = parseEventLogs({ abi: vaultFactoryAbi, eventName: "CreateVaultV2", logs: vaultReceipt.logs })[0]
           ?.args.newVaultV2 as Address | undefined;
         if (!vault) throw new Error("Não achei o endereço do vault no recibo.");
 
@@ -98,10 +103,10 @@ export function useDeploySponsorshipVault() {
         const adapterData = encodeFunctionData({
           abi: adapterFactoryAbi, functionName: "createMorphoVaultV1Adapter", args: [vault, MOONWELL_USDC],
         });
-        tx = prepareTransaction({ client, chain: base, to: ADAPTER_FACTORY, data: adapterData });
-        hash = (await sendTransaction({ account, transaction: tx })).transactionHash;
-        receipt = await waitForReceipt({ client, chain: base, transactionHash: hash });
-        const adapter = parseEventLogs({ abi: adapterFactoryAbi, eventName: "CreateMorphoVaultV1Adapter", logs: receipt.logs })[0]
+        const adapterTx = prepareTransaction({ client, chain: base, to: ADAPTER_FACTORY, data: adapterData });
+        const adapterHash = (await sendTransaction({ account, transaction: adapterTx })).transactionHash;
+        const adapterReceipt = await waitForReceipt({ client, chain: base, transactionHash: adapterHash });
+        const adapter = parseEventLogs({ abi: adapterFactoryAbi, eventName: "CreateMorphoVaultV1Adapter", logs: adapterReceipt.logs })[0]
           ?.args.morphoVaultV1Adapter as Address | undefined;
         if (!adapter) throw new Error("Não achei o endereço do adapter no recibo.");
 

--- a/src/lib/gnars-vaults.ts
+++ b/src/lib/gnars-vaults.ts
@@ -27,7 +27,14 @@ export type Rider = {
 };
 
 export const RIDERS: Record<RiderId, Rider> = {
-  vlad: { id: "vlad", handle: "vlad", wallet: getAddress("0x8Bf5941d27176242745B716251943Ae4892a3C26") },
+  vlad: {
+    id: "vlad",
+    handle: "vlad",
+    wallet: getAddress("0x8Bf5941d27176242745B716251943Ae4892a3C26"),
+    // Already deployed (Gnars 50% / vlad 50%, owner = SOPA Safe) — the deploy
+    // reuses it instead of creating another split.
+    split: getAddress("0xCf0fD6F7D9C382EcDf85e549cBc081afa1E2D179"),
+  },
   yan: { id: "yan", handle: "nogenta", wallet: getAddress("0xD1195629d9Ba1168591B8EcdEc9abb1721fCC7D8") },
   r4to: { id: "r4to", handle: "r4topunk", wallet: getAddress("0x39a7B6fa1597BB6657Fe84e64E3B836c37d6F75d") },
   pamtech: { id: "pamtech", handle: "pamtech", wallet: getAddress("0x057CFcd04198E6D17F1Bf502135d9508b6Fa2FDe") },


### PR DESCRIPTION
A partial deploy (split lands, later step fails) left the rider's split orphaned, and retrying created yet another one. The deploy now takes the rider's configured `split` and **skips step 1 when it exists** — a retry costs one fewer signature and never duplicates the contract.

Registers vlad's live split `0xCf0fD6F7D9C382EcDf85e549cBc081afa1E2D179` (Gnars 50% / vlad 50%, owner = SOPA Safe), created by an earlier partial run and verified on-chain.

Build ✓ · tsc ✓ · lint ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)