### PR TITLE
fix(stake): no scroll jump when selecting a rider

### DIFF
--- a/src/components/stake/CharacterSelector.tsx
+++ b/src/components/stake/CharacterSelector.tsx
@@ -202,7 +202,12 @@ export function CharacterSelector({ initialRider }: { initialRider?: string } = 
               "radial-gradient(120% 90% at 50% 38%, rgba(245,140,30,.22) 0%, rgba(245,140,30,0) 52%), linear-gradient(180deg,#161210,#0c0a08)",
           }}
         >
-          <AnimatePresence initial={false} custom={direction} mode="popLayout">
+          {/* Default (sync) mode: both cut-outs are absolutely positioned inside
+              the stage and cross-fade in place. Avoid mode="popLayout" here — it
+              portals the exiting cut-out onto document.body, where its
+              top/bottom percentages blow up the page height and yank the scroll
+              upward on every select. */}
+          <AnimatePresence initial={false} custom={direction}>
             <motion.div
               key={active.id}
               custom={direction}


### PR DESCRIPTION
## The bug

Selecting a character (roster tile or arrows) yanked the page scroll **upward**.

## Cause

The stage's `AnimatePresence` used `mode="popLayout"`. popLayout portals the **exiting** element onto `document.body`. The cut-out is `absolute top-[6%] bottom-[6%]` relative to its stage — on `document.body` those percentages resolve against the whole page, blowing up the document height and pulling the scroll up on every select.

## Fix

Both cut-outs are already absolutely positioned inside the stage, so popLayout was unnecessary. Drop it and let the default (sync) mode cross-fade them in place — same visual, no body portal, no scroll jump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)