### PR TITLE
feat(stake): Morpheus donate mode — route MOR to Gnars/athlete split

### DIFF
--- a/src/components/stake/MorpheusPanel.tsx
+++ b/src/components/stake/MorpheusPanel.tsx
@@ -16,7 +16,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { RIDER_LIST } from "@/lib/gnars-vaults";
-import { MORPHEUS_POOLS, type MorpheusAsset } from "@/lib/morpheus";
+import { MORPHEUS_POOLS, MOR_SPLITS, type MorpheusAsset } from "@/lib/morpheus";
 import { useMorpheusStake } from "@/hooks/use-morpheus-stake";
 import { useMorpheusPosition } from "@/hooks/use-morpheus-position";
 
@@ -25,7 +25,7 @@ const fmt = (n: number, d = 4) => n.toLocaleString("en-US", { maximumFractionDig
 export function MorpheusPanel() {
   const account = useActiveAccount();
   const you = account?.address;
-  const { stake, withdraw, claim, phase, error, isBusy } = useMorpheusStake();
+  const { stake, withdraw, claim, setDonateReceiver, phase, error, isBusy } = useMorpheusStake();
   const [refresh, setRefresh] = useState(0);
   const position = useMorpheusPosition(you, refresh);
 
@@ -54,11 +54,30 @@ export function MorpheusPanel() {
 
   const onClaim = async (a: MorpheusAsset) => {
     if (!you) return;
-    // Self-claim to your own address on Arbitrum. Donate-to-split comes with the
-    // Arbitrum splits (needs the SOPA Safe deployed there).
-    const ok = await claim(a, you as `0x${string}`);
-    if (ok) { toast.success("MOR claimed", { description: "Arriving on Arbitrum in a few minutes." }); setRefresh((n) => n + 1); }
-    else toast.error("Claim failed", { description: error ?? undefined });
+    // Route to the picked rider's split if the user turned donate mode on for
+    // this pool; otherwise self-claim to their own Arbitrum address.
+    const split = MOR_SPLITS[riderId];
+    const receiver = donateAssets[a] && split ? split : (you as `0x${string}`);
+    const ok = await claim(a, receiver);
+    if (ok) {
+      toast.success("MOR claimed", { description: receiver === split ? `Split to Gnars + ${riderId} on Arbitrum.` : "Arriving on Arbitrum in a few minutes." });
+      setRefresh((n) => n + 1);
+    } else toast.error("Claim failed", { description: error ?? undefined });
+  };
+
+  // Which pools the user has flipped into donate mode (points claims at the split).
+  const [donateAssets, setDonateAssets] = useState<Partial<Record<MorpheusAsset, boolean>>>({});
+  const onDonateToggle = async (a: MorpheusAsset) => {
+    const split = MOR_SPLITS[riderId];
+    if (!split || !you) return;
+    const turningOn = !donateAssets[a];
+    const ok = await setDonateReceiver(a, turningOn ? split : (you as `0x${string}`));
+    if (ok) {
+      setDonateAssets((d) => ({ ...d, [a]: turningOn }));
+      toast.success(turningOn ? `Donating MOR to Gnars + ${riderId}` : "Keeping your MOR", {
+        description: turningOn ? "Future claims route to the split — anyone can trigger them." : "Claims go back to your wallet.",
+      });
+    } else toast.error("Failed", { description: error ?? undefined });
   };
 
   const phaseLabel =
@@ -141,7 +160,19 @@ export function MorpheusPanel() {
                 <span className="text-xs text-muted-foreground">
                   {p.pendingMor > 0 ? `${fmt(p.pendingMor, 4)} MOR pending` : "MOR accruing"}
                 </span>
-                <div className="flex gap-2">
+                <div className="flex flex-wrap gap-2">
+                  {MOR_SPLITS[riderId] && (
+                    <Button
+                      size="sm"
+                      variant={donateAssets[p.asset] ? "default" : "outline"}
+                      disabled={isBusy}
+                      onClick={() => onDonateToggle(p.asset)}
+                      className={donateAssets[p.asset] ? "bg-violet-500 text-white hover:bg-violet-600" : ""}
+                      title={`Route this position's MOR to Gnars + ${riderId}`}
+                    >
+                      {donateAssets[p.asset] ? `donating → ${riderId}` : "Donate MOR"}
+                    </Button>
+                  )}
                   {p.pendingMor > 0 && (
                     <Button size="sm" disabled={isBusy} onClick={() => onClaim(p.asset)} className="bg-violet-500 text-white hover:bg-violet-600">
                       {phase === "claim" ? "claiming…" : "Claim MOR"}

--- a/src/hooks/use-morpheus-stake.ts
+++ b/src/hooks/use-morpheus-stake.ts
@@ -194,8 +194,44 @@ export function useMorpheusStake() {
     [writer],
   );
 
+  /**
+   * Donate mode: point this pool's claim receiver at a Gnars/athlete split.
+   * Once set, every future claim (self OR a permissionless keeper `claimFor`)
+   * routes 100% of this position's MOR to the split. Set receiver = own wallet
+   * to turn donate mode off.
+   */
+  const setDonateReceiver = useCallback(
+    async (asset: MorpheusAsset, receiver: Address): Promise<boolean> => {
+      if (pending.current) return false;
+      const client = getThirdwebClient();
+      if (!client) { setError("Thirdweb not configured."); setPhase("error"); return false; }
+      if (!writer) { setError("Connect your wallet."); setPhase("error"); return false; }
+      const { pool } = MORPHEUS_POOLS[asset];
+      const account = writer.account;
+      setError(null);
+      pending.current = true;
+      try {
+        await ensureOnChain(writer.wallet, ethereum);
+        setPhase("stake");
+        const data = encodeFunctionData({ abi: depositPoolAbi, functionName: "setClaimReceiver", args: [MOR_REWARD_POOL_INDEX, receiver] });
+        const tx = prepareTransaction({ client, chain: ethereum, to: pool, data });
+        const hash = (await sendTransaction({ account, transaction: tx })).transactionHash;
+        await waitForReceipt({ client, chain: ethereum, transactionHash: hash });
+        setPhase("done");
+        return true;
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Failed to set donate mode.");
+        setPhase("error");
+        return false;
+      } finally {
+        pending.current = false;
+      }
+    },
+    [writer],
+  );
+
   return {
-    stake, withdraw, claim, phase, error,
+    stake, withdraw, claim, setDonateReceiver, phase, error,
     isBusy: phase === "approve" || phase === "stake" || phase === "withdraw" || phase === "claim",
   };
 }

--- a/src/lib/morpheus.ts
+++ b/src/lib/morpheus.ts
@@ -49,6 +49,24 @@ export const MOR_DECIMALS = 18;
 /** 0xSplits SplitV2 PullSplitFactory — same deterministic address on Arbitrum. */
 export const ARBITRUM_PULL_SPLIT_FACTORY = getAddress("0x6B9118074aB15142d7524E8c4ea8f62A3Bdb98f1");
 
+/**
+ * The Gnars reward recipient on Arbitrum — a dedicated 3-of-3 multisig. NOT the
+ * Base treasury (0x72ad…6f88, a Nouns timelock with no code on Arbitrum, where
+ * MOR would be permanently stuck). Recipient of the Gnars half of every athlete
+ * split, and their owner.
+ */
+export const MOR_GNARS_RECIPIENT = getAddress("0xBe6C3D651d2F6e9eFA562b5a7CDf411304cad076");
+
+/** Per-athlete MOR reward splits on Arbitrum (Gnars 50 / athlete 50). */
+export const MOR_SPLITS: Record<string, Address> = {
+  vlad: getAddress("0x65E849Ac55E5283270383fE0619b61768248152B"),
+  yan: getAddress("0x50f470b0bCFAEC93A81447e762A419BdC1D77207"),
+  r4to: getAddress("0x363C2ea82C3274113e3d712Bb7dB3B551733A76c"),
+  pamtech: getAddress("0xfb3a1b62db94cbB212438537c4E194dE30BC4175"),
+  v2: getAddress("0xeA5BF9B03EDE018d1285d3748183c7c808756909"),
+  zima: getAddress("0x6ed4922635f610381AAF9B3EF8cb192AfB6D94Dc"),
+};
+
 /** 7-day locks (read on-chain from rewardPoolsProtocolDetails(0)). */
 export const WITHDRAW_LOCK_SECONDS = 604800;
 


### PR DESCRIPTION
Completes the Morpheus tier (phases 0→3). Six per-athlete splits deployed on **Arbitrum** (Gnars multisig 50 / athlete 50) are registered, and a **"Donate MOR"** toggle on each position calls `setClaimReceiver(0, split)`: once on, every future claim — self OR a permissionless keeper `claimFor` — routes 100% of that position's MOR to the split instead of the depositor's wallet. Toggle off to keep it.

The Gnars recipient is a dedicated Arbitrum 3-of-3 multisig `0xBe6C…d076`, **not** the Base treasury (`0x72ad…6f88` is a Nouns timelock with no code on Arbitrum — MOR there would be permanently stuck).

**Morpheus tier now complete:** stake stETH/USDC (mainnet, athlete=referrer) · withdraw · claim MOR (LZ fee quoted) · donate-to-split.

Build ✓ tsc ✓ lint ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)