### PR TITLE
feat(stake): close the MOR loop — 3-way split rewards + lootbox claim

### DIFF
--- a/messages/en/stake.json
+++ b/messages/en/stake.json
@@ -123,6 +123,18 @@
     "principal": "principal",
     "yield": "yield"
   },
+  "lootbox": {
+    "title": "Rewards ready",
+    "claim": "Claim",
+    "claiming": "claiming…",
+    "distribute": "Split",
+    "distributing": "splitting…",
+    "bridging": "MOR claimed — bridging to Arbitrum (~a few min). Come back to Split it.",
+    "claimedTitle": "MOR claimed",
+    "distributedTitle": "MOR split — you kept 50%",
+    "failed": "Didn’t go through",
+    "hint": "You keep 50% · Gnars 25% · athlete 25%"
+  },
   "admin": {
     "title": "Sponsorship vaults",
     "desc": "One Morpho vault per rider. Deposits earn on Moonwell; half the yield becomes a fee split Gnars 25% / athlete 25% (the depositor keeps 50%). Owner = SOPA Safe. You sign the deploy and the batch — 1 of the Safe’s 2 confirmations.",

--- a/messages/pt-br/stake.json
+++ b/messages/pt-br/stake.json
@@ -123,6 +123,18 @@
     "principal": "principal",
     "yield": "rendimento"
   },
