### PR TITLE
feat(stake): claim rewards — withdraw yield, keep principal staked

### DIFF
--- a/src/components/stake/StakeDialog.tsx
+++ b/src/components/stake/StakeDialog.tsx
@@ -8,7 +8,10 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { getRider } from "@/lib/gnars-vaults";
 import { useStakeDeposit } from "@/hooks/use-stake-deposit";
-import { useVaultPosition } from "@/hooks/use-vault-total";
+import { useVaultPosition, useVaultEarned } from "@/hooks/use-vault-total";
+
+// Only offer a rewards claim once it's worth more than the gas to take it.
+const CLAIM_FLOOR_USD = 1;
 import {
   Dialog,
   DialogContent,
@@ -72,7 +75,7 @@ function fmtUsd(n: number) {
 
 export function StakeDialog({ open, onOpenChange, riderId, name, image, accent }: StakeDialogProps) {
   const t = useTranslations("stake");
-  const { stake, withdrawAll, phase: stakePhase, error: stakeError, isStaking, account } =
+  const { stake, withdrawAll, claimRewards, phase: stakePhase, error: stakeError, isStaking, account } =
     useStakeDeposit();
   const [refresh, setRefresh] = useState(0);
   const [asset, setAsset] = useState<Asset>("eth");
@@ -117,6 +120,18 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, accent }
   // Real deposit for USDC once the rider's vault is live; ETH has no vault yet.
   const rider = getRider(riderId);
   const position = useVaultPosition(rider?.vault, account ?? undefined, refresh);
+  const earned = useVaultEarned(rider?.vault, account ?? undefined, refresh);
+
+  const handleClaim = async () => {
+    if (!rider?.vault || !earned || earned.earnedRaw <= BigInt(0)) return;
+    const ok = await claimRewards(rider.vault, earned.earnedRaw);
+    if (ok) {
+      toast.success("Rendimento sacado", { description: "O principal continua rendendo." });
+      setRefresh((n) => n + 1);
+    } else {
+      toast.error("Falha ao sacar rendimento", { description: stakeError ?? undefined });
+    }
+  };
 
   const handleWithdraw = async () => {
     if (!rider?.vault || !position || position.shares <= BigInt(0)) return;
@@ -277,20 +292,42 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, accent }
 
         <DialogFooter className="mt-4">
           {position && position.shares > BigInt(0) && (
-            <div className="mr-auto flex items-center gap-3">
+            <div className="mr-auto flex flex-wrap items-center gap-x-4 gap-y-2">
               <span className="text-xs text-muted-foreground">
                 Sua posição:{" "}
                 <strong className="font-mono text-foreground">${position.assets.toFixed(2)}</strong>
+                {earned && earned.principal > 0 && (
+                  <>
+                    {" "}
+                    <span className="opacity-70">
+                      (principal ${earned.principal.toFixed(2)} · rendimento{" "}
+                      <span className="text-emerald-500">${earned.earned.toFixed(2)}</span>)
+                    </span>
+                  </>
+                )}
               </span>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleWithdraw}
-                disabled={isStaking}
-                className="cursor-pointer"
-              >
-                {stakePhase === "withdraw" ? "sacando…" : "Sacar tudo"}
-              </Button>
+              <div className="flex items-center gap-2">
+                {earned && earned.earned >= CLAIM_FLOOR_USD && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleClaim}
+                    disabled={isStaking}
+                    className="cursor-pointer"
+                  >
+                    {stakePhase === "claim" ? "sacando…" : `Sacar rendimento ($${earned.earned.toFixed(2)})`}
+                  </Button>
+                )}
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleWithdraw}
+                  disabled={isStaking}
+                  className="cursor-pointer"
+                >
+                  {stakePhase === "withdraw" ? "sacando…" : "Sacar tudo"}
+                </Button>
+              </div>
             </div>
           )}
           <Button variant="outline" onClick={() => onOpenChange(false)} className="cursor-pointer">

