### PR TITLE
feat(stake): rename Spin/Rail stats to Style/Surf

### DIFF
--- a/messages/en/stake.json
+++ b/messages/en/stake.json
@@ -30,8 +30,8 @@
     "speed": "Speed",
     "air": "Air",
     "ollie": "Ollie",
-    "spin": "Spin",
-    "rail": "Rail",
+    "spin": "Style",
+    "rail": "Surf",
     "flow": "Flow",
     "devSkills": "Dev Skills",
     "creativity": "Creativity"

--- a/messages/pt-br/stake.json
+++ b/messages/pt-br/stake.json
@@ -30,8 +30,8 @@
     "speed": "Velocidade",
     "air": "Air",
     "ollie": "Ollie",
-    "spin": "Giro",
-    "rail": "Corrimão",
+    "spin": "Estilo",
+    "rail": "Surf",
     "flow": "Flow",
     "devSkills": "Habilidade Dev",
     "creativity": "Criatividade"


### PR DESCRIPTION
The roster has surfers too, so "Style" and "Surf" read better across the whole crew than "Spin"/"Rail". Labels only — the underlying stat keys are unchanged.

Build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)