### PR TITLE
feat(stake): Morpheus (MOR) stakes as green streams in the orbit

### DIFF
--- a/messages/en/stake.json
+++ b/messages/en/stake.json
@@ -70,7 +70,9 @@
     "you": "you",
     "loading": "loading the flow…",
     "treasury": "TREASURY",
-    "earnedForTreasury": "Earned for treasury"
+    "earnedForTreasury": "Earned for treasury",
+    "legendVault": "Morpho vault",
+    "legendMor": "Morpheus · MOR"
   },
   "backing": "<b>{amount}</b> backing {name}",
   "loadingSupport": "loading support…",

--- a/messages/pt-br/stake.json
+++ b/messages/pt-br/stake.json
@@ -70,7 +70,9 @@
     "you": "você",
     "loading": "carregando o fluxo…",
     "treasury": "TESOURO",
-    "earnedForTreasury": "Rendeu pro tesouro"
+    "earnedForTreasury": "Rendeu pro tesouro",
+    "legendVault": "Vault Morpho",
+    "legendMor": "Morpheus · MOR"
   },
   "backing": "<b>{amount}</b> apoiando {name}",
   "loadingSupport": "carregando apoio…",

--- a/src/components/stake/StakeOrbit.tsx
+++ b/src/components/stake/StakeOrbit.tsx
@@ -25,6 +25,9 @@ const RIDER_VISUAL: Record<RiderId, { hex: string; image: string; face: { size: 
 const usd = (n: number) => `$${n.toLocaleString("en-US", { maximumFractionDigits: n > 0 && n < 100 ? 2 : 0 })}`;
 const short = (a: string) => `${a.slice(0, 5)}…${a.slice(-3)}`;
 const GOLD = "#f7c948";
+// Morpheus green — MOR stakes get their own colored stream, distinct from the
+// rider-tinted Morpho vault flows, so a wallet that backs both shows two lines.
+const MOR_GREEN = "#2be58b";
 
 const W = 760;
 const C = W / 2;
@@ -80,6 +83,22 @@ export function StakeOrbit() {
         </div>
       </div>
 
+      <div className="mb-3 flex flex-wrap items-center gap-4 text-[11px] text-white/50">
+        <span className="flex items-center gap-1.5">
+          <span className="h-2 w-2 rounded-full bg-white/60" />
+          {t("orbit.legendVault")}
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span
+            className="flex h-3.5 w-3.5 items-center justify-center rounded-full text-[8px] font-black text-[#04140d]"
+            style={{ background: MOR_GREEN }}
+          >
+            M
+          </span>
+          {t("orbit.legendMor")}
+        </span>
+      </div>
+
       <div className="overflow-x-auto">
         <svg viewBox={`0 0 ${W} ${W}`} className="mx-auto block h-auto w-full max-w-[640px]" role="img" aria-label={t("orbit.title")}>
           <style>{`
@@ -118,16 +137,28 @@ export function StakeOrbit() {
                   const bp = pt(angle + off, R_SUP);
                   const mid = { x: (ap.x + bp.x) / 2, y: (ap.y + bp.y) / 2 };
                   const isYou = you && b.address.toLowerCase() === you;
+                  const isMor = b.kind === "mor";
+                  const col = isMor ? MOR_GREEN : v.hex;
                   return (
-                    <g key={b.address}>
-                      <line x1={bp.x} y1={bp.y} x2={ap.x} y2={ap.y} stroke={v.hex} strokeOpacity={0.35} strokeWidth={supW(b.amount)} strokeLinecap="round" />
-                      <line x1={bp.x} y1={bp.y} x2={ap.x} y2={ap.y} className="so-flow" stroke={v.hex} strokeWidth={supW(b.amount)} strokeLinecap="round" />
+                    <g key={`${b.kind}-${b.address}`}>
+                      <line x1={bp.x} y1={bp.y} x2={ap.x} y2={ap.y} stroke={col} strokeOpacity={0.35} strokeWidth={supW(b.amount)} strokeLinecap="round" />
+                      <line x1={bp.x} y1={bp.y} x2={ap.x} y2={ap.y} className="so-flow" stroke={col} strokeWidth={supW(b.amount)} strokeLinecap="round" />
                       {/* value on the line */}
                       <text x={mid.x} y={mid.y - 4} textAnchor="middle" fontSize="11" fontWeight="700" fill="#fff" style={{ paintOrder: "stroke", stroke: "#0c0a08", strokeWidth: 3 }}>
                         {usd(b.amount)}
                       </text>
-                      {/* backer node */}
-                      <circle cx={bp.x} cy={bp.y} r={isYou ? 9 : 7} fill={isYou ? GOLD : "#0c0a08"} stroke={isYou ? GOLD : v.hex} strokeWidth={2} />
+                      {/* backer node — MOR stakes carry the green Morpheus "M" mark */}
+                      <circle
+                        cx={bp.x} cy={bp.y} r={isYou ? 9 : 7}
+                        fill={isMor ? col : isYou ? GOLD : "#0c0a08"}
+                        stroke={isYou ? GOLD : col}
+                        strokeWidth={2}
+                      />
+                      {isMor && (
+                        <text x={bp.x} y={bp.y + 3} textAnchor="middle" fontSize="9" fontWeight="900" fill="#04140d">
+                          M
+                        </text>
+                      )}
                       <text x={bp.x} y={bp.y + (bp.y < C ? -14 : 20)} textAnchor="middle" fontSize="9.5" fill={isYou ? GOLD : "rgba(255,255,255,.55)"} fontFamily="monospace" fontWeight={isYou ? 700 : 400}>
                         {isYou ? t("orbit.you") : short(b.address)}
                       </text>

--- a/src/hooks/use-stake-graph.ts
+++ b/src/hooks/use-stake-graph.ts
@@ -10,8 +10,9 @@
 
 import { useEffect, useState } from "react";
 import { createPublicClient, http, fallback, formatUnits, getAddress, type Address } from "viem";
-import { base } from "viem/chains";
+import { base, mainnet } from "viem/chains";
 import { RIDER_LIST, type RiderId } from "@/lib/gnars-vaults";
+import { MORPHEUS_POOLS, MOR_REWARD_POOL_INDEX, depositPoolAbi } from "@/lib/morpheus";
 
 const client = createPublicClient({
   chain: base,
@@ -22,13 +23,42 @@ const client = createPublicClient({
   ]),
 });
 
+// Morpheus deposits live on Ethereum mainnet; a separate client reads them.
+const ethClient = createPublicClient({
+  chain: mainnet,
+  transport: fallback([
+    http("https://ethereum.publicnode.com"),
+    http("https://eth.llamarpc.com"),
+    http("https://rpc.ankr.com/eth"),
+  ]),
+});
+
+// The referrer is indexed, so we can pull exactly the Morpheus stakes that named
+// one of our riders — cheaply, without scanning every staker on the pool.
+const userReferredEvent = {
+  type: "event", name: "UserReferred",
+  inputs: [
+    { name: "rewardPoolIndex", type: "uint256", indexed: true },
+    { name: "user", type: "address", indexed: true },
+    { name: "referrer", type: "address", indexed: true },
+    { name: "amount", type: "uint256", indexed: false },
+  ],
+} as const;
+
 const abi = [
   { type: "function", name: "totalAssets", stateMutability: "view", inputs: [], outputs: [{ type: "uint256" }] },
   { type: "function", name: "balanceOf", stateMutability: "view", inputs: [{ type: "address" }], outputs: [{ type: "uint256" }] },
   { type: "function", name: "convertToAssets", stateMutability: "view", inputs: [{ type: "uint256" }], outputs: [{ type: "uint256" }] },
 ] as const;
 
-export type OrbitBacker = { address: Address; amount: number };
+export type OrbitBacker = {
+  address: Address;
+  amount: number;
+  /** "vault" = Morpho USDC sponsorship vault (Base); "mor" = Morpheus stake (mainnet). */
+  kind: "vault" | "mor";
+  /** For MOR backers, which asset they staked. */
+  asset?: "steth" | "usdc";
+};
 export type OrbitAthlete = {
   id: RiderId;
   handle: string;
@@ -73,6 +103,81 @@ async function backerAddresses(vault: Address, feeRecipient?: Address): Promise<
   return out;
 }
 
+async function fetchEthUsd(): Promise<number> {
+  try {
+    const res = await fetch("/api/eth-price");
+    if (!res.ok) return 0;
+    const json = (await res.json()) as { usd?: number };
+    return json.usd ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Morpheus (MOR) backers per rider — the mainnet stakes that named a rider as
+ * referrer. Kept separate from the vault backers, so a wallet that staked on
+ * BOTH shows up twice (a green MOR stream and a Morpho one). Best-effort: on any
+ * RPC hiccup the orbit just falls back to the vault backers.
+ */
+async function morBackersByRider(ethUsd: number): Promise<Record<string, OrbitBacker[]>> {
+  const walletToId = new Map<string, RiderId>();
+  for (const r of RIDER_LIST) if (r.wallet) walletToId.set(r.wallet.toLowerCase(), r.id);
+  const referrers = [...walletToId.keys()].map((a) => getAddress(a));
+  const out: Record<string, OrbitBacker[]> = {};
+  if (referrers.length === 0) return out;
+
+  let latest: bigint;
+  try { latest = await ethClient.getBlockNumber(); } catch { return out; }
+  // Gnars referrals only started recently; a ~2-week window (chunked to stay
+  // under public-RPC getLogs limits) covers them without a full-history scan.
+  const WINDOW = BigInt(90_000);
+  const CHUNK = BigInt(45_000);
+  const from0 = latest > WINDOW ? latest - WINDOW : BigInt(0);
+
+  const pools: Array<{ asset: "steth" | "usdc"; pool: Address; decimals: number }> = [
+    { asset: "steth", pool: MORPHEUS_POOLS.stEth.pool, decimals: 18 },
+    { asset: "usdc", pool: MORPHEUS_POOLS.usdc.pool, decimals: 6 },
+  ];
+
+  for (const { asset, pool, decimals } of pools) {
+    const userToRef = new Map<string, string>(); // user (lc) -> referrer (lc)
+    for (let start = from0; start <= latest; start += CHUNK + BigInt(1)) {
+      const end = start + CHUNK > latest ? latest : start + CHUNK;
+      try {
+        const logs = await ethClient.getLogs({
+          address: pool, event: userReferredEvent,
+          args: { rewardPoolIndex: MOR_REWARD_POOL_INDEX, referrer: referrers },
+          fromBlock: start, toBlock: end,
+        });
+        for (const l of logs) {
+          const user = l.args.user as Address | undefined;
+          const ref = l.args.referrer as Address | undefined;
+          if (user && ref) userToRef.set(user.toLowerCase(), ref.toLowerCase());
+        }
+      } catch { /* skip this chunk */ }
+    }
+
+    for (const [userLc, refLc] of userToRef) {
+      const id = walletToId.get(refLc);
+      if (!id) continue;
+      try {
+        const ud = (await ethClient.readContract({
+          address: pool, abi: depositPoolAbi, functionName: "usersData",
+          args: [getAddress(userLc), MOR_REWARD_POOL_INDEX],
+        })) as unknown as readonly bigint[];
+        const deposited = ud[1] ?? BigInt(0); // struct field: deposited
+        if (deposited <= BigInt(0)) continue;
+        const tokens = Number(formatUnits(deposited, decimals));
+        const amount = asset === "steth" ? tokens * ethUsd : tokens; // stETH≈ETH, USDC=$1
+        if (amount <= 0) continue;
+        (out[id] ||= []).push({ address: getAddress(userLc), amount, kind: "mor", asset });
+      } catch { /* skip this user */ }
+    }
+  }
+  return out;
+}
+
 export function useStakeGraph(nonce = 0): StakeGraph | null {
   const [graph, setGraph] = useState<StakeGraph | null>(null);
 
@@ -83,6 +188,8 @@ export function useStakeGraph(nonce = 0): StakeGraph | null {
 
     (async () => {
       try {
+        const ethUsd = await fetchEthUsd();
+        const morPromise = morBackersByRider(ethUsd);
         const athletes = await Promise.all(
           live.map(async (r): Promise<OrbitAthlete> => {
             const vault = r.vault as Address;
@@ -93,7 +200,7 @@ export function useStakeGraph(nonce = 0): StakeGraph | null {
               const shares = await client.readContract({ address: vault, abi, functionName: "balanceOf", args: [address] });
               if (shares <= BigInt(0)) continue;
               const assets = await client.readContract({ address: vault, abi, functionName: "convertToAssets", args: [shares] });
-              backers.push({ address, amount: Number(formatUnits(assets, 6)) });
+              backers.push({ address, amount: Number(formatUnits(assets, 6)), kind: "vault" });
             }
             backers.sort((a, b) => b.amount - a.amount);
 
@@ -113,7 +220,16 @@ export function useStakeGraph(nonce = 0): StakeGraph | null {
             };
           }),
         );
+        const mor = await morPromise;
         if (cancelled) return;
+        // Attach MOR backers (kept distinct from vault backers) and re-rank.
+        for (const a of athletes) {
+          const m = mor[a.id];
+          if (m && m.length) {
+            a.backers.push(...m);
+            a.backers.sort((x, y) => y.amount - x.amount);
+          }
+        }
         const distinct = new Set<string>();
         athletes.forEach((a) => a.backers.forEach((b) => distinct.add(b.address.toLowerCase())));
         setGraph({


### PR DESCRIPTION
## What

The sponsorship orbit now shows **Morpheus (MOR) stakes** alongside the Morpho vault flows — in **Morpheus green** with an **"M"** node mark, so backing a rider's MOR pool is visible too.

A wallet that staked on **both** Morpho and Morpheus shows **two separate streams** into the athlete (as requested) — MOR backers are never merged into the vault backers.

## Attribution (cheap + honest)

`UserReferred(rewardPoolIndex, user, **indexed referrer**, amount)` lets us pull exactly the mainnet stakes that named one of our riders:

- one `getLogs` per pool, filtered to the rider wallets (chunked, ~2-week window)
- current size from `usersData(user, 0).deposited`, valued in USD (stETH≈ETH, USDC=$1)
- **best-effort**: any RPC hiccup just falls back to the vault backers — the orbit never breaks

## UI

- Green flowing streams + green "M" node for MOR backers; rider-tinted flows for the Morpho vault unchanged.
- Small legend: **● Morpho vault** · **Ⓜ Morpheus · MOR**. Localized en + pt-br.

`tsc` + `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)