### PR TITLE
feat(stake): Morpheus (MOR) staking — mainnet stETH/USDC + athlete referrer

### DIFF
--- a/src/app/[locale]/stake/[rider]/page.tsx
+++ b/src/app/[locale]/stake/[rider]/page.tsx
@@ -4,6 +4,7 @@ import { getTranslations, setRequestLocale } from "next-intl/server";
 import { CharacterSelector } from "@/components/stake/CharacterSelector";
 import { StakeAdminPanel } from "@/components/stake/StakeAdminPanel";
 import { StakeOrbit } from "@/components/stake/StakeOrbit";
+import { MorpheusPanel } from "@/components/stake/MorpheusPanel";
 import { RIDER_LIST, getRider } from "@/lib/gnars-vaults";
 import { STAKE_MINIAPP_EMBED_CONFIG } from "@/lib/miniapp-config";
 import { BASE_URL } from "@/lib/config";
@@ -83,6 +84,7 @@ export default async function StakeRiderPage({
 
         <CharacterSelector initialRider={rider} />
         <StakeOrbit />
+        <MorpheusPanel />
         <StakeAdminPanel />
       </div>
     </div>

--- a/src/app/[locale]/stake/page.tsx
+++ b/src/app/[locale]/stake/page.tsx
@@ -3,6 +3,7 @@ import { getTranslations, setRequestLocale } from "next-intl/server";
 import { CharacterSelector } from "@/components/stake/CharacterSelector";
 import { StakeAdminPanel } from "@/components/stake/StakeAdminPanel";
 import { StakeOrbit } from "@/components/stake/StakeOrbit";
+import { MorpheusPanel } from "@/components/stake/MorpheusPanel";
 import { STAKE_MINIAPP_EMBED_CONFIG } from "@/lib/miniapp-config";
 
 export async function generateMetadata({
@@ -63,6 +64,7 @@ export default async function StakePage({ params }: { params: Promise<{ locale: 
 
         <CharacterSelector />
         <StakeOrbit />
+        <MorpheusPanel />
         <StakeAdminPanel />
       </div>
     </div>

--- a/src/components/stake/MorpheusPanel.tsx
+++ b/src/components/stake/MorpheusPanel.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+// Morpheus (MOR) staking — the experimental, higher-risk tier, clearly separate
+// from the Base/Moonwell vaults. Stake stETH or USDC on Ethereum mainnet, credit
+// an athlete as referrer (their protocol-funded cut), earn MOR on Arbitrum.
+//
+// Phases wired here: stake + withdraw (with the athlete referrer). Claiming MOR
+// and the opt-in donate-split come next.
+
+import { useState } from "react";
+import { useActiveAccount } from "thirdweb/react";
+import { toast } from "sonner";
+import { AlertTriangle } from "lucide-react";
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { RIDER_LIST } from "@/lib/gnars-vaults";
+import { MORPHEUS_POOLS, type MorpheusAsset } from "@/lib/morpheus";
+import { useMorpheusStake } from "@/hooks/use-morpheus-stake";
+import { useMorpheusPosition } from "@/hooks/use-morpheus-position";
+
+const fmt = (n: number, d = 4) => n.toLocaleString("en-US", { maximumFractionDigits: d });
+
+export function MorpheusPanel() {
+  const account = useActiveAccount();
+  const you = account?.address;
+  const { stake, withdraw, phase, error, isBusy } = useMorpheusStake();
+  const [refresh, setRefresh] = useState(0);
+  const position = useMorpheusPosition(you, refresh);
+
+  const [asset, setAsset] = useState<MorpheusAsset>("usdc");
+  const [amount, setAmount] = useState("");
+  const [riderId, setRiderId] = useState(RIDER_LIST[0].id);
+  const rider = RIDER_LIST.find((r) => r.id === riderId)!;
+
+  const onStake = async () => {
+    if (!amount || Number(amount) <= 0) return;
+    const ok = await stake(asset, amount, rider.wallet!);
+    if (ok) {
+      toast.success(`Staked with ${riderId}`, { description: `Earning MOR on Arbitrum — ${riderId} gets the referrer bonus.` });
+      setAmount("");
+      setRefresh((n) => n + 1);
+    } else {
+      toast.error("Stake failed", { description: error ?? undefined });
+    }
+  };
+
+  const onWithdraw = async (a: MorpheusAsset, staked: number) => {
+    const ok = await withdraw(a, String(staked));
+    if (ok) { toast.success("Withdrawn"); setRefresh((n) => n + 1); }
+    else toast.error("Withdraw failed", { description: error ?? undefined });
+  };
+
+  const phaseLabel =
+    phase === "approve" ? `approving ${MORPHEUS_POOLS[asset].symbol}…`
+    : phase === "stake" ? "staking on mainnet…"
+    : phase === "withdraw" ? "withdrawing…"
+    : `Stake ${MORPHEUS_POOLS[asset].symbol}`;
+
+  return (
+    <Card className="border-violet-500/30 bg-violet-500/[0.03]">
+      <CardHeader>
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="outline" className="border-violet-500/50 text-violet-400">MOR · experimental</Badge>
+          <CardTitle>Stake for MOR rewards</CardTitle>
+        </div>
+        <CardDescription>
+          Stake stETH or USDC into Morpheus on <b>Ethereum mainnet</b> and earn <b>MOR</b> (on Arbitrum).
+          The athlete you pick gets a protocol-funded referrer bonus. Higher upside, but MOR is a young,
+          volatile token and every action is a mainnet tx (real gas) — separate from the Base vaults above.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* pick athlete + asset */}
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div>
+            <label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Back which rider</label>
+            <select
+              value={riderId}
+              onChange={(e) => setRiderId(e.target.value as typeof riderId)}
+              className="mt-1 w-full rounded-lg border border-border/60 bg-background px-3 py-2 text-sm capitalize"
+            >
+              {RIDER_LIST.filter((r) => r.wallet).map((r) => (
+                <option key={r.id} value={r.id} className="capitalize">{r.id} (@{r.handle})</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Asset</label>
+            <div className="mt-1 grid grid-cols-2 gap-2 rounded-lg border border-border/60 bg-muted/30 p-1">
+              {(Object.keys(MORPHEUS_POOLS) as MorpheusAsset[]).map((a) => (
+                <button
+                  key={a}
+                  type="button"
+                  onClick={() => setAsset(a)}
+                  className={`cursor-pointer rounded-md px-3 py-1.5 text-sm font-semibold transition ${asset === a ? "bg-violet-500 text-white" : "text-muted-foreground hover:bg-muted"}`}
+                >
+                  {MORPHEUS_POOLS[a].symbol}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex gap-2">
+          <Input
+            type="number"
+            inputMode="decimal"
+            placeholder={`min ${MORPHEUS_POOLS[asset].minStake} ${MORPHEUS_POOLS[asset].symbol}`}
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+          />
+          <Button onClick={onStake} disabled={isBusy || !you} className="shrink-0 gap-2 bg-violet-500 text-white hover:bg-violet-600">
+            {phaseLabel}
+          </Button>
+        </div>
+
+        <p className="flex items-start gap-1.5 text-xs text-muted-foreground">
+          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-violet-400" />
+          Principal is yours, withdrawable after a 7-day lock. MOR arrives on Arbitrum; claiming it comes next.
+          Start small — mainnet gas can rival a small stake.
+        </p>
+
+        {/* your positions */}
+        {position?.hasStake && (
+          <div className="space-y-2 border-t border-border/40 pt-3">
+            <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Your Morpheus positions</p>
+            {position.pools.filter((p) => p.staked > 0).map((p) => (
+              <div key={p.asset} className="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-background/40 px-3 py-2 text-sm">
+                <span className="font-mono">{fmt(p.staked, 4)} {p.symbol}</span>
+                <span className="text-xs text-muted-foreground">
+                  {p.pendingMor > 0 ? `${fmt(p.pendingMor, 4)} MOR pending` : "MOR accruing"}
+                </span>
+                <Button size="sm" variant="outline" disabled={isBusy} onClick={() => onWithdraw(p.asset, p.staked)}>
+                  Withdraw
+                </Button>
+              </div>
+            ))}
+            <p className="text-[11px] text-muted-foreground">
+              Total accrued: <b className="text-violet-400">{fmt(position.totalMor, 4)} MOR</b>
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/use-morpheus-position.ts
+++ b/src/hooks/use-morpheus-position.ts
@@ -1,0 +1,86 @@
+"use client";
+
+// Read-only view of a wallet's Morpheus Capital positions (Phase 0): how much
+// stETH / USDC it has staked, the MOR accrued so far, and when the 7-day
+// withdraw lock lifts. All reads are on Ethereum mainnet; nothing here moves
+// money.
+
+import { useEffect, useState } from "react";
+import { createPublicClient, http, fallback, formatUnits, type Address } from "viem";
+import { mainnet } from "viem/chains";
+import {
+  MORPHEUS_POOLS, MOR_REWARD_POOL_INDEX, MOR_DECIMALS, WITHDRAW_LOCK_SECONDS,
+  depositPoolAbi, type MorpheusAsset,
+} from "@/lib/morpheus";
+
+const client = createPublicClient({
+  chain: mainnet,
+  transport: fallback([
+    http("https://ethereum.publicnode.com"),
+    http("https://eth.llamarpc.com"),
+    http("https://rpc.ankr.com/eth"),
+  ]),
+});
+
+export type MorpheusPoolPosition = {
+  asset: MorpheusAsset;
+  symbol: string;
+  /** Staked principal, in the deposit asset. */
+  staked: number;
+  /** MOR accrued and claimable so far. */
+  pendingMor: number;
+  /** Unix seconds when the withdraw lock lifts (0 if nothing staked). */
+  unlockAt: number;
+};
+
+export type MorpheusPositions = {
+  pools: MorpheusPoolPosition[];
+  /** Total MOR accrued across pools. */
+  totalMor: number;
+  /** True if the wallet has any Morpheus stake at all. */
+  hasStake: boolean;
+};
+
+export function useMorpheusPosition(wallet?: string, nonce = 0): MorpheusPositions | null {
+  const [pos, setPos] = useState<MorpheusPositions | null>(null);
+
+  useEffect(() => {
+    if (!wallet) { setPos(null); return; }
+    let cancelled = false;
+    setPos(null);
+
+    (async () => {
+      try {
+        const pools = await Promise.all(
+          (Object.keys(MORPHEUS_POOLS) as MorpheusAsset[]).map(async (asset) => {
+            const { pool, decimals, symbol } = MORPHEUS_POOLS[asset];
+            const [data, reward] = await Promise.all([
+              client.readContract({ address: pool, abi: depositPoolAbi, functionName: "usersData", args: [wallet as Address, MOR_REWARD_POOL_INDEX] }),
+              client.readContract({ address: pool, abi: depositPoolAbi, functionName: "getLatestUserReward", args: [MOR_REWARD_POOL_INDEX, wallet as Address] }),
+            ]);
+            const lastStake = Number(data[0]); // uint128 lastStake
+            const deposited = data[1]; // uint256 deposited
+            return {
+              asset, symbol,
+              staked: Number(formatUnits(deposited, decimals)),
+              pendingMor: Number(formatUnits(reward, MOR_DECIMALS)),
+              unlockAt: deposited > BigInt(0) ? lastStake + WITHDRAW_LOCK_SECONDS : 0,
+            } satisfies MorpheusPoolPosition;
+          }),
+        );
+        if (cancelled) return;
+        setPos({
+          pools,
+          totalMor: pools.reduce((s, p) => s + p.pendingMor, 0),
+          hasStake: pools.some((p) => p.staked > 0),
+        });
+      } catch {
+        if (!cancelled) setPos(null);
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [wallet, nonce]);
+
+  return pos;
+}

--- a/src/hooks/use-morpheus-stake.ts
+++ b/src/hooks/use-morpheus-stake.ts
@@ -1,0 +1,145 @@
+"use client";
+
+// Morpheus stake / withdraw on Ethereum MAINNET (phases 1–2).
+//
+// stake() passes the athlete's wallet as `referrer_`, so the athlete accrues a
+// protocol-funded referral bonus (3–15% tiered) at zero cost to the depositor —
+// this is the athlete's "cut", since Morpheus has no fee skim to route through a
+// split. The claim flow (MOR out, LayerZero fee) and the opt-in donate split
+// come in a later phase.
+//
+// Everything is a real mainnet tx (gas is not cheap) — the UI flags that.
+
+import { useCallback, useRef, useState } from "react";
+import { prepareTransaction, sendTransaction, waitForReceipt } from "thirdweb";
+import { ethereum } from "thirdweb/chains";
+import {
+  createPublicClient, http, fallback, encodeFunctionData, parseUnits, erc20Abi, type Address,
+} from "viem";
+import { mainnet } from "viem/chains";
+import { useWriteAccount } from "@/hooks/use-write-account";
+import { ensureOnChain } from "@/lib/thirdweb-tx";
+import { getThirdwebClient } from "@/lib/thirdweb";
+import { MORPHEUS_POOLS, MOR_REWARD_POOL_INDEX, depositPoolAbi, type MorpheusAsset } from "@/lib/morpheus";
+
+const rpc = createPublicClient({
+  chain: mainnet,
+  transport: fallback([
+    http("https://ethereum.publicnode.com"),
+    http("https://eth.llamarpc.com"),
+    http("https://rpc.ankr.com/eth"),
+  ]),
+});
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function waitForAllowance(token: Address, owner: Address, spender: Address, needed: bigint, tries = 12): Promise<void> {
+  for (let i = 0; i < tries; i++) {
+    try {
+      const a = await rpc.readContract({ address: token, abi: erc20Abi, functionName: "allowance", args: [owner, spender] });
+      if (a >= needed) return;
+    } catch { /* keep polling */ }
+    await sleep(1500);
+  }
+}
+
+export type MorpheusPhase = "idle" | "approve" | "stake" | "withdraw" | "done" | "error";
+
+export function useMorpheusStake() {
+  const writer = useWriteAccount();
+  const [phase, setPhase] = useState<MorpheusPhase>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const pending = useRef(false);
+
+  /** Stake `amount` of the asset, crediting the athlete as referrer. */
+  const stake = useCallback(
+    async (asset: MorpheusAsset, amount: string, athlete: Address): Promise<boolean> => {
+      if (pending.current) return false;
+      const client = getThirdwebClient();
+      if (!client) { setError("Thirdweb not configured."); setPhase("error"); return false; }
+      if (!writer) { setError("Connect your wallet."); setPhase("error"); return false; }
+      const { pool, token, decimals } = MORPHEUS_POOLS[asset];
+
+      let assets: bigint;
+      try { assets = parseUnits(amount, decimals); } catch { setError("Invalid amount."); setPhase("error"); return false; }
+      if (assets <= BigInt(0)) { setError("Invalid amount."); setPhase("error"); return false; }
+
+      const account = writer.account;
+      setError(null);
+      pending.current = true;
+      try {
+        await ensureOnChain(writer.wallet, ethereum);
+
+        const allowance = await rpc.readContract({ address: token, abi: erc20Abi, functionName: "allowance", args: [account.address as Address, pool] });
+        if (allowance < assets) {
+          setPhase("approve");
+          const approveData = encodeFunctionData({ abi: erc20Abi, functionName: "approve", args: [pool, assets] });
+          const approveTx = prepareTransaction({ client, chain: ethereum, to: token, data: approveData });
+          const hash = (await sendTransaction({ account, transaction: approveTx })).transactionHash;
+          await waitForReceipt({ client, chain: ethereum, transactionHash: hash });
+          await waitForAllowance(token, account.address as Address, pool, assets);
+        }
+
+        setPhase("stake");
+        // claimLockEnd = 0 → no extra lock beyond the protocol's 7-day default.
+        const stakeData = encodeFunctionData({
+          abi: depositPoolAbi, functionName: "stake",
+          args: [MOR_REWARD_POOL_INDEX, assets, BigInt(0), athlete],
+        });
+        const sendStake = async () => {
+          const tx = prepareTransaction({ client, chain: ethereum, to: pool, data: stakeData });
+          return (await sendTransaction({ account, transaction: tx })).transactionHash;
+        };
+        let stakeHash: `0x${string}`;
+        try { stakeHash = await sendStake(); } catch { await sleep(4000); stakeHash = await sendStake(); }
+        await waitForReceipt({ client, chain: ethereum, transactionHash: stakeHash });
+
+        setPhase("done");
+        return true;
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Stake failed.");
+        setPhase("error");
+        return false;
+      } finally {
+        pending.current = false;
+      }
+    },
+    [writer],
+  );
+
+  /** Withdraw staked principal (reverts before the 7-day lock lifts). */
+  const withdraw = useCallback(
+    async (asset: MorpheusAsset, amount: string): Promise<boolean> => {
+      if (pending.current) return false;
+      const client = getThirdwebClient();
+      if (!client) { setError("Thirdweb not configured."); setPhase("error"); return false; }
+      if (!writer) { setError("Connect your wallet."); setPhase("error"); return false; }
+      const { pool, decimals } = MORPHEUS_POOLS[asset];
+
+      let assets: bigint;
+      try { assets = parseUnits(amount, decimals); } catch { setError("Invalid amount."); setPhase("error"); return false; }
+
+      const account = writer.account;
+      setError(null);
+      pending.current = true;
+      try {
+        await ensureOnChain(writer.wallet, ethereum);
+        setPhase("withdraw");
+        const data = encodeFunctionData({ abi: depositPoolAbi, functionName: "withdraw", args: [MOR_REWARD_POOL_INDEX, assets] });
+        const tx = prepareTransaction({ client, chain: ethereum, to: pool, data });
+        const hash = (await sendTransaction({ account, transaction: tx })).transactionHash;
+        await waitForReceipt({ client, chain: ethereum, transactionHash: hash });
+        setPhase("done");
+        return true;
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Withdrawal failed.");
+        setPhase("error");
+        return false;
+      } finally {
+        pending.current = false;
+      }
+    },
+    [writer],
+  );
+
+  return { stake, withdraw, phase, error, isBusy: phase === "approve" || phase === "stake" || phase === "withdraw" };
+}

--- a/src/lib/morpheus.ts
+++ b/src/lib/morpheus.ts
@@ -1,0 +1,88 @@
+// Morpheus (MOR) Capital — the higher-risk / MOR-reward staking option.
+//
+// A depositor stakes stETH or USDC into a shared Morpheus DepositPool on
+// Ethereum MAINNET; their principal stays theirs (withdrawable after a 7-day
+// lock) and they earn MOR emissions, minted natively on ARBITRUM via LayerZero
+// to whatever address their claim names.
+//
+// Unlike the Morpho vaults (Base, a real fee skim), Morpheus has no protocol
+// skim: 100% of a staker's MOR goes where their own claim points. So the
+// "sponsorship" is (a) the athlete's cut via the `referrer` arg on stake
+// (protocol-funded, additive), and (b) an opt-in redirect of the staker's own
+// MOR to a Gnars/athlete split via setClaimReceiver.
+//
+// Every address here was verified on-chain (bytecode + state) before hardcoding.
+
+import { getAddress, type Address } from "viem";
+
+export const MAINNET_CHAIN_ID = 1;
+export const ARBITRUM_CHAIN_ID = 42161;
+
+/** The shared public "Capital" reward pool index — both stETH and USDC feed it. */
+export const MOR_REWARD_POOL_INDEX = BigInt(0);
+
+/** One DepositPool per asset, all on Ethereum mainnet. */
+export const MORPHEUS_POOLS = {
+  stEth: {
+    pool: getAddress("0x47176B2Af9885dC6C4575d4eFd63895f7Aaa4790"),
+    token: getAddress("0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"), // stETH
+    decimals: 18,
+    symbol: "stETH",
+    /** minimalStake read on-chain (0.01 stETH). */
+    minStake: "0.01",
+  },
+  usdc: {
+    pool: getAddress("0x6cCE082851Add4c535352f596662521B4De4750E"),
+    token: getAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"), // canonical USDC
+    decimals: 6,
+    symbol: "USDC",
+    minStake: "1",
+  },
+} as const;
+
+export type MorpheusAsset = keyof typeof MORPHEUS_POOLS;
+
+/** MOR reward token, on Arbitrum One. */
+export const MOR_TOKEN = getAddress("0x092baadb7def4c3981454dd9c0a0d7ff07bcfc86");
+export const MOR_DECIMALS = 18;
+
+/** 0xSplits SplitV2 PullSplitFactory — same deterministic address on Arbitrum. */
+export const ARBITRUM_PULL_SPLIT_FACTORY = getAddress("0x6B9118074aB15142d7524E8c4ea8f62A3Bdb98f1");
+
+/** 7-day locks (read on-chain from rewardPoolsProtocolDetails(0)). */
+export const WITHDRAW_LOCK_SECONDS = 604800;
+
+// ---- ABIs (exact signatures from the Morpheus source, verified on-chain) ----
+export const depositPoolAbi = [
+  { type: "function", name: "stake", stateMutability: "nonpayable", inputs: [
+    { name: "rewardPoolIndex", type: "uint256" }, { name: "amount", type: "uint256" },
+    { name: "claimLockEnd", type: "uint128" }, { name: "referrer", type: "address" },
+  ], outputs: [] },
+  { type: "function", name: "withdraw", stateMutability: "nonpayable", inputs: [
+    { name: "rewardPoolIndex", type: "uint256" }, { name: "amount", type: "uint256" },
+  ], outputs: [] },
+  { type: "function", name: "claim", stateMutability: "payable", inputs: [
+    { name: "rewardPoolIndex", type: "uint256" }, { name: "receiver", type: "address" },
+  ], outputs: [] },
+  { type: "function", name: "claimFor", stateMutability: "payable", inputs: [
+    { name: "poolId", type: "uint256" }, { name: "user", type: "address" }, { name: "receiver", type: "address" },
+  ], outputs: [] },
+  { type: "function", name: "setClaimReceiver", stateMutability: "nonpayable", inputs: [
+    { name: "rewardPoolIndex", type: "uint256" }, { name: "receiver", type: "address" },
+  ], outputs: [] },
+  { type: "function", name: "getLatestUserReward", stateMutability: "view", inputs: [
+    { name: "rewardPoolIndex", type: "uint256" }, { name: "user", type: "address" },
+  ], outputs: [{ type: "uint256" }] },
+  { type: "function", name: "usersData", stateMutability: "view", inputs: [
+    { name: "user", type: "address" }, { name: "rewardPoolIndex", type: "uint256" },
+  ], outputs: [
+    { name: "lastStake", type: "uint128" }, { name: "deposited", type: "uint256" },
+    { name: "rate", type: "uint256" }, { name: "pendingRewards", type: "uint256" },
+    { name: "claimLockStart", type: "uint128" }, { name: "claimLockEnd", type: "uint128" },
+    { name: "virtualDeposited", type: "uint256" }, { name: "lastClaim", type: "uint128" },
+    { name: "referrer", type: "address" },
+  ] },
+] as const;
+
+/** MOR reward destination for a rider — a 2-recipient Arbitrum split (Gnars/athlete). */
+export type MorpheusSponsor = { morSplit?: Address };


### PR DESCRIPTION
Higher-risk staking tier next to the Base/Moonwell vaults. Stake **stETH or USDC into Morpheus Capital on Ethereum mainnet**; principal stays yours (7-day withdraw lock), earns **MOR** (minted on Arbitrum). The athlete you back is the `referrer_` → protocol-funded bonus, no cost to depositor (Morpheus has no fee skim).

Addresses verified on-chain (`src/lib/morpheus.ts`). Wired: read position, stake, withdraw. Distinct violet "experimental" panel, mainnet-gas warning, kept separate from the safe Base vaults.

Next: claim MOR (LayerZero fee ≈ 0.000475 ETH, quotable via estimateFees) + donate-split on Arbitrum.

Build ✓ tsc ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)