### PR TITLE
feat(stake): name rider vaults at deploy time

### DIFF
--- a/src/hooks/use-deploy-sponsorship-vault.ts
+++ b/src/hooks/use-deploy-sponsorship-vault.ts
@@ -152,7 +152,7 @@ export function useDeploySponsorshipVault() {
 
         // 4. propose config batch to the SOPA Safe -------------------------
         setPhase("propose");
-        const calls: SafeCall[] = buildConfigCalls(vault, adapter, split);
+        const calls: SafeCall[] = buildConfigCalls(vault, adapter, split, handle);
         const msData = encodeFunctionData({ abi: multiSendAbi, functionName: "multiSend", args: [encodeMultiSend(calls)] });
         const nonce = await nextSafeNonce(SOPA_SAFE);
         const message = {

--- a/src/lib/sponsorship-vaults.ts
+++ b/src/lib/sponsorship-vaults.ts
@@ -99,6 +99,8 @@ export const splitFactoryAbi = [{
 export const vaultAbi = [
   { type: "function", name: "submit", stateMutability: "nonpayable", inputs: [{ type: "bytes" }], outputs: [] },
   { type: "function", name: "setCurator", stateMutability: "nonpayable", inputs: [{ type: "address" }], outputs: [] },
+  { type: "function", name: "setName", stateMutability: "nonpayable", inputs: [{ type: "string" }], outputs: [] },
+  { type: "function", name: "setSymbol", stateMutability: "nonpayable", inputs: [{ type: "string" }], outputs: [] },
   { type: "function", name: "setIsAllocator", stateMutability: "nonpayable", inputs: [{ type: "address" }, { type: "bool" }], outputs: [] },
   { type: "function", name: "addAdapter", stateMutability: "nonpayable", inputs: [{ type: "address" }], outputs: [] },
   { type: "function", name: "increaseAbsoluteCap", stateMutability: "nonpayable", inputs: [{ type: "bytes" }, { type: "uint256" }], outputs: [] },
@@ -142,9 +144,30 @@ const submitThenCall = (vault: Address, data: Hex): SafeCall[] => [
  * actions run direct, right after the Safe is made an allocator. Ordering
  * matters: adapter + caps must exist before setLiquidityAdapter.
  */
-export function buildConfigCalls(vault: Address, adapter: Address, split: Address): SafeCall[] {
+/** ERC-20 identity for a rider's vault, so it isn't nameless in wallets and explorers. */
+export function vaultNaming(riderId: string) {
+  const label = riderId.charAt(0).toUpperCase() + riderId.slice(1);
+  return { name: `Gnars ${label} USDC`, symbol: `gn${riderId.toUpperCase()}` };
+}
+
+export function buildConfigCalls(
+  vault: Address,
+  adapter: Address,
+  split: Address,
+  riderId?: string,
+): SafeCall[] {
   const id = idData(adapter);
+  const naming = riderId ? vaultNaming(riderId) : null;
   return [
+    // Name it up front — an unnamed vault shows as a blank ERC-20 in wallets and
+    // explorers, and block indexers skip its holders entirely. Owner-gated, no
+    // timelock.
+    ...(naming
+      ? [
+          { to: vault, data: enc("setName", [naming.name]) },
+          { to: vault, data: enc("setSymbol", [naming.symbol]) },
+        ]
+      : []),
     // createVaultV2 only sets the OWNER; every call below is curator-gated, so
     // the Safe has to make itself curator first (owner-only, no timelock) or
     // the whole batch reverts.


### PR DESCRIPTION
Every vault we deployed shipped **nameless**. In the Morpho curator app that reads as a list of indistinguishable addresses, wallets show a blank ERC-20, and Blockscout skips holder indexing for them entirely — which is what made the supporters list read zero. The reference SOPA vault has always had `"SOPA USDC"`/`"USDSOPA"`; we just never set it on the new ones.

`buildConfigCalls` now opens with `setName`/`setSymbol` (owner-gated, timelock 0 — verified on-chain), deriving `Gnars <Rider> USDC` / `gn<RIDER>` from the rider id.

The already-deployed ones are handled by a separate Safe batch:

| vault | name |
|---|---|
| `0xF3f8…d4D2` vlad | Gnars Vlad USDC (gnVLAD) |
| `0xF358…8b5c` yan | Gnars Yan USDC (gnYAN) |
| `0x1e5D…4e96` orphan from a failed attempt | UNUSED do not deposit (UNUSED) |

Build ✓ tsc ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)