### PR TITLE
feat(stake): Morpheus claim — pull accrued MOR (LayerZero fee quoted)

### DIFF
--- a/src/components/stake/MorpheusPanel.tsx
+++ b/src/components/stake/MorpheusPanel.tsx
@@ -25,7 +25,7 @@ const fmt = (n: number, d = 4) => n.toLocaleString("en-US", { maximumFractionDig
 export function MorpheusPanel() {
   const account = useActiveAccount();
   const you = account?.address;
-  const { stake, withdraw, phase, error, isBusy } = useMorpheusStake();
+  const { stake, withdraw, claim, phase, error, isBusy } = useMorpheusStake();
   const [refresh, setRefresh] = useState(0);
   const position = useMorpheusPosition(you, refresh);
 
@@ -50,6 +50,15 @@ export function MorpheusPanel() {
     const ok = await withdraw(a, String(staked));
     if (ok) { toast.success("Withdrawn"); setRefresh((n) => n + 1); }
     else toast.error("Withdraw failed", { description: error ?? undefined });
+  };
+
+  const onClaim = async (a: MorpheusAsset) => {
+    if (!you) return;
+    // Self-claim to your own address on Arbitrum. Donate-to-split comes with the
+    // Arbitrum splits (needs the SOPA Safe deployed there).
+    const ok = await claim(a, you as `0x${string}`);
+    if (ok) { toast.success("MOR claimed", { description: "Arriving on Arbitrum in a few minutes." }); setRefresh((n) => n + 1); }
+    else toast.error("Claim failed", { description: error ?? undefined });
   };
 
   const phaseLabel =
@@ -127,14 +136,21 @@ export function MorpheusPanel() {
           <div className="space-y-2 border-t border-border/40 pt-3">
             <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Your Morpheus positions</p>
             {position.pools.filter((p) => p.staked > 0).map((p) => (
-              <div key={p.asset} className="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-background/40 px-3 py-2 text-sm">
+              <div key={p.asset} className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-border/60 bg-background/40 px-3 py-2 text-sm">
                 <span className="font-mono">{fmt(p.staked, 4)} {p.symbol}</span>
                 <span className="text-xs text-muted-foreground">
                   {p.pendingMor > 0 ? `${fmt(p.pendingMor, 4)} MOR pending` : "MOR accruing"}
                 </span>
-                <Button size="sm" variant="outline" disabled={isBusy} onClick={() => onWithdraw(p.asset, p.staked)}>
-                  Withdraw
-                </Button>
+                <div className="flex gap-2">
+                  {p.pendingMor > 0 && (
+                    <Button size="sm" disabled={isBusy} onClick={() => onClaim(p.asset)} className="bg-violet-500 text-white hover:bg-violet-600">
+                      {phase === "claim" ? "claiming…" : "Claim MOR"}
+                    </Button>
+                  )}
+                  <Button size="sm" variant="outline" disabled={isBusy} onClick={() => onWithdraw(p.asset, p.staked)}>
+                    Withdraw
+                  </Button>
+                </div>
               </div>
             ))}
             <p className="text-[11px] text-muted-foreground">

--- a/src/hooks/use-morpheus-stake.ts
+++ b/src/hooks/use-morpheus-stake.ts
@@ -14,13 +14,26 @@ import { useCallback, useRef, useState } from "react";
 import { prepareTransaction, sendTransaction, waitForReceipt } from "thirdweb";
 import { ethereum } from "thirdweb/chains";
 import {
-  createPublicClient, http, fallback, encodeFunctionData, parseUnits, erc20Abi, type Address,
+  createPublicClient, http, fallback, encodeFunctionData, encodeAbiParameters, parseUnits, erc20Abi, type Address,
 } from "viem";
 import { mainnet } from "viem/chains";
 import { useWriteAccount } from "@/hooks/use-write-account";
 import { ensureOnChain } from "@/lib/thirdweb-tx";
 import { getThirdwebClient } from "@/lib/thirdweb";
-import { MORPHEUS_POOLS, MOR_REWARD_POOL_INDEX, depositPoolAbi, type MorpheusAsset } from "@/lib/morpheus";
+import {
+  MORPHEUS_POOLS, MOR_REWARD_POOL_INDEX, depositPoolAbi, type MorpheusAsset,
+  L1_SENDER, LZ_GATEWAY, LZ_DST_CHAIN_ID, LZ_ADAPTER_PARAMS, lzEndpointAbi,
+} from "@/lib/morpheus";
+
+/** Quote the LayerZero native fee for a claim (payload is fixed-size, so amount is nominal). */
+async function quoteClaimFee(user: Address, amount: bigint): Promise<bigint> {
+  const payload = encodeAbiParameters([{ type: "address" }, { type: "uint256" }], [user, amount]);
+  const [nativeFee] = await rpc.readContract({
+    address: LZ_GATEWAY, abi: lzEndpointAbi, functionName: "estimateFees",
+    args: [LZ_DST_CHAIN_ID, L1_SENDER, payload, false, LZ_ADAPTER_PARAMS],
+  });
+  return (nativeFee * BigInt(120)) / BigInt(100); // +20% margin; excess is refunded on-chain
+}
 
 const rpc = createPublicClient({
   chain: mainnet,
@@ -42,7 +55,7 @@ async function waitForAllowance(token: Address, owner: Address, spender: Address
   }
 }
 
-export type MorpheusPhase = "idle" | "approve" | "stake" | "withdraw" | "done" | "error";
+export type MorpheusPhase = "idle" | "approve" | "stake" | "withdraw" | "claim" | "done" | "error";
 
 export function useMorpheusStake() {
   const writer = useWriteAccount();
@@ -141,5 +154,48 @@ export function useMorpheusStake() {
     [writer],
   );
 
-  return { stake, withdraw, phase, error, isBusy: phase === "approve" || phase === "stake" || phase === "withdraw" };
+  /**
+   * Claim accrued MOR to `receiver` (own wallet for self-claim, or a Gnars/athlete
+   * split for donate mode). Pays the quoted LayerZero fee; excess is refunded.
+   */
+  const claim = useCallback(
+    async (asset: MorpheusAsset, receiver: Address): Promise<boolean> => {
+      if (pending.current) return false;
+      const client = getThirdwebClient();
+      if (!client) { setError("Thirdweb not configured."); setPhase("error"); return false; }
+      if (!writer) { setError("Connect your wallet."); setPhase("error"); return false; }
+      const { pool } = MORPHEUS_POOLS[asset];
+      const account = writer.account;
+      setError(null);
+      pending.current = true;
+      try {
+        await ensureOnChain(writer.wallet, ethereum);
+        setPhase("claim");
+        const pending_ = await rpc.readContract({
+          address: pool, abi: depositPoolAbi, functionName: "getLatestUserReward",
+          args: [MOR_REWARD_POOL_INDEX, account.address as Address],
+        });
+        if (pending_ <= BigInt(0)) { setError("No MOR to claim yet."); setPhase("error"); return false; }
+        const fee = await quoteClaimFee(account.address as Address, pending_);
+        const data = encodeFunctionData({ abi: depositPoolAbi, functionName: "claim", args: [MOR_REWARD_POOL_INDEX, receiver] });
+        const tx = prepareTransaction({ client, chain: ethereum, to: pool, data, value: fee });
+        const hash = (await sendTransaction({ account, transaction: tx })).transactionHash;
+        await waitForReceipt({ client, chain: ethereum, transactionHash: hash });
+        setPhase("done");
+        return true;
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Claim failed.");
+        setPhase("error");
+        return false;
+      } finally {
+        pending.current = false;
+      }
+    },
+    [writer],
+  );
+
+  return {
+    stake, withdraw, claim, phase, error,
+    isBusy: phase === "approve" || phase === "stake" || phase === "withdraw" || phase === "claim",
+  };
 }

--- a/src/lib/morpheus.ts
+++ b/src/lib/morpheus.ts
@@ -84,5 +84,25 @@ export const depositPoolAbi = [
   ] },
 ] as const;
 
+// ---- Claim / LayerZero fee (all read on-chain from L1SenderV2's config) ----
+// `claim`/`claimFor` are payable: the ETH pays the LayerZero message that mints
+// MOR on Arbitrum. The message payload is a fixed 64 bytes (abi.encode(address,
+// uint256)), so the native fee is essentially constant (~0.000475 ETH); excess
+// is refunded to the refundTo the contracts pass. We still quote it live so a
+// protocol config change can't silently under-fund the claim.
+export const L1_SENDER = getAddress("0x2Efd4430489e1a05A89c2f51811aC661B7E5FF84");
+export const LZ_GATEWAY = getAddress("0x66A71Dcef29A0fFBDBE3c6a460a3B5BC225Cd675");
+export const LZ_DST_CHAIN_ID = 110; // LayerZero v1 chain id for Arbitrum One
+export const LZ_ADAPTER_PARAMS = "0x" as const;
+
+export const lzEndpointAbi = [{
+  type: "function", name: "estimateFees", stateMutability: "view",
+  inputs: [
+    { name: "dstChainId", type: "uint16" }, { name: "userApplication", type: "address" },
+    { name: "payload", type: "bytes" }, { name: "payInZRO", type: "bool" }, { name: "adapterParam", type: "bytes" },
+  ],
+  outputs: [{ name: "nativeFee", type: "uint256" }, { name: "zroFee", type: "uint256" }],
+}] as const;
+
 /** MOR reward destination for a rider — a 2-recipient Arbitrum split (Gnars/athlete). */
 export type MorpheusSponsor = { morSplit?: Address };


### PR DESCRIPTION
Adds the **claim** flow to the Morpheus tier: read accrued MOR, **quote the LayerZero native fee live** from the endpoint (fixed-size payload → ~0.000475 ETH; +20% margin, excess refunded on-chain), and call `claim(0, receiver)` with it. CTA appears per pool when MOR is pending; self-claims to the connected wallet on Arbitrum.

`L1Sender`/gateway/dstChainId(110)/adapterParams read on-chain and pinned in `morpheus.ts`. The donate-to-split `receiver` comes with the Arbitrum splits (needs the SOPA Safe deployed on Arbitrum).

Build ✓ tsc ✓ lint ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)