### PR TITLE
feat(treasury): surface the DAO's sponsorship yield + a claim proposal template

### DIFF
--- a/src/app/[locale]/treasury/page.tsx
+++ b/src/app/[locale]/treasury/page.tsx
@@ -10,6 +10,7 @@ import {
 import { NftHoldings } from "@/components/treasury/NftHoldings";
 import { TokenHoldings } from "@/components/treasury/TokenHoldings";
 import { TreasuryBalance } from "@/components/treasury/TreasuryBalance";
+import { SponsorshipYield } from "@/components/treasury/SponsorshipYield";
 import { ZoraCoinHoldings } from "@/components/treasury/ZoraCoinHoldings";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { DAO_ADDRESSES } from "@/lib/config";
@@ -120,6 +121,12 @@ export default async function TreasuryPage({ params }: { params: Promise<{ local
               </Suspense>
             </CardContent>
           </Card>
+        </div>
+
+        {/* Rider sponsorship vaults — the DAO's share of the staking yield, and
+            the proposal that turns it into treasury USDC. */}
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+          <SponsorshipYield />
         </div>
 
         {/* Charts */}

--- a/src/components/treasury/SponsorshipYield.tsx
+++ b/src/components/treasury/SponsorshipYield.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+// The DAO's cut of the rider sponsorship vaults.
+//
+// The performance fee is minted as vault SHARES to each rider's 0xSplits
+// contract (Gnars 50 / athlete 50). The athlete can withdraw theirs whenever;
+// the treasury is a Nouns Builder timelock, so its half only moves through a
+// governance proposal. This card surfaces what's sitting there and starts that
+// proposal from the matching template.
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { PiggyBank, ArrowRight } from "lucide-react";
+import { createPublicClient, http, fallback, formatUnits, type Address } from "viem";
+import { base } from "viem/chains";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { RIDER_LIST } from "@/lib/gnars-vaults";
+
+const client = createPublicClient({
+  chain: base,
+  transport: fallback([
+    http("https://mainnet.base.org"),
+    http("https://base-rpc.publicnode.com"),
+    http("https://base.drpc.org"),
+  ]),
+});
+
+const abi = [
+  { type: "function", name: "balanceOf", stateMutability: "view", inputs: [{ type: "address" }], outputs: [{ type: "uint256" }] },
+  { type: "function", name: "convertToAssets", stateMutability: "view", inputs: [{ type: "uint256" }], outputs: [{ type: "uint256" }] },
+] as const;
+
+type Row = { id: string; handle: string; vault: Address; accrued: number };
+
+const usd = (n: number) =>
+  `$${n.toLocaleString("en-US", { maximumFractionDigits: n > 0 && n < 100 ? 4 : 2 })}`;
+
+export function SponsorshipYield() {
+  const [rows, setRows] = useState<Row[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const live = RIDER_LIST.filter((r) => r.vault && r.split);
+      try {
+        const out = await Promise.all(
+          live.map(async (r) => {
+            const shares = await client.readContract({
+              address: r.vault as Address, abi, functionName: "balanceOf", args: [r.split as Address],
+            });
+            const accrued =
+              shares === BigInt(0)
+                ? 0
+                : Number(
+                    formatUnits(
+                      await client.readContract({
+                        address: r.vault as Address, abi, functionName: "convertToAssets", args: [shares],
+                      }),
+                      6,
+                    ),
+                  );
+            return { id: r.id, handle: r.handle, vault: r.vault as Address, accrued };
+          }),
+        );
+        if (!cancelled) setRows(out);
+      } catch {
+        if (!cancelled) setRows(null);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  // Nothing deployed yet — don't show an empty widget on the treasury page.
+  if (RIDER_LIST.every((r) => !r.vault)) return null;
+
+  // The split is 50/50, so the treasury's share is half of what accrued to it.
+  const totalAccrued = rows?.reduce((s, r) => s + r.accrued, 0) ?? 0;
+  const treasuryShare = totalAccrued / 2;
+
+  return (
+    <Card className="gap-2">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          <PiggyBank className="h-4 w-4" /> Sponsorship yield
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div>
+          <p className="font-mono text-2xl font-bold tabular-nums">
+            {rows === null ? "—" : usd(treasuryShare)}
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Treasury&apos;s share of the yield accrued in the rider vaults. Depositors keep their
+            principal — only the yield is split.
+          </p>
+        </div>
+
+        {rows && rows.length > 0 && (
+          <div className="space-y-1.5">
+            {rows.map((r) => (
+              <div key={r.id} className="flex items-center justify-between text-xs">
+                <span className="capitalize text-muted-foreground">{r.id}</span>
+                <span className="font-mono tabular-nums">{usd(r.accrued / 2)}</span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {treasuryShare > 0 ? (
+          <Button asChild size="sm" variant="outline" className="w-full">
+            <Link href="/propose?template=sponsorship-yield-claim">
+              Start claim proposal <ArrowRight className="ml-1 h-3.5 w-3.5" />
+            </Link>
+          </Button>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            Nothing to claim yet — the fee accrues as the vaults earn.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/proposal-template-schemas.test.ts
+++ b/src/lib/proposal-template-schemas.test.ts
@@ -78,7 +78,7 @@ describe("compileTemplate", () => {
 });
 
 describe("TEMPLATE_SCHEMAS", () => {
-  it("covers all 6 templates", () => {
+  it("covers all 7 templates", () => {
     expect(Object.keys(TEMPLATE_SCHEMAS).sort()).toEqual([
       "athlete-sponsorship",
       "content-media",
@@ -86,6 +86,7 @@ describe("TEMPLATE_SCHEMAS", () => {
       "droposal",
       "event-activation",
       "physical-installation",
+      "sponsorship-yield-claim",
     ]);
   });
 

--- a/src/lib/proposal-template-schemas.ts
+++ b/src/lib/proposal-template-schemas.ts
@@ -36,6 +36,50 @@ export type TemplateFieldValue = string | BudgetRow[];
 export type TemplateValues = Record<string, TemplateFieldValue | undefined>;
 
 export const TEMPLATE_SCHEMAS: Record<string, TemplateSchema> = {
+  // Sponsorship vaults pay the DAO's cut as vault SHARES held by a 0xSplits
+  // contract. The treasury is a timelock, so unlike the athletes it can't just
+  // click withdraw — realising that yield needs a governance proposal. This
+  // template is that proposal. No budget field: nothing is being spent, the
+  // amounts are whatever has accrued on-chain.
+  "sponsorship-yield-claim": {
+    slug: "sponsorship-yield-claim",
+    title: "Sponsorship Yield Claim",
+    defaultTitle: "Claim sponsorship yield — [period]",
+    fields: [
+      {
+        id: "vaults",
+        label: "Vaults being claimed",
+        type: "textarea",
+        rows: 4,
+        required: true,
+        helper:
+          "Which rider vaults this claim covers and how much has accrued to each. The treasury's cut is 25% of the yield — depositors' principal is never touched.",
+        placeholder:
+          "Vlad — vault 0xF3f8…d4D2, split 0xCf0f…D179 — 12.40 USDC accrued, treasury share 6.20 USDC",
+      },
+      {
+        id: "calls",
+        label: "Transactions",
+        type: "textarea",
+        rows: 5,
+        required: true,
+        helper:
+          "The exact calls to add in the transaction step. The fee arrives as vault shares, so the treasury withdraws them from the Splits Warehouse and then redeems them for USDC.",
+        placeholder:
+          "1. PullSplit.distribute(...) — permissionless, can be called by anyone beforehand\n2. SplitsWarehouse.withdraw(treasury, <vault share token>)\n3. VaultV2.redeem(<shares>, treasury, treasury)",
+      },
+      {
+        id: "rationale",
+        label: "Why claim now",
+        type: "textarea",
+        rows: 3,
+        helper:
+          "Gas and voter attention cost more than a tiny claim is worth, so say why this amount justifies a proposal, and what the USDC is earmarked for.",
+        placeholder:
+          "First claim since the vaults launched; batching every rider keeps it to a single proposal. Funds return to the treasury's USDC balance.",
+      },
+    ],
+  },
   "athlete-sponsorship": {
     slug: "athlete-sponsorship",
     title: "Athlete Sponsorship",


### PR DESCRIPTION
The rider sponsorship vaults pay the DAO's cut as **vault shares held by a 0xSplits contract**. The athletes can withdraw their half whenever; the treasury is a Nouns Builder **timelock**, so its half only moves through a governance proposal — and nothing in the app said so, or helped anyone do it. That yield would have quietly accumulated forever.

- **New proposal template `sponsorship-yield-claim`** — the 7th, in the same registry as `athlete-sponsorship` / `droposal` / etc., reachable at `/propose?template=sponsorship-yield-claim`. Fields: which vaults are being claimed, the exact transactions (distribute → Warehouse withdraw → vault redeem), and why claim now. **No budget field on purpose**: this isn't a spend, the amounts are whatever accrued on-chain.
- **Treasury card** — reads each rider vault's accrued fee on-chain and shows the treasury's half, broken down per rider, with a button straight into the wizard at that template. It stays quiet ("nothing to claim yet") when there's nothing there, rather than inviting a governance proposal to withdraw $0.

Template schema tests updated (6 → 7 slugs); 17 passing. Build ✓ tsc ✓ lint ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)