### PR TITLE
feat(stake): make "Stake as <rider>" a real USDC deposit

### DIFF
--- a/src/components/stake/CharacterSelector.tsx
+++ b/src/components/stake/CharacterSelector.tsx
@@ -346,6 +346,7 @@ export function CharacterSelector() {
       <StakeDialog
         open={dialogOpen}
         onOpenChange={setDialogOpen}
+        riderId={active.id}
         name={name}
         image={active.image}
         accent={active.hex}

--- a/src/components/stake/StakeDialog.tsx
+++ b/src/components/stake/StakeDialog.tsx
@@ -6,6 +6,8 @@ import { useQuery } from "@tanstack/react-query";
 import { Info, Zap } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { getRider } from "@/lib/gnars-vaults";
+import { useStakeDeposit } from "@/hooks/use-stake-deposit";
 import {
   Dialog,
   DialogContent,
@@ -25,6 +27,8 @@ type Asset = "eth" | "usdc";
 interface StakeDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** Rider id — picks which sponsorship vault the deposit goes into. */
+  riderId: string;
   name: string;
   image: string;
   accent: string; // hex
@@ -65,8 +69,9 @@ function fmtUsd(n: number) {
   });
 }
 
-export function StakeDialog({ open, onOpenChange, name, image, accent }: StakeDialogProps) {
+export function StakeDialog({ open, onOpenChange, riderId, name, image, accent }: StakeDialogProps) {
   const t = useTranslations("stake");
+  const { stake, phase: stakePhase, error: stakeError, isStaking } = useStakeDeposit();
   const [asset, setAsset] = useState<Asset>("eth");
   const [amount, setAmount] = useState(ASSETS.eth.default);
 
@@ -106,9 +111,24 @@ export function StakeDialog({ open, onOpenChange, name, image, accent }: StakeDi
     },
   ];
 
-  const handleConfirm = () => {
-    toast.success(t("stakeToast", { name }));
-    onOpenChange(false);
+  // Real deposit for USDC once the rider's vault is live; ETH has no vault yet.
+  const rider = getRider(riderId);
+  const handleConfirm = async () => {
+    if (asset !== "usdc") {
+      toast.info("Por enquanto só USDC", { description: "O cofre de ETH ainda não está no ar." });
+      return;
+    }
+    if (!rider?.vault) {
+      toast.info("Cofre ainda não deployado", { description: `${name} ainda não tem cofre de patrocínio.` });
+      return;
+    }
+    const ok = await stake(rider.vault, amount);
+    if (ok) {
+      toast.success(t("stakeToast", { name }), { description: "Seu depósito continua seu — dá pra sacar quando quiser." });
+      onOpenChange(false);
+    } else {
+      toast.error("Falha no depósito", { description: stakeError ?? undefined });
+    }
   };
 
   return (
@@ -245,11 +265,16 @@ export function StakeDialog({ open, onOpenChange, name, image, accent }: StakeDi
           </Button>
           <Button
             onClick={handleConfirm}
+            disabled={isStaking}
             className="cursor-pointer gap-2 text-white"
             style={{ backgroundColor: accent }}
           >
             <Zap className="h-4 w-4" />
-            {t("stakeCta", { name })}
+            {stakePhase === "approve"
+              ? "1/2 · aprovando USDC…"
+              : stakePhase === "deposit"
+                ? "2/2 · depositando…"
+                : t("stakeCta", { name })}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/hooks/use-stake-deposit.ts
+++ b/src/hooks/use-stake-deposit.ts
@@ -1,0 +1,82 @@
+"use client";
+
+// Stake into a rider's sponsorship vault: approve USDC, then deposit. Shares go
+// to the depositor, so the principal stays theirs and they can withdraw any
+// time — only the yield is split (50% depositor / 25% Gnars / 25% athlete).
+//
+// USDC only: the vaults are Morpho V2 USDC vaults. The ETH option on /stake has
+// no vault behind it yet.
+
+import { useCallback, useState } from "react";
+import { prepareTransaction, sendTransaction, waitForReceipt } from "thirdweb";
+import { base } from "thirdweb/chains";
+import { encodeFunctionData, parseUnits, type Address } from "viem";
+import { useWriteAccount } from "@/hooks/use-write-account";
+import { ensureOnChain } from "@/lib/thirdweb-tx";
+import { getThirdwebClient } from "@/lib/thirdweb";
+import { USDC } from "@/lib/sponsorship-vaults";
+
+const erc20Abi = [{
+  type: "function", name: "approve", stateMutability: "nonpayable",
+  inputs: [{ type: "address" }, { type: "uint256" }], outputs: [{ type: "bool" }],
+}] as const;
+
+const vaultAbi = [{
+  type: "function", name: "deposit", stateMutability: "nonpayable",
+  inputs: [{ type: "uint256" }, { type: "address" }], outputs: [{ type: "uint256" }],
+}] as const;
+
+export type StakePhase = "idle" | "approve" | "deposit" | "done" | "error";
+
+export function useStakeDeposit() {
+  const writer = useWriteAccount();
+  const [phase, setPhase] = useState<StakePhase>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const stake = useCallback(
+    async (vault: Address, amountUsdc: string): Promise<boolean> => {
+      const client = getThirdwebClient();
+      if (!client) { setError("Thirdweb não configurado."); setPhase("error"); return false; }
+      if (!writer) { setError("Conecte a carteira."); setPhase("error"); return false; }
+
+      let assets: bigint;
+      try {
+        assets = parseUnits(amountUsdc, 6); // USDC has 6 decimals
+      } catch {
+        setError("Valor inválido."); setPhase("error"); return false;
+      }
+      if (assets <= BigInt(0)) { setError("Valor inválido."); setPhase("error"); return false; }
+
+      const account = writer.account;
+      setError(null);
+
+      try {
+        await ensureOnChain(writer.wallet, base);
+
+        setPhase("approve");
+        const approveData = encodeFunctionData({ abi: erc20Abi, functionName: "approve", args: [vault, assets] });
+        const approveTx = prepareTransaction({ client, chain: base, to: USDC, data: approveData });
+        const approveHash = (await sendTransaction({ account, transaction: approveTx })).transactionHash;
+        await waitForReceipt({ client, chain: base, transactionHash: approveHash });
+
+        setPhase("deposit");
+        const depositData = encodeFunctionData({
+          abi: vaultAbi, functionName: "deposit", args: [assets, account.address as Address],
+        });
+        const depositTx = prepareTransaction({ client, chain: base, to: vault, data: depositData });
+        const depositHash = (await sendTransaction({ account, transaction: depositTx })).transactionHash;
+        await waitForReceipt({ client, chain: base, transactionHash: depositHash });
+
+        setPhase("done");
+        return true;
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Falha no depósito.");
+        setPhase("error");
+        return false;
+      }
+    },
+    [writer],
+  );
+
+  return { stake, phase, error, isStaking: phase === "approve" || phase === "deposit" };
+}

--- a/src/lib/gnars-vaults.ts
+++ b/src/lib/gnars-vaults.ts
@@ -31,8 +31,10 @@ export const RIDERS: Record<RiderId, Rider> = {
     id: "vlad",
     handle: "vlad",
     wallet: getAddress("0x8Bf5941d27176242745B716251943Ae4892a3C26"),
-    // Already deployed (Gnars 50% / vlad 50%, owner = SOPA Safe) — the deploy
-    // reuses it instead of creating another split.
+    // Live and fully configured: routes to Moonwell, 50% performance fee to the
+    // split (Gnars 25% / vlad 25% of the yield), caps max/100%.
+    vault: getAddress("0xF3f8F84E6891A7881956a2495DaBFF480EE2d4D2"),
+    adapter: getAddress("0x4aA117b2B40C629E20164B5091f0A540db442865"),
     split: getAddress("0xCf0fD6F7D9C382EcDf85e549cBc081afa1E2D179"),
   },
   yan: { id: "yan", handle: "nogenta", wallet: getAddress("0xD1195629d9Ba1168591B8EcdEc9abb1721fCC7D8") },


### PR DESCRIPTION
The stake CTA only fired a toast. It now **approves USDC and deposits into the selected rider's sponsorship vault**. Shares go to the depositor — the principal stays theirs and is withdrawable at any time; only the **yield** is split (depositor 50% / Gnars 25% / athlete 25%).

- `use-stake-deposit` — approve + deposit via thirdweb, with phase state driving the button ("1/2 aprovando USDC…" → "2/2 depositando…").
- `StakeDialog` takes a `riderId` to pick the vault. **ETH** shows a notice (Lido isn't a Morpho vault, so there's no ETH vault yet); riders **without** a deployed vault say so instead of pretending.
- Registers **vlad's live vault** `0xF3f8F84E…d4D2` + adapter `0x4aA117b2…2865`, verified on-chain: curator ✓ allocator ✓ adapter ✓ liquidityAdapter → Moonwell ✓ maxRate 20% ✓ fee 50% → split ✓ caps max/100% ✓

Next: the supporters list per rider (port of SOPA's depositors panel).

Build ✓ tsc ✓ lint ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)