### PR TITLE
fix(miniapp): give /stake and /blogs their own Farcaster embed

### DIFF
--- a/src/app/[locale]/blogs/page.tsx
+++ b/src/app/[locale]/blogs/page.tsx
@@ -4,6 +4,7 @@ import { getTranslations, setRequestLocale } from "next-intl/server";
 import { BlogsPageSkeleton } from "@/components/blogs/BlogsPageSkeleton";
 import { BlogsView } from "@/components/blogs/BlogsView";
 import { getAllBlogSummaries } from "@/services/blogs";
+import { BLOGS_MINIAPP_EMBED_CONFIG } from "@/lib/miniapp-config";
 
 export async function generateMetadata({
   params,
@@ -36,6 +37,10 @@ export async function generateMetadata({
       card: "summary_large_image",
       title: t("title"),
       description: t("description"),
+    },
+    // Farcaster mini app embed — launch straight into the blog instead of home.
+    other: {
+      "fc:miniapp": JSON.stringify(BLOGS_MINIAPP_EMBED_CONFIG),
     },
   };
 }

--- a/src/app/[locale]/stake/[rider]/page.tsx
+++ b/src/app/[locale]/stake/[rider]/page.tsx
@@ -4,6 +4,8 @@ import { getTranslations, setRequestLocale } from "next-intl/server";
 import { CharacterSelector } from "@/components/stake/CharacterSelector";
 import { StakeAdminPanel } from "@/components/stake/StakeAdminPanel";
 import { RIDER_LIST, getRider } from "@/lib/gnars-vaults";
+import { STAKE_MINIAPP_EMBED_CONFIG } from "@/lib/miniapp-config";
+import { BASE_URL } from "@/lib/config";
 
 // Shareable per-rider entry point: /stake/vlad opens the roster on that rider,
 // so a supporter can link straight to the athlete they're backing.
@@ -42,6 +44,17 @@ export async function generateMetadata({
       images: [{ url: `/stake/cutout/${rider}.png` }],
     },
     twitter: { card: "summary_large_image", title, description },
+    // Farcaster mini app embed — launch straight into this rider.
+    other: {
+      "fc:miniapp": JSON.stringify({
+        ...STAKE_MINIAPP_EMBED_CONFIG,
+        button: {
+          ...STAKE_MINIAPP_EMBED_CONFIG.button,
+          title: `Stake with ${name}`,
+          action: { ...STAKE_MINIAPP_EMBED_CONFIG.button.action, url: `${BASE_URL}/stake/${rider}` },
+        },
+      }),
+    },
   };
 }
 

--- a/src/app/[locale]/stake/page.tsx
+++ b/src/app/[locale]/stake/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { CharacterSelector } from "@/components/stake/CharacterSelector";
 import { StakeAdminPanel } from "@/components/stake/StakeAdminPanel";
+import { STAKE_MINIAPP_EMBED_CONFIG } from "@/lib/miniapp-config";
 
 export async function generateMetadata({
   params,
@@ -33,6 +34,11 @@ export async function generateMetadata({
       card: "summary_large_image",
       title: t("title"),
       description: t("description"),
+    },
+    // Farcaster mini app embed — without this /stake inherits the root default
+    // and launches the home miniapp instead of the rider select.
+    other: {
+      "fc:miniapp": JSON.stringify(STAKE_MINIAPP_EMBED_CONFIG),
     },
   };
 }

--- a/src/lib/miniapp-config.ts
+++ b/src/lib/miniapp-config.ts
@@ -335,3 +335,40 @@ export const MIGRATE_MINIAPP_EMBED_CONFIG = {
     },
   },
 };
+
+/**
+ * Stake Mini App Configuration
+ * Fighting-game rider select — back an athlete's sponsorship vault.
+ */
+export const STAKE_MINIAPP_EMBED_CONFIG = {
+  version: "1",
+  imageUrl: `${BASE_URL}/miniapp-image`,
+  button: {
+    title: "Stake or Die",
+    action: {
+      type: "launch_miniapp" as const,
+      name: "Gnars Stake",
+      url: `${BASE_URL}/stake`,
+      splashImageUrl: `${BASE_URL}/gnars-splash-200.png`,
+      splashBackgroundColor: "#000000",
+    },
+  },
+};
+
+/**
+ * Blogs Mini App Configuration
+ */
+export const BLOGS_MINIAPP_EMBED_CONFIG = {
+  version: "1",
+  imageUrl: `${BASE_URL}/miniapp-image`,
+  button: {
+    title: "Read the blog",
+    action: {
+      type: "launch_miniapp" as const,
+      name: "Gnars Blog",
+      url: `${BASE_URL}/blogs`,
+      splashImageUrl: `${BASE_URL}/gnars-splash-200.png`,
+      splashBackgroundColor: "#000000",
+    },
+  },
+};


### PR DESCRIPTION
Both pages had **no `fc:miniapp` of their own**, so they inherited the root default whose launch action points at the home URL. Shared or opened as a mini app, they'd open the generic **home** miniapp instead of the actual page.

Adds `STAKE_MINIAPP_EMBED_CONFIG` and `BLOGS_MINIAPP_EMBED_CONFIG` and wires each page's metadata `other["fc:miniapp"]` to it. The per-rider `/stake/<rider>` page launches straight into that rider.

**Audit** — routes still on the generic fallback: auctions, treasury, community, store, feed, propose, rounds, about, propdates, mural, installations, nogglesrails, coin-proposal, [slug] (+ internal debug/demo). Fixing those is the same 5-line pattern; flagged for a follow-up.

Build ✓ tsc ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)