--- a/src/hooks/use-stake-deposit.ts
+++ b/src/hooks/use-stake-deposit.ts
@@ -29,6 +29,10 @@ const vaultAbi = [{
   // can't leave a rounding remainder that reverts a "withdraw everything".
   type: "function", name: "redeem", stateMutability: "nonpayable",
   inputs: [{ type: "uint256" }, { type: "address" }, { type: "address" }], outputs: [{ type: "uint256" }],
+}, {
+  // Withdraw by assets — used to pull only the earned amount, leaving principal.
+  type: "function", name: "withdraw", stateMutability: "nonpayable",
+  inputs: [{ type: "uint256" }, { type: "address" }, { type: "address" }], outputs: [{ type: "uint256" }],
 }] as const;
 
 // Reads used to skip a redundant approve and to refuse deposits that would
@@ -36,7 +40,7 @@ const vaultAbi = [{
 const ALLOWANCE = "function allowance(address owner, address spender) view returns (uint256)" as const;
 const PREVIEW_DEPOSIT = "function previewDeposit(uint256 assets) view returns (uint256)" as const;
 
-export type StakePhase = "idle" | "approve" | "deposit" | "withdraw" | "done" | "error";
+export type StakePhase = "idle" | "approve" | "deposit" | "withdraw" | "claim" | "done" | "error";
 
 export function useStakeDeposit() {
   const writer = useWriteAccount();
@@ -160,12 +164,52 @@ export function useStakeDeposit() {
     [writer],
   );
 
+  /**
+   * Withdraw only the earned amount (in USDC micro-units), leaving the principal
+   * staked and still earning. The yield lives in the share price, so this burns
+   * just the shares worth `earnedRaw`.
+   */
+  const claimRewards = useCallback(
+    async (vault: Address, earnedRaw: bigint): Promise<boolean> => {
+      if (pending.current) return false;
+      const client = getThirdwebClient();
+      if (!client) { setError("Thirdweb não configurado."); setPhase("error"); return false; }
+      if (!writer) { setError("Conecte a carteira."); setPhase("error"); return false; }
+      if (earnedRaw <= BigInt(0)) { setError("Sem rendimento pra sacar."); setPhase("error"); return false; }
+
+      const account = writer.account;
+      setError(null);
+      pending.current = true;
+      try {
+        await ensureOnChain(writer.wallet, base);
+        setPhase("claim");
+        const data = encodeFunctionData({
+          abi: vaultAbi, functionName: "withdraw",
+          args: [earnedRaw, account.address as Address, account.address as Address],
+        });
+        const tx = prepareTransaction({ client, chain: base, to: vault, data });
+        const hash = (await sendTransaction({ account, transaction: tx })).transactionHash;
+        await waitForReceipt({ client, chain: base, transactionHash: hash });
+        setPhase("done");
+        return true;
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Falha ao sacar rendimento.");
+        setPhase("error");
+        return false;
+      } finally {
+        pending.current = false;
+      }
+    },
+    [writer],
+  );
+
   return {
     stake,
     withdrawAll,
+    claimRewards,
     phase,
     error,
-    isStaking: phase === "approve" || phase === "deposit" || phase === "withdraw",
+    isStaking: phase === "approve" || phase === "deposit" || phase === "withdraw" || phase === "claim",
     /** The account that deposits/withdraws — read positions for this one. */
     account: writer?.account.address ?? null,
   };

--- a/src/hooks/use-vault-total.ts
+++ b/src/hooks/use-vault-total.ts
@@ -65,6 +65,90 @@ export function useVaultPosition(
   return pos;
 }
 
+type DecodedParam = { name?: string; value?: unknown };
+type LogItem = { decoded?: { method_call?: string; parameters?: DecodedParam[] } | null };
+
+/** Net principal an account put in: sum of its Deposit assets minus Withdraw assets. */
+async function principalFromLogs(vault: Address, account: string): Promise<bigint> {
+  const res = await fetch(`https://base.blockscout.com/api/v2/addresses/${vault}/logs`, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(9000),
+  });
+  if (!res.ok) return BigInt(0);
+  const json = (await res.json()) as { items?: LogItem[] };
+  const me = account.toLowerCase();
+  let principal = BigInt(0);
+  for (const log of json.items ?? []) {
+    const call = log.decoded?.method_call ?? "";
+    const params = log.decoded?.parameters ?? [];
+    const owner = params.find((p) => p.name === "owner")?.value;
+    if (typeof owner !== "string" || owner.toLowerCase() !== me) continue;
+    const assets = params.find((p) => p.name === "assets")?.value;
+    if (typeof assets !== "string" && typeof assets !== "number") continue;
+    const amt = BigInt(assets);
+    if (call.startsWith("Deposit(")) principal += amt;
+    else if (call.startsWith("Withdraw(")) principal -= amt;
+  }
+  return principal > BigInt(0) ? principal : BigInt(0);
+}
+
+export type VaultEarned = {
+  /** Current position value, USDC. */
+  current: number;
+  /** Net deposited, USDC. */
+  principal: number;
+  /** current − principal, floored at 0, USDC. */
+  earned: number;
+  /** Raw earned in USDC micro-units, for the withdraw call. */
+  earnedRaw: bigint;
+  shares: bigint;
+};
+
+/**
+ * Splits a position into principal vs earned. Principal isn't stored per-user
+ * on-chain, so it's reconstructed from the account's Deposit/Withdraw events;
+ * the current value is read from the contract. `nonce` forces a refetch.
+ */
+export function useVaultEarned(vault?: Address, account?: string, nonce = 0): VaultEarned | null {
+  const [data, setData] = useState<VaultEarned | null>(null);
+
+  useEffect(() => {
+    if (!vault || !account) { setData(null); return; }
+    let cancelled = false;
+    setData(null);
+    (async () => {
+      try {
+        const shares = await client.readContract({
+          address: vault, abi, functionName: "balanceOf", args: [account as Address],
+        });
+        if (cancelled) return;
+        if (shares === BigInt(0)) {
+          setData({ current: 0, principal: 0, earned: 0, earnedRaw: BigInt(0), shares: BigInt(0) });
+          return;
+        }
+        const [currentRaw, principalRaw] = await Promise.all([
+          client.readContract({ address: vault, abi, functionName: "convertToAssets", args: [shares] }),
+          principalFromLogs(vault, account),
+        ]);
+        if (cancelled) return;
+        const earnedRaw = currentRaw > principalRaw ? currentRaw - principalRaw : BigInt(0);
+        setData({
+          current: Number(formatUnits(currentRaw, 6)),
+          principal: Number(formatUnits(principalRaw, 6)),
+          earned: Number(formatUnits(earnedRaw, 6)),
+          earnedRaw,
+          shares,
+        });
+      } catch {
+        if (!cancelled) setData(null);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [vault, account, nonce]);
+
+  return data;
+}
+
 export function useVaultTotal(vault?: Address): number | null {
   const [total, setTotal] = useState<number | null>(null);
 


### PR DESCRIPTION
There's no separate rewards pot — yield accrues into the **share price**. So "claim rewards" means withdrawing only the earned part while the principal stays staked.

- The dialog splits a position into **principal vs earned**: principal is reconstructed from the account's own `Deposit`/`Withdraw` events (it isn't stored per-user on-chain), current value is read from the contract. Both are shown, earned in green.
- **"Sacar rendimento"** calls `withdraw(earned)` — burns just the shares worth the yield, leaving the principal earning. It appears only once earned clears a **$1 floor**, so nobody's invited to spend more gas than the yield is worth. Below that it's informational, next to the existing **"Sacar tudo"**.
- The share price is already net of the 50% performance fee (minted as shares to the split, diluting depositors), so the earned figure is exactly the depositor's half — no split math needed.

At today's $5 position the earned is ~$0.00, so the breakdown shows but the button doesn't — by design.

Build ✓ tsc ✓ lint ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)