### PR TITLE
fix(miniapp): own Farcaster embed for the remaining user-facing routes

### DIFF
--- a/src/app/[locale]/about/layout.tsx
+++ b/src/app/[locale]/about/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { ABOUT_MINIAPP_EMBED_CONFIG } from "@/lib/miniapp-config";
+
+// Adds this route's own Farcaster mini app embed so it launches here instead of
+// inheriting the root default (which opens the home mini app). Metadata merges
+// with the page's own title/description.
+export function generateMetadata(): Metadata {
+  return {
+    other: {
+      "fc:miniapp": JSON.stringify(ABOUT_MINIAPP_EMBED_CONFIG),
+    },
+  };
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/[locale]/auctions/layout.tsx
+++ b/src/app/[locale]/auctions/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
+import { AUCTIONS_MINIAPP_EMBED_CONFIG } from "@/lib/miniapp-config";
 
 export async function generateMetadata({
   params,
@@ -32,6 +33,9 @@ export async function generateMetadata({
       card: "summary_large_image",
       title: t("title"),
       description: t("description"),
+    },
+    other: {
+      "fc:miniapp": JSON.stringify(AUCTIONS_MINIAPP_EMBED_CONFIG),
     },
   };
 }

--- a/src/app/[locale]/community/layout.tsx
+++ b/src/app/[locale]/community/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { COMMUNITY_MINIAPP_EMBED_CONFIG } from "@/lib/miniapp-config";
+
+// Adds this route's own Farcaster mini app embed so it launches here instead of
+// inheriting the root default (which opens the home mini app). Metadata merges
+// with the page's own title/description.
+export function generateMetadata(): Metadata {
+  return {
+    other: {
+      "fc:miniapp": JSON.stringify(COMMUNITY_MINIAPP_EMBED_CONFIG),
+    },
+  };
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/[locale]/feed/layout.tsx
+++ b/src/app/[locale]/feed/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { FEED_MINIAPP_EMBED_CONFIG } from "@/lib/miniapp-config";
+
+// Adds this route's own Farcaster mini app embed so it launches here instead of
+// inheriting the root default (which opens the home mini app). Metadata merges
+// with the page's own title/description.
+export function generateMetadata(): Metadata {
+  return {
+    other: {
+      "fc:miniapp": JSON.stringify(FEED_MINIAPP_EMBED_CONFIG),
+    },
+  };
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/[locale]/propdates/layout.tsx
+++ b/src/app/[locale]/propdates/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { PROPDATES_MINIAPP_EMBED_CONFIG } from "@/lib/miniapp-config";
+
+// Adds this route's own Farcaster mini app embed so it launches here instead of
+// inheriting the root default (which opens the home mini app). Metadata merges
+// with the page's own title/description.
+export function generateMetadata(): Metadata {
+  return {
+    other: {
+      "fc:miniapp": JSON.stringify(PROPDATES_MINIAPP_EMBED_CONFIG),
+    },
+  };
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/[locale]/propose/layout.tsx
+++ b/src/app/[locale]/propose/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { PROPOSE_MINIAPP_EMBED_CONFIG } from "@/lib/miniapp-config";
+
+// Adds this route's own Farcaster mini app embed so it launches here instead of
+// inheriting the root default (which opens the home mini app). Metadata merges
+// with the page's own title/description.
+export function generateMetadata(): Metadata {
+  return {
+    other: {
+      "fc:miniapp": JSON.stringify(PROPOSE_MINIAPP_EMBED_CONFIG),
+    },
+  };
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/[locale]/rounds/layout.tsx
+++ b/src/app/[locale]/rounds/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { ROUNDS_MINIAPP_EMBED_CONFIG } from "@/lib/miniapp-config";
+
+// Adds this route's own Farcaster mini app embed so it launches here instead of
+// inheriting the root default (which opens the home mini app). Metadata merges
+// with the page's own title/description.
+export function generateMetadata(): Metadata {
+  return {
+    other: {
+      "fc:miniapp": JSON.stringify(ROUNDS_MINIAPP_EMBED_CONFIG),
+    },
+  };
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/[locale]/store/layout.tsx
+++ b/src/app/[locale]/store/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { STORE_MINIAPP_EMBED_CONFIG } from "@/lib/miniapp-config";
+
+// Adds this route's own Farcaster mini app embed so it launches here instead of
+// inheriting the root default (which opens the home mini app). Metadata merges
+// with the page's own title/description.
+export function generateMetadata(): Metadata {
+  return {
+    other: {
+      "fc:miniapp": JSON.stringify(STORE_MINIAPP_EMBED_CONFIG),
+    },
+  };
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/[locale]/treasury/layout.tsx
+++ b/src/app/[locale]/treasury/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { TREASURY_MINIAPP_EMBED_CONFIG } from "@/lib/miniapp-config";
+
+// Adds this route's own Farcaster mini app embed so it launches here instead of
+// inheriting the root default (which opens the home mini app). Metadata merges
+// with the page's own title/description.
+export function generateMetadata(): Metadata {
+  return {
+    other: {
+      "fc:miniapp": JSON.stringify(TREASURY_MINIAPP_EMBED_CONFIG),
+    },
+  };
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/lib/miniapp-config.ts
+++ b/src/lib/miniapp-config.ts
@@ -372,3 +372,34 @@ export const BLOGS_MINIAPP_EMBED_CONFIG = {
     },
   },
 };
+
+/**
+ * Generic launch embed for routes that just need to open at their own URL
+ * instead of inheriting the root default (which launches the home mini app).
+ */
+export function launchMiniappEmbed(path: string, name: string, title: string) {
+  return {
+    version: "1" as const,
+    imageUrl: `${BASE_URL}/miniapp-image`,
+    button: {
+      title,
+      action: {
+        type: "launch_miniapp" as const,
+        name,
+        url: `${BASE_URL}${path}`,
+        splashImageUrl: `${BASE_URL}/gnars-splash-200.png`,
+        splashBackgroundColor: "#000000",
+      },
+    },
+  };
+}
+
+export const AUCTIONS_MINIAPP_EMBED_CONFIG = launchMiniappEmbed("/auctions", "Gnars Auctions", "View auction");
+export const TREASURY_MINIAPP_EMBED_CONFIG = launchMiniappEmbed("/treasury", "Gnars Treasury", "View treasury");
+export const COMMUNITY_MINIAPP_EMBED_CONFIG = launchMiniappEmbed("/community", "Gnars Community", "Explore community");
+export const STORE_MINIAPP_EMBED_CONFIG = launchMiniappEmbed("/store", "Gnars Store", "Shop Gnars");
+export const FEED_MINIAPP_EMBED_CONFIG = launchMiniappEmbed("/feed", "Gnars Feed", "Open the feed");
+export const PROPOSE_MINIAPP_EMBED_CONFIG = launchMiniappEmbed("/propose", "Gnars Propose", "Create a proposal");
+export const ROUNDS_MINIAPP_EMBED_CONFIG = launchMiniappEmbed("/rounds", "Gnars Rounds", "View rounds");
+export const ABOUT_MINIAPP_EMBED_CONFIG = launchMiniappEmbed("/about", "About Gnars", "About Gnars");
+export const PROPDATES_MINIAPP_EMBED_CONFIG = launchMiniappEmbed("/propdates", "Gnars Propdates", "View propdates");


### PR DESCRIPTION
Completes the mini app audit. **auctions, treasury, community, store, feed, propose, rounds, about, propdates** all inherited the root default `fc:miniapp` → shared or launched as a mini app, they opened the **home** app instead of themselves.

Adds a `launchMiniappEmbed(path, name, title)` factory + a per-route config, and a minimal `layout.tsx` (or the existing auctions layout) that injects each route's `fc:miniapp`. Metadata merges with the page's own title/description.

Left on the default intentionally: internal routes (debug, demo) and loose `[slug]` pages.

Now with own embed: stake, blogs (prior PR) + these 9 → all user-facing routes covered.

Build ✓ tsc ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)