+  "lootbox": {
+    "title": "Recompensas prontas",
+    "claim": "Sacar",
+    "claiming": "sacando…",
+    "distribute": "Dividir",
+    "distributing": "dividindo…",
+    "bridging": "MOR sacado — indo pra Arbitrum (~alguns min). Volte pra Dividir.",
+    "claimedTitle": "MOR sacado",
+    "distributedTitle": "MOR dividido — você ficou com 50%",
+    "failed": "Não rolou",
+    "hint": "Você fica com 50% · Gnars 25% · atleta 25%"
+  },
   "admin": {
     "title": "Cofres de patrocínio",
     "desc": "Um vault Morpho por rider. Depósito rende na Moonwell; metade do rendimento vira fee dividida Gnars 25% / atleta 25% (o depositante fica com 50%). Owner = Safe da SOPA. Você assina o deploy e o batch — 1 das 2 confirmações do Safe.",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,13 @@
+allowBuilds:
+  '@parcel/watcher': set this to true or false
+  '@sentry/cli': set this to true or false
+  '@swc/core': set this to true or false
+  '@tailwindcss/oxide': set this to true or false
+  bufferutil: set this to true or false
+  esbuild: set this to true or false
+  keccak: set this to true or false
+  msw: set this to true or false
+  protobufjs: set this to true or false
+  sharp: set this to true or false
+  unrs-resolver: set this to true or false
+  utf-8-validate: set this to true or false

--- a/src/app/[locale]/stake/[rider]/page.tsx
+++ b/src/app/[locale]/stake/[rider]/page.tsx
@@ -5,6 +5,7 @@ import { CharacterSelector } from "@/components/stake/CharacterSelector";
 import { StakeAdminPanel } from "@/components/stake/StakeAdminPanel";
 import { StakeOrbit } from "@/components/stake/StakeOrbit";
 import { MorpheusPanel } from "@/components/stake/MorpheusPanel";
+import { MorLootbox } from "@/components/stake/MorLootbox";
 import { RIDER_LIST, getRider } from "@/lib/gnars-vaults";
 import { STAKE_MINIAPP_EMBED_CONFIG } from "@/lib/miniapp-config";
 import { BASE_URL } from "@/lib/config";
@@ -91,6 +92,7 @@ export default async function StakeRiderPage({
         <MorpheusPanel />
         <StakeAdminPanel />
       </div>
+      <MorLootbox />
     </div>
   );
 }

--- a/src/app/[locale]/stake/page.tsx
+++ b/src/app/[locale]/stake/page.tsx
@@ -4,6 +4,7 @@ import { CharacterSelector } from "@/components/stake/CharacterSelector";
 import { StakeAdminPanel } from "@/components/stake/StakeAdminPanel";
 import { StakeOrbit } from "@/components/stake/StakeOrbit";
 import { MorpheusPanel } from "@/components/stake/MorpheusPanel";
+import { MorLootbox } from "@/components/stake/MorLootbox";
 import { STAKE_MINIAPP_EMBED_CONFIG } from "@/lib/miniapp-config";
 
 export async function generateMetadata({
@@ -67,6 +68,7 @@ export default async function StakePage({ params }: { params: Promise<{ locale: 
         <MorpheusPanel />
         <StakeAdminPanel />
       </div>
+      <MorLootbox />
     </div>
   );
 }

--- a/src/components/stake/MorLootbox.tsx
+++ b/src/components/stake/MorLootbox.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+// Floating "lootbox" that appears when the connected wallet has MOR to collect.
+// One tap closes the Morpheus loop:
+//   1. Claim  — pull accrued MOR from mainnet to your 3-way split (LayerZero).
+//   2. Split  — once it lands on Arbitrum, deploy (if needed) + distribute:
+//               you keep 50%, Gnars 25%, athlete 25%.
+// Because the claim bridges cross-chain, the box shows a "bridging" beat between
+// the two steps, and re-surfaces the Split action whenever a split is funded —
+// even on a later visit, without another claim.
+
+import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { useActiveAccount } from "thirdweb/react";
+import { AnimatePresence, motion } from "framer-motion";
+import { Gift, Sparkles, X } from "lucide-react";
+import { toast } from "sonner";
+import { type Address } from "viem";
+import { Button } from "@/components/ui/button";
+import { useMorpheusPosition } from "@/hooks/use-morpheus-position";
+import { useMorpheusStake } from "@/hooks/use-morpheus-stake";
+import { useMorDistribute } from "@/hooks/use-mor-distribute";
+import { predictSplitAddress, splitMorBalance } from "@/lib/mor-split";
+import type { MorpheusAsset } from "@/lib/morpheus";
+
+const ZERO = "0x0000000000000000000000000000000000000000";
+const LOOT_MIN_MOR = 0.0001; // ignore dust
+const MOR_GREEN = "#2be58b";
+const fmt = (n: number) => n.toLocaleString("en-US", { maximumFractionDigits: 4 });
+
+export function MorLootbox() {
+  const t = useTranslations("stake");
+  const you = useActiveAccount()?.address;
+  const [nonce, setNonce] = useState(0);
+  const position = useMorpheusPosition(you, nonce);
+  const morpheus = useMorpheusStake();
+  const { distribute, isBusy: distributing } = useMorDistribute();
+
+  const [open, setOpen] = useState(false);
+  const [splitBalances, setSplitBalances] = useState<Partial<Record<MorpheusAsset, number>>>({});
+  const [busyAsset, setBusyAsset] = useState<MorpheusAsset | null>(null);
+
+  // Read what's already sitting at each position's split on Arbitrum.
+  useEffect(() => {
+    if (!you || !position) { setSplitBalances({}); return; }
+    let cancelled = false;
+    (async () => {
+      const eligible = position.pools.filter((p) => p.staked > 0 && p.referrer && p.referrer.toLowerCase() !== ZERO);
+      const entries = await Promise.all(
+        eligible.map(async (p) => [p.asset, await splitMorBalance(you as Address, p.referrer)] as const),
+      );
+      if (!cancelled) setSplitBalances(Object.fromEntries(entries));
+    })();
+    return () => { cancelled = true; };
+  }, [you, position, nonce]);
+
+  const pools = position?.pools ?? [];
+  const claimable = pools.filter((p) => p.pendingMor > LOOT_MIN_MOR && p.referrer && p.referrer.toLowerCase() !== ZERO);
+  const distributable = pools.filter((p) => (splitBalances[p.asset] ?? 0) > LOOT_MIN_MOR);
+  const hasAction = claimable.length > 0 || distributable.length > 0;
+
+  const refresh = () => setNonce((n) => n + 1);
+
+  const onClaim = useCallback(
+    async (asset: MorpheusAsset, referrer: Address) => {
+      if (!you) return;
+      setBusyAsset(asset);
+      try {
+        const split = await predictSplitAddress(you as Address, referrer);
+        const ok = await morpheus.claim(asset, split);
+        if (ok) {
+          toast.success(t("lootbox.claimedTitle"), { description: t("lootbox.bridging") });
+          refresh();
+        } else {
+          toast.error(t("lootbox.failed"), { description: morpheus.error ?? undefined });
+        }
+      } finally {
+        setBusyAsset(null);
+      }
+    },
+    [you, morpheus, t],
+  );
+
+  const onDistribute = useCallback(
+    async (asset: MorpheusAsset, referrer: Address) => {
+      setBusyAsset(asset);
+      try {
+        const ok = await distribute(referrer);
+        if (ok) {
+          toast.success(t("lootbox.distributedTitle"), { description: t("lootbox.hint") });
+          refresh();
+        } else {
+          toast.error(t("lootbox.failed"));
+        }
+      } finally {
+        setBusyAsset(null);
+      }
+    },
+    [distribute, t],
+  );
+
+  if (!you || !hasAction) return null;
+
+  const totalClaimable = claimable.reduce((s, p) => s + p.pendingMor, 0);
+  const totalDistributable = distributable.reduce((s, p) => s + (splitBalances[p.asset] ?? 0), 0);
+  const badge = totalClaimable + totalDistributable;
+
+  return (
+    <div className="fixed bottom-5 right-5 z-50 flex flex-col items-end gap-3">
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            key="panel"
+            initial={{ opacity: 0, y: 12, scale: 0.96 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 12, scale: 0.96 }}
+            transition={{ duration: 0.18 }}
+            className="w-[300px] rounded-2xl border border-border bg-surface p-4 shadow-2xl"
+          >
+            <div className="mb-3 flex items-center justify-between">
+              <span className="flex items-center gap-1.5 text-sm font-bold text-foreground">
+                <Sparkles className="h-4 w-4" style={{ color: MOR_GREEN }} />
+                {t("lootbox.title")}
+              </span>
+              <button type="button" onClick={() => setOpen(false)} className="cursor-pointer text-foreground-subtle hover:text-foreground">
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+
+            <div className="space-y-2">
+              {claimable.map((p) => (
+                <div key={`c-${p.asset}`} className="flex items-center justify-between gap-2 rounded-lg border border-border/60 bg-surface-elevated px-3 py-2">
+                  <span className="text-xs text-foreground-muted">
+                    <b className="font-mono text-foreground">{fmt(p.pendingMor)}</b> MOR · {p.symbol}
+                  </span>
+                  <Button
+                    size="sm"
+                    disabled={busyAsset === p.asset || morpheus.isBusy}
+                    onClick={() => onClaim(p.asset, p.referrer)}
+                    className="h-7 gap-1 text-white"
+                    style={{ backgroundColor: MOR_GREEN, color: "#04140d" }}
+                  >
+                    {busyAsset === p.asset && morpheus.isBusy ? t("lootbox.claiming") : t("lootbox.claim")}
+                  </Button>
+                </div>
+              ))}
+
+              {distributable.map((p) => (
+                <div key={`d-${p.asset}`} className="flex items-center justify-between gap-2 rounded-lg border border-border/60 bg-surface-elevated px-3 py-2">
+                  <span className="text-xs text-foreground-muted">
+                    <b className="font-mono text-foreground">{fmt(splitBalances[p.asset] ?? 0)}</b> MOR · {p.symbol}
+                  </span>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={busyAsset === p.asset || distributing}
+                    onClick={() => onDistribute(p.asset, p.referrer)}
+                    className="h-7"
+                  >
+                    {busyAsset === p.asset && distributing ? t("lootbox.distributing") : t("lootbox.distribute")}
+                  </Button>
+                </div>
+              ))}
+            </div>
+
+            <p className="mt-3 text-[11px] leading-snug text-foreground-subtle">{t("lootbox.hint")}</p>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Floating lootbox trigger */}
+      <motion.button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-label={t("lootbox.title")}
+        className="relative flex h-16 w-16 cursor-pointer items-center justify-center rounded-2xl shadow-xl"
+        style={{ background: "linear-gradient(160deg,#123, #04140d)", border: `1px solid ${MOR_GREEN}55` }}
+        animate={{ y: [0, -6, 0] }}
+        transition={{ duration: 2.4, repeat: Infinity, ease: "easeInOut" }}
+        whileHover={{ scale: 1.06 }}
+        whileTap={{ scale: 0.94 }}
+      >
+        {/* pulsing glow */}
+        <motion.span
+          aria-hidden
+          className="absolute inset-0 rounded-2xl"
+          style={{ boxShadow: `0 0 24px 2px ${MOR_GREEN}` }}
+          animate={{ opacity: [0.35, 0.8, 0.35] }}
+          transition={{ duration: 2, repeat: Infinity, ease: "easeInOut" }}
+        />
+        <Gift className="relative h-7 w-7" style={{ color: MOR_GREEN }} />
+        <span
+          className="absolute -right-1.5 -top-1.5 flex min-w-5 items-center justify-center rounded-full px-1.5 text-[10px] font-black"
+          style={{ backgroundColor: MOR_GREEN, color: "#04140d" }}
+        >
+          {badge >= 1 ? Math.floor(badge) : "!"}
+        </span>
+      </motion.button>
+    </div>
+  );
+}

--- a/src/components/stake/MorpheusPanel.tsx
+++ b/src/components/stake/MorpheusPanel.tsx
@@ -16,7 +16,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { RIDER_LIST } from "@/lib/gnars-vaults";
-import { MORPHEUS_POOLS, MOR_SPLITS, type MorpheusAsset } from "@/lib/morpheus";
+import { MORPHEUS_POOLS, type MorpheusAsset } from "@/lib/morpheus";
 import { useMorpheusStake } from "@/hooks/use-morpheus-stake";
 import { useMorpheusPosition } from "@/hooks/use-morpheus-position";
 
@@ -25,7 +25,7 @@ const fmt = (n: number, d = 4) => n.toLocaleString("en-US", { maximumFractionDig
 export function MorpheusPanel() {
   const account = useActiveAccount();
   const you = account?.address;
-  const { stake, withdraw, claim, setDonateReceiver, phase, error, isBusy } = useMorpheusStake();
+  const { stake, withdraw, phase, error, isBusy } = useMorpheusStake();
   const [refresh, setRefresh] = useState(0);
   const position = useMorpheusPosition(you, refresh);
 
@@ -52,37 +52,10 @@ export function MorpheusPanel() {
     else toast.error("Withdraw failed", { description: error ?? undefined });
   };
 
-  const onClaim = async (a: MorpheusAsset) => {
-    if (!you) return;
-    // Route to the picked rider's split if the user turned donate mode on for
-    // this pool; otherwise self-claim to their own Arbitrum address.
-    const split = MOR_SPLITS[riderId];
-    const receiver = donateAssets[a] && split ? split : (you as `0x${string}`);
-    const ok = await claim(a, receiver);
-    if (ok) {
-      toast.success("MOR claimed", { description: receiver === split ? `Split to Gnars + ${riderId} on Arbitrum.` : "Arriving on Arbitrum in a few minutes." });
-      setRefresh((n) => n + 1);
-    } else toast.error("Claim failed", { description: error ?? undefined });
-  };
-
-  // Which pools the user has flipped into donate mode (points claims at the split).
-  const [donateAssets, setDonateAssets] = useState<Partial<Record<MorpheusAsset, boolean>>>({});
-  const onDonateToggle = async (a: MorpheusAsset) => {
-    const split = MOR_SPLITS[riderId];
-    if (!split || !you) return;
-    const turningOn = !donateAssets[a];
-    const ok = await setDonateReceiver(a, turningOn ? split : (you as `0x${string}`));
-    if (ok) {
-      setDonateAssets((d) => ({ ...d, [a]: turningOn }));
-      toast.success(turningOn ? `Donating MOR to Gnars + ${riderId}` : "Keeping your MOR", {
-        description: turningOn ? "Future claims route to the split — anyone can trigger them." : "Claims go back to your wallet.",
-      });
-    } else toast.error("Failed", { description: error ?? undefined });
-  };
-
   const phaseLabel =
     phase === "approve" ? `approving ${MORPHEUS_POOLS[asset].symbol}…`
     : phase === "stake" ? "staking on mainnet…"
+    : phase === "setReceiver" ? "linking reward split…"
     : phase === "withdraw" ? "withdrawing…"
     : `Stake ${MORPHEUS_POOLS[asset].symbol}`;
 
@@ -146,7 +119,8 @@ export function MorpheusPanel() {
 
         <p className="flex items-start gap-1.5 text-xs text-muted-foreground">
           <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-violet-400" />
-          Principal is yours, withdrawable after a 7-day lock. MOR arrives on Arbitrum; claiming it comes next.
+          Principal is yours, withdrawable after a 7-day lock. Your MOR routes to a 3-way split
+          (you 50% · Gnars 25% · athlete 25%) — collect it from the floating reward box.
           Start small — mainnet gas can rival a small stake.
         </p>
 
@@ -161,23 +135,6 @@ export function MorpheusPanel() {
                   {p.pendingMor > 0 ? `${fmt(p.pendingMor, 4)} MOR pending` : "MOR accruing"}
                 </span>
                 <div className="flex flex-wrap gap-2">
-                  {MOR_SPLITS[riderId] && (
-                    <Button
-                      size="sm"
-                      variant={donateAssets[p.asset] ? "default" : "outline"}
-                      disabled={isBusy}
-                      onClick={() => onDonateToggle(p.asset)}
-                      className={donateAssets[p.asset] ? "bg-violet-500 text-white hover:bg-violet-600" : ""}
-                      title={`Route this position's MOR to Gnars + ${riderId}`}
-                    >
-                      {donateAssets[p.asset] ? `donating → ${riderId}` : "Donate MOR"}
-                    </Button>
-                  )}
-                  {p.pendingMor > 0 && (
-                    <Button size="sm" disabled={isBusy} onClick={() => onClaim(p.asset)} className="bg-violet-500 text-white hover:bg-violet-600">
-                      {phase === "claim" ? "claiming…" : "Claim MOR"}
-                    </Button>
-                  )}
                   <Button size="sm" variant="outline" disabled={isBusy} onClick={() => onWithdraw(p.asset, p.staked)}>
                     Withdraw
                   </Button>

--- a/src/hooks/use-mor-distribute.ts
+++ b/src/hooks/use-mor-distribute.ts
@@ -1,0 +1,94 @@
+"use client";
+
+// Second half of the MOR loop, on ARBITRUM: once a staker's claimed MOR has
+// bridged to their deterministic 3-way split, deploy the split (lazily, if it
+// doesn't exist yet) and `distribute` it — pushing staker 50 / Gnars 25 /
+// athlete 25 straight to their wallets (PushSplit, no warehouse withdraw).
+//
+// The split address is deterministic and was set as the claim receiver at stake
+// time, so the MOR is already sitting there. distribute() is permissionless —
+// whoever clicks pays the (tiny) Arbitrum gas.
+
+import { useCallback, useRef, useState } from "react";
+import { prepareTransaction, sendTransaction, waitForReceipt } from "thirdweb";
+import { arbitrum } from "thirdweb/chains";
+import { encodeFunctionData, type Address } from "viem";
+import { useWriteAccount } from "@/hooks/use-write-account";
+import { ensureOnChain } from "@/lib/thirdweb-tx";
+import { getThirdwebClient } from "@/lib/thirdweb";
+import { ARBITRUM_PUSH_SPLIT_FACTORY, MOR_TOKEN } from "@/lib/morpheus";
+import {
+  splitParamsFor, predictSplitAddress, isSplitDeployed,
+  pushSplitFactoryAbi, splitWalletAbi, SPLIT_OWNER, SPLIT_SALT,
+} from "@/lib/mor-split";
+
+export type DistributePhase = "idle" | "deploy" | "distribute" | "done" | "error";
+
+export function useMorDistribute() {
+  const writer = useWriteAccount();
+  const [phase, setPhase] = useState<DistributePhase>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const pending = useRef(false);
+
+  /**
+   * Deploy (if needed) and distribute the caller's 3-way split for `athlete`,
+   * paying out any MOR that has arrived at the split address.
+   */
+  const distribute = useCallback(
+    async (athlete: Address): Promise<boolean> => {
+      if (pending.current) return false;
+      const client = getThirdwebClient();
+      if (!client) { setError("Thirdweb not configured."); setPhase("error"); return false; }
+      if (!writer) { setError("Connect your wallet."); setPhase("error"); return false; }
+      const account = writer.account;
+      const staker = account.address as Address;
+      const params = splitParamsFor(staker, athlete);
+
+      setError(null);
+      pending.current = true;
+      try {
+        await ensureOnChain(writer.wallet, arbitrum);
+        const split = await predictSplitAddress(staker, athlete);
+
+        // Deploy the split the first time — same params/owner/salt reproduce the
+        // predicted address the MOR was sent to.
+        if (!(await isSplitDeployed(staker, athlete))) {
+          setPhase("deploy");
+          const deployData = encodeFunctionData({
+            abi: pushSplitFactoryAbi, functionName: "createSplitDeterministic",
+            args: [params, SPLIT_OWNER, staker, SPLIT_SALT],
+          });
+          const deployTx = prepareTransaction({ client, chain: arbitrum, to: ARBITRUM_PUSH_SPLIT_FACTORY, data: deployData });
+          const dHash = (await sendTransaction({ account, transaction: deployTx })).transactionHash;
+          await waitForReceipt({ client, chain: arbitrum, transactionHash: dHash });
+        }
+
+        setPhase("distribute");
+        const distData = encodeFunctionData({
+          abi: splitWalletAbi, functionName: "distribute",
+          args: [params, MOR_TOKEN, staker],
+        });
+        const distTx = prepareTransaction({ client, chain: arbitrum, to: split, data: distData });
+        const hash = (await sendTransaction({ account, transaction: distTx })).transactionHash;
+        await waitForReceipt({ client, chain: arbitrum, transactionHash: hash });
+
+        setPhase("done");
+        return true;
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Distribute failed.");
+        setPhase("error");
+        return false;
+      } finally {
+        pending.current = false;
+      }
+    },
+    [writer],
+  );
+
+  return {
+    distribute,
+    phase,
+    error,
+    isBusy: phase === "deploy" || phase === "distribute",
+  };
+}

--- a/src/hooks/use-morpheus-position.ts
+++ b/src/hooks/use-morpheus-position.ts
@@ -31,6 +31,8 @@ export type MorpheusPoolPosition = {
   pendingMor: number;
   /** Unix seconds when the withdraw lock lifts (0 if nothing staked). */
   unlockAt: number;
+  /** The athlete credited as referrer for this position (drives the 3-way split). */
+  referrer: Address;
 };
 
 export type MorpheusPositions = {
@@ -60,11 +62,13 @@ export function useMorpheusPosition(wallet?: string, nonce = 0): MorpheusPositio
             ]);
             const lastStake = Number(data[0]); // uint128 lastStake
             const deposited = data[1]; // uint256 deposited
+            const referrer = data[8] as Address; // stored referrer (athlete)
             return {
               asset, symbol,
               staked: Number(formatUnits(deposited, decimals)),
               pendingMor: Number(formatUnits(reward, MOR_DECIMALS)),
               unlockAt: deposited > BigInt(0) ? lastStake + WITHDRAW_LOCK_SECONDS : 0,
+              referrer,
             } satisfies MorpheusPoolPosition;
           }),
         );

--- a/src/hooks/use-morpheus-stake.ts
+++ b/src/hooks/use-morpheus-stake.ts
@@ -27,6 +27,7 @@ import {
   MORPHEUS_POOLS, MORPHEUS_DISTRIBUTOR, MOR_REWARD_POOL_INDEX, depositPoolAbi, type MorpheusAsset,
   L1_SENDER, LZ_GATEWAY, LZ_DST_CHAIN_ID, LZ_ADAPTER_PARAMS, lzEndpointAbi,
 } from "@/lib/morpheus";
+import { predictSplitAddress } from "@/lib/mor-split";
 
 /** Quote the LayerZero native fee for a claim (payload is fixed-size, so amount is nominal). */
 async function quoteClaimFee(user: Address, amount: bigint): Promise<bigint> {
@@ -78,7 +79,7 @@ async function confirmAllowance(
   return false;
 }
 
-export type MorpheusPhase = "idle" | "approve" | "stake" | "withdraw" | "claim" | "done" | "error";
+export type MorpheusPhase = "idle" | "approve" | "stake" | "setReceiver" | "withdraw" | "claim" | "done" | "error";
 
 export function useMorpheusStake() {
   const writer = useWriteAccount();
@@ -140,6 +141,19 @@ export function useMorpheusStake() {
         let stakeHash: `0x${string}`;
         try { stakeHash = await sendStake(); } catch { await sleep(4000); stakeHash = await sendStake(); }
         await waitForReceipt({ client, chain: ethereum, transactionHash: stakeHash });
+
+        // Route this position's MOR to the staker's deterministic 3-way split by
+        // default (opt-out): staker 50 / Gnars 25 / athlete 25. Only the staker
+        // can set their own receiver, so this is a 2nd signature. Non-fatal: the
+        // stake already succeeded, and the receiver can also be set at claim time.
+        try {
+          setPhase("setReceiver");
+          const split = await predictSplitAddress(account.address as Address, athlete);
+          const rData = encodeFunctionData({ abi: depositPoolAbi, functionName: "setClaimReceiver", args: [MOR_REWARD_POOL_INDEX, split] });
+          const rTx = prepareTransaction({ client, chain: ethereum, to: pool, data: rData });
+          const rHash = (await sendTransaction({ account, transaction: rTx })).transactionHash;
+          await waitForReceipt({ client, chain: ethereum, transactionHash: rHash });
+        } catch { /* receiver not set; claim can still target the split explicitly */ }
 
         setPhase("done");
         return true;
@@ -267,6 +281,6 @@ export function useMorpheusStake() {
 
   return {
     stake, withdraw, claim, setDonateReceiver, phase, error,
-    isBusy: phase === "approve" || phase === "stake" || phase === "withdraw" || phase === "claim",
+    isBusy: phase === "approve" || phase === "stake" || phase === "setReceiver" || phase === "withdraw" || phase === "claim",
   };
 }

--- a/src/lib/mor-split.ts
+++ b/src/lib/mor-split.ts
@@ -1,0 +1,109 @@
+// Per-staker 3-way MOR reward split (staker 50% / Gnars 25% / athlete 25%).
+//
+// This mirrors the Morpho vault's sponsorship model for the Morpheus tier:
+// instead of the athlete-only referrer bonus, a supporter points their MOR
+// claim receiver at a deterministic 0xSplits PushSplit whose recipients are
+// themselves, the Gnars Arbitrum multisig, and the athlete.
+//
+// Deterministic-lazy: the split's address is computed BEFORE it exists, so the
+// staker can set it as their claim receiver on mainnet and MOR accrues at that
+// Arbitrum address. The split contract is deployed lazily (createSplitDeterministic
+// with the SAME params/owner/salt → SAME address, verified on-chain) and then
+// `distribute` pushes each recipient's cut. Owner = address(0) → immutable, so
+// nobody can rewrite a staker's split.
+
+import {
+  createPublicClient, http, fallback, getAddress, type Address,
+} from "viem";
+import { arbitrum } from "viem/chains";
+import { ARBITRUM_PUSH_SPLIT_FACTORY, MOR_TOKEN, MOR_GNARS_RECIPIENT } from "@/lib/morpheus";
+
+export const SPLIT_TOTAL_ALLOCATION = BigInt(1_000_000);
+/** staker 50% / Gnars 25% / athlete 25% (of 1,000,000). */
+export const SPLIT_ALLOC = {
+  staker: BigInt(500_000),
+  gnars: BigInt(250_000),
+  athlete: BigInt(250_000),
+} as const;
+
+/** Immutable split, fixed salt — the params already differ per (staker, athlete). */
+export const SPLIT_OWNER = getAddress("0x0000000000000000000000000000000000000000");
+export const SPLIT_SALT = "0x0000000000000000000000000000000000000000000000000000000000000000" as const;
+
+export const arbitrumClient = createPublicClient({
+  chain: arbitrum,
+  transport: fallback([
+    http("https://arb1.arbitrum.io/rpc"),
+    http("https://arbitrum.publicnode.com"),
+    http("https://arbitrum-one.publicnode.com"),
+  ]),
+});
+
+/** SplitV2Lib.Split — recipients, allocations, totalAllocation, distributionIncentive. */
+export type SplitParams = {
+  recipients: readonly Address[];
+  allocations: readonly bigint[];
+  totalAllocation: bigint;
+  distributionIncentive: number;
+};
+
+const splitParamsTuple = {
+  type: "tuple", name: "_splitParams", components: [
+    { name: "recipients", type: "address[]" },
+    { name: "allocations", type: "uint256[]" },
+    { name: "totalAllocation", type: "uint256" },
+    { name: "distributionIncentive", type: "uint16" },
+  ],
+} as const;
+
+export const pushSplitFactoryAbi = [
+  { type: "function", name: "createSplitDeterministic", stateMutability: "nonpayable",
+    inputs: [splitParamsTuple, { name: "_owner", type: "address" }, { name: "_creator", type: "address" }, { name: "_salt", type: "bytes32" }],
+    outputs: [{ name: "split", type: "address" }] },
+  { type: "function", name: "predictDeterministicAddress", stateMutability: "view",
+    inputs: [splitParamsTuple, { name: "_owner", type: "address" }, { name: "_salt", type: "bytes32" }],
+    outputs: [{ type: "address" }] },
+  { type: "function", name: "isDeployed", stateMutability: "view",
+    inputs: [splitParamsTuple, { name: "_owner", type: "address" }, { name: "_salt", type: "bytes32" }],
+    outputs: [{ name: "split", type: "address" }, { name: "exists", type: "bool" }] },
+] as const;
+
+/** distribute(Split, token, distributor) — pushes each recipient's balance of `token`. */
+export const splitWalletAbi = [
+  { type: "function", name: "distribute", stateMutability: "nonpayable",
+    inputs: [splitParamsTuple, { name: "_token", type: "address" }, { name: "_distributor", type: "address" }],
+    outputs: [] },
+] as const;
+
+/**
+ * The split params for a (staker, athlete) pair. Recipient ORDER is fixed —
+ * [staker, Gnars, athlete] — because the deterministic address depends on the
+ * exact params encoding, so predict and deploy must pass them identically.
+ */
+export function splitParamsFor(staker: Address, athlete: Address): SplitParams {
+  return {
+    recipients: [getAddress(staker), MOR_GNARS_RECIPIENT, getAddress(athlete)],
+    allocations: [SPLIT_ALLOC.staker, SPLIT_ALLOC.gnars, SPLIT_ALLOC.athlete],
+    totalAllocation: SPLIT_TOTAL_ALLOCATION,
+    distributionIncentive: 0,
+  };
+}
+
+/** The deterministic Arbitrum address of a staker's 3-way split (exists or not). */
+export async function predictSplitAddress(staker: Address, athlete: Address): Promise<Address> {
+  return arbitrumClient.readContract({
+    address: ARBITRUM_PUSH_SPLIT_FACTORY, abi: pushSplitFactoryAbi,
+    functionName: "predictDeterministicAddress",
+    args: [splitParamsFor(staker, athlete), SPLIT_OWNER, SPLIT_SALT],
+  });
+}
+
+/** Whether a staker's 3-way split has been deployed yet. */
+export async function isSplitDeployed(staker: Address, athlete: Address): Promise<boolean> {
+  const [, exists] = await arbitrumClient.readContract({
+    address: ARBITRUM_PUSH_SPLIT_FACTORY, abi: pushSplitFactoryAbi,
+    functionName: "isDeployed",
+    args: [splitParamsFor(staker, athlete), SPLIT_OWNER, SPLIT_SALT],
+  });
+  return exists;
+}

--- a/src/lib/mor-split.ts
+++ b/src/lib/mor-split.ts
@@ -13,10 +13,10 @@
 // nobody can rewrite a staker's split.
 
 import {
-  createPublicClient, http, fallback, getAddress, type Address,
+  createPublicClient, http, fallback, getAddress, erc20Abi, formatUnits, type Address,
 } from "viem";
 import { arbitrum } from "viem/chains";
-import { ARBITRUM_PUSH_SPLIT_FACTORY, MOR_TOKEN, MOR_GNARS_RECIPIENT } from "@/lib/morpheus";
+import { ARBITRUM_PUSH_SPLIT_FACTORY, MOR_TOKEN, MOR_DECIMALS, MOR_GNARS_RECIPIENT } from "@/lib/morpheus";
 
 export const SPLIT_TOTAL_ALLOCATION = BigInt(1_000_000);
 /** staker 50% / Gnars 25% / athlete 25% (of 1,000,000). */
@@ -106,4 +106,17 @@ export async function isSplitDeployed(staker: Address, athlete: Address): Promis
     args: [splitParamsFor(staker, athlete), SPLIT_OWNER, SPLIT_SALT],
   });
   return exists;
+}
+
+/** MOR sitting at a staker's split on Arbitrum, waiting to be distributed. */
+export async function splitMorBalance(staker: Address, athlete: Address): Promise<number> {
+  try {
+    const split = await predictSplitAddress(staker, athlete);
+    const bal = await arbitrumClient.readContract({
+      address: MOR_TOKEN, abi: erc20Abi, functionName: "balanceOf", args: [split],
+    });
+    return Number(formatUnits(bal, MOR_DECIMALS));
+  } catch {
+    return 0;
+  }
 }

--- a/src/lib/morpheus.ts
+++ b/src/lib/morpheus.ts
@@ -61,6 +61,15 @@ export const MOR_DECIMALS = 18;
 export const ARBITRUM_PULL_SPLIT_FACTORY = getAddress("0x6B9118074aB15142d7524E8c4ea8f62A3Bdb98f1");
 
 /**
+ * 0xSplits SplitV2 **PushSplitFactory** on Arbitrum — verified live (has code;
+ * SPLIT_WALLET_IMPLEMENTATION 0x6291…1b99). Push (not Pull) so `distribute`
+ * delivers the MOR straight to each recipient's wallet instead of parking it in
+ * the SplitsWarehouse for a separate withdraw. Used for the per-staker 3-way
+ * reward splits (staker 50 / Gnars 25 / athlete 25).
+ */
+export const ARBITRUM_PUSH_SPLIT_FACTORY = getAddress("0x80f1B766817D04870f115fEBbcCADF8DBF75E017");
+
+/**
  * The Gnars reward recipient on Arbitrum — a dedicated 3-of-3 multisig. NOT the
  * Base treasury (0x72ad…6f88, a Nouns timelock with no code on Arbitrum, where
  * MOR would be permanently stuck). Recipient of the Gnars half of every athlete


### PR DESCRIPTION
## What

Closes the Morpheus (MOR) loop so a supporter's rewards are shared like the Morpho vault — **staker 50% / Gnars 25% / athlete 25%** — instead of the old opt-in 100%-donate.

## The flow

1. **Stake** (mainnet) → athlete credited as referrer, and — opt-out — the staker's **claim receiver is auto-set** to their deterministic 3-way **PushSplit**.
2. **Claim** (mainnet, via the lootbox) → MOR bridges to the split address on Arbitrum (LayerZero, quoted fee).
3. **Split** (Arbitrum) → deploy the split lazily (`createSplitDeterministic` → the same predicted address the MOR was sent to) + `distribute()` → PushSplit pays all three wallets directly (no warehouse withdraw).

## Lootbox

A floating, animated 🎁 that appears when the connected wallet has MOR to collect. One tap runs claim; once MOR lands on Arbitrum it surfaces the **Split** action (deploy+distribute). It also detects already-funded splits on later visits, so a claim that bridged earlier can still be distributed. Theme-aware, localized **en + pt-br**.

## On-chain verified (not fabricated)

- `predictDeterministicAddress == isDeployed` address for the PushSplit → deterministic-lazy is safe (MOR accrues at the address before the contract exists; deploying later reproduces it).
- `distribute(Split, token, distributor)` signature from the 0xSplits monorepo.
- **PushSplitFactory** `0x80f1…` verified live on Arbitrum (Push, so distribute delivers straight to wallets).

## Files
- `lib/mor-split.ts` (foundation), `lib/morpheus.ts` (PushSplitFactory)
- `hooks/use-mor-distribute.ts` (new), `hooks/use-morpheus-stake.ts` (auto-set receiver), `hooks/use-morpheus-position.ts` (referrer)
- `components/stake/MorLootbox.tsx` (new), `MorpheusPanel.tsx` (migration), stake pages (mount), en+pt-br i18n

`tsc --noEmit` + `next build` clean.

## Test caveat
Mainnet gas is real; claim pays a LayerZero fee and MOR takes a few minutes to bridge before Split works. Start small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)