### PR TITLE
fix(stake): approve the Morpheus distributor, not the pool

### DIFF
--- a/src/hooks/use-morpheus-stake.ts
+++ b/src/hooks/use-morpheus-stake.ts
@@ -24,7 +24,7 @@ import { useWriteAccount } from "@/hooks/use-write-account";
 import { ensureOnChain } from "@/lib/thirdweb-tx";
 import { getThirdwebClient } from "@/lib/thirdweb";
 import {
-  MORPHEUS_POOLS, MOR_REWARD_POOL_INDEX, depositPoolAbi, type MorpheusAsset,
+  MORPHEUS_POOLS, MORPHEUS_DISTRIBUTOR, MOR_REWARD_POOL_INDEX, depositPoolAbi, type MorpheusAsset,
   L1_SENDER, LZ_GATEWAY, LZ_DST_CHAIN_ID, LZ_ADAPTER_PARAMS, lzEndpointAbi,
 } from "@/lib/morpheus";
 
@@ -105,18 +105,21 @@ export function useMorpheusStake() {
       try {
         await ensureOnChain(writer.wallet, ethereum);
 
-        const allowance = await rpc.readContract({ address: token, abi: erc20Abi, functionName: "allowance", args: [account.address as Address, pool] });
+        // The Distributor (not the DepositPool we call `stake` on) is what pulls
+        // the deposit token, so the approval must name the distributor as spender.
+        const spender = MORPHEUS_DISTRIBUTOR;
+        const allowance = await rpc.readContract({ address: token, abi: erc20Abi, functionName: "allowance", args: [account.address as Address, spender] });
         if (allowance < assets) {
           setPhase("approve");
-          const approveData = encodeFunctionData({ abi: erc20Abi, functionName: "approve", args: [pool, assets] });
+          const approveData = encodeFunctionData({ abi: erc20Abi, functionName: "approve", args: [spender, assets] });
           const approveTx = prepareTransaction({ client, chain: ethereum, to: token, data: approveData });
           const hash = (await sendTransaction({ account, transaction: approveTx })).transactionHash;
           await waitForReceipt({ client, chain: ethereum, transactionHash: hash });
-          // Wait until the pool's allowance is actually visible on the estimation
-          // RPC — otherwise the stake reverts with "transfer amount exceeds
-          // allowance". If it never propagates, abort cleanly rather than
-          // broadcasting a doomed tx.
-          const ok = await confirmAllowance(client, token, account.address as Address, pool, assets);
+          // Wait until the allowance is actually visible on the estimation RPC —
+          // otherwise the stake reverts with "transfer amount exceeds allowance".
+          // If it never propagates, abort cleanly rather than broadcasting a
+          // doomed tx.
+          const ok = await confirmAllowance(client, token, account.address as Address, spender, assets);
           if (!ok) {
             setError("Approval is still confirming on-chain — give it a few seconds and tap Stake again.");
             setPhase("error");

--- a/src/lib/morpheus.ts
+++ b/src/lib/morpheus.ts
@@ -42,6 +42,17 @@ export const MORPHEUS_POOLS = {
 
 export type MorpheusAsset = keyof typeof MORPHEUS_POOLS;
 
+/**
+ * The shared Morpheus Distributor. `DepositPool.stake()` delegates the token
+ * `transferFrom` to THIS contract, so the deposit-token approval must be granted
+ * to the distributor — NOT the per-asset DepositPool we call `stake` on.
+ *
+ * Verified by a state-override `eth_call`: with an allowance to the pool, stake
+ * reverts "ERC20: transfer amount exceeds allowance"; with an allowance to the
+ * distributor, the same stake succeeds. Both pools report the same distributor.
+ */
+export const MORPHEUS_DISTRIBUTOR = getAddress("0xDf1AC1AC255d91F5f4B1E3B4Aef57c5350F64C7A");
+
 /** MOR reward token, on Arbitrum One. */
 export const MOR_TOKEN = getAddress("0x092baadb7def4c3981454dd9c0a0d7ff07bcfc86");
 export const MOR_DECIMALS = 18;


### PR DESCRIPTION
## The bug

Every Morpheus stake reverted with **`ERC20: transfer amount exceeds allowance`** — even after PR #187's race fix, because it was never a race.

## Root cause

`DepositPool.stake()` delegates the deposit-token `transferFrom` to the shared **Distributor** (`0xDf1AC1AC255d91F5f4B1E3B4Aef57c5350F64C7A`). So the token approval has to name the **distributor** as spender — but we were approving the per-asset **DepositPool** that we call `stake` on. The distributor's allowance stayed 0, so its `transferFrom` reverted every time.

## Proof (state-override `eth_call`)

Simulated `stake(0, 1 USDC, 0, vlad)` from a funded test address:

| Allowance granted to | Result |
|---|---|
| DepositPool | ❌ `execution reverted: ERC20: transfer amount exceeds allowance` |
| Distributor | ✅ stake succeeds |

Both pools (stETH + USDC) report the same distributor.

## Fix

Approve the distributor (and confirm *that* allowance) while still sending `stake` to the per-asset pool. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)