### PR TITLE
fix(stake): stop "transfer amount exceeds allowance" reverts after approve

### DIFF
--- a/src/hooks/use-morpheus-stake.ts
+++ b/src/hooks/use-morpheus-stake.ts
@@ -11,7 +11,10 @@
 // Everything is a real mainnet tx (gas is not cheap) — the UI flags that.
 
 import { useCallback, useRef, useState } from "react";
-import { prepareTransaction, sendTransaction, waitForReceipt } from "thirdweb";
+import {
+  prepareTransaction, sendTransaction, waitForReceipt, readContract, getContract,
+  type ThirdwebClient,
+} from "thirdweb";
 import { ethereum } from "thirdweb/chains";
 import {
   createPublicClient, http, fallback, encodeFunctionData, encodeAbiParameters, parseUnits, erc20Abi, type Address,
@@ -45,14 +48,34 @@ const rpc = createPublicClient({
 });
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-async function waitForAllowance(token: Address, owner: Address, spender: Address, needed: bigint, tries = 12): Promise<void> {
+const ALLOWANCE = "function allowance(address owner, address spender) view returns (uint256)" as const;
+
+/**
+ * Confirm the pool's allowance is high enough *on the RPC that will estimate the
+ * stake* before we send it. Mainnet is ~12s/block and the free fallback RPCs lag
+ * each other, so we treat thirdweb's node (the one that gas-estimates the write)
+ * as the source of truth and use the viem fallback only as a secondary signal.
+ * Returns false if the allowance never propagates in the poll window — the
+ * caller then aborts with a friendly "try again" instead of broadcasting a tx
+ * that reverts with "transfer amount exceeds allowance".
+ */
+async function confirmAllowance(
+  client: ThirdwebClient, token: Address, owner: Address, spender: Address, needed: bigint,
+  tries = 24,
+): Promise<boolean> {
+  const contract = getContract({ client, chain: ethereum, address: token });
   for (let i = 0; i < tries; i++) {
     try {
-      const a = await rpc.readContract({ address: token, abi: erc20Abi, functionName: "allowance", args: [owner, spender] });
-      if (a >= needed) return;
+      const a = await readContract({ contract, method: ALLOWANCE, params: [owner, spender] });
+      if (a >= needed) return true;
     } catch { /* keep polling */ }
-    await sleep(1500);
+    try {
+      const a = await rpc.readContract({ address: token, abi: erc20Abi, functionName: "allowance", args: [owner, spender] });
+      if (a >= needed) return true;
+    } catch { /* keep polling */ }
+    await sleep(2000);
   }
+  return false;
 }
 
 export type MorpheusPhase = "idle" | "approve" | "stake" | "withdraw" | "claim" | "done" | "error";
@@ -89,7 +112,16 @@ export function useMorpheusStake() {
           const approveTx = prepareTransaction({ client, chain: ethereum, to: token, data: approveData });
           const hash = (await sendTransaction({ account, transaction: approveTx })).transactionHash;
           await waitForReceipt({ client, chain: ethereum, transactionHash: hash });
-          await waitForAllowance(token, account.address as Address, pool, assets);
+          // Wait until the pool's allowance is actually visible on the estimation
+          // RPC — otherwise the stake reverts with "transfer amount exceeds
+          // allowance". If it never propagates, abort cleanly rather than
+          // broadcasting a doomed tx.
+          const ok = await confirmAllowance(client, token, account.address as Address, pool, assets);
+          if (!ok) {
+            setError("Approval is still confirming on-chain — give it a few seconds and tap Stake again.");
+            setPhase("error");
+            return false;
+          }
         }
 
         setPhase("stake");

--- a/src/hooks/use-stake-deposit.ts
+++ b/src/hooks/use-stake-deposit.ts
@@ -8,7 +8,7 @@
 // no vault behind it yet.
 
 import { useCallback, useRef, useState } from "react";
-import { prepareTransaction, sendTransaction, waitForReceipt, readContract, getContract } from "thirdweb";
+import { prepareTransaction, sendTransaction, waitForReceipt, readContract, getContract, type ThirdwebClient } from "thirdweb";
 import { base } from "thirdweb/chains";
 import {
   createPublicClient, http, fallback,
@@ -34,14 +34,26 @@ const rpc = createPublicClient({
 });
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-async function waitForAllowance(owner: Address, spender: Address, needed: bigint, tries = 12): Promise<void> {
+// Confirm the vault's allowance is visible on the RPC that estimates the deposit
+// (thirdweb's node) — not just the viem fallback, which can lag out of sync and
+// let a doomed "transfer amount exceeds allowance" tx through. Returns false if
+// it never propagates so the caller can abort cleanly.
+async function confirmAllowance(
+  client: ThirdwebClient, owner: Address, spender: Address, needed: bigint, tries = 16,
+): Promise<boolean> {
+  const contract = getContract({ client, chain: base, address: USDC });
   for (let i = 0; i < tries; i++) {
     try {
+      const a = await readContract({ contract, method: ALLOWANCE, params: [owner, spender] });
+      if (a >= needed) return true;
+    } catch { /* keep polling */ }
+    try {
       const a = await rpc.readContract({ address: USDC, abi: viemErc20Abi, functionName: "allowance", args: [owner, spender] });
-      if (a >= needed) return;
+      if (a >= needed) return true;
     } catch { /* keep polling */ }
     await sleep(1500);
   }
+  return false;
 }
 
 const erc20Abi = [{
@@ -132,7 +144,12 @@ export function useStakeDeposit() {
           // Don't send the deposit until the allowance is actually visible — this
           // is what makes a single click work instead of failing with a scary
           // "insufficient allowance" and needing a second try.
-          await waitForAllowance(account.address as Address, vault, assets);
+          const ok = await confirmAllowance(client, account.address as Address, vault, assets);
+          if (!ok) {
+            setError("Approval is still confirming on-chain — give it a few seconds and tap Stake again.");
+            setPhase("error");
+            return false;
+          }
         }
 
         setPhase("deposit");


### PR DESCRIPTION
## The bug

Staking failed with **`ERC20: transfer amount exceeds allowance`** right after the approve — the classic "click twice" allowance race, on both the Morpheus mainnet stake and the Base Morpho deposit.

## Root cause

After approving, both hooks confirmed the fresh allowance by polling **only the viem fallback RPCs**, then returned even on timeout and broadcast the tx anyway. But the write's gas estimation runs against **thirdweb's node**. On mainnet (~12s blocks + free public RPCs) the two RPC sets fall out of sync — the fallback could report the allowance (or just time out) while thirdweb's node still rejected the tx with `transfer amount exceeds allowance`.

## Fix

- Poll the allowance on the **same RPC that estimates the write** (thirdweb's node) as the source of truth; keep the viem fallback as a secondary signal.
- Be more patient on mainnet (24×2s ≈ 48s).
- **Abort cleanly** with `Approval is still confirming on-chain — give it a few seconds and tap Stake again.` instead of broadcasting a doomed tx when the allowance never propagates.

Applied to both `use-morpheus-stake.ts` (mainnet) and `use-stake-deposit.ts` (Base). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)