### PR TITLE
fix(stake): MOR stakes vanished from the orbit — reliable getLogs RPC

### DIFF
--- a/src/services/stake-graph.ts
+++ b/src/services/stake-graph.ts
@@ -15,23 +15,36 @@ import { base, mainnet } from "viem/chains";
 import { RIDER_LIST, type RiderId } from "@/lib/gnars-vaults";
 import { MORPHEUS_POOLS, MOR_REWARD_POOL_INDEX, depositPoolAbi } from "@/lib/morpheus";
 
+// Prefer Alchemy (reliable, handles large getLogs) when the key is set, since
+// the public RPCs frequently fail/timeout on the MOR log scan — and a swallowed
+// failure there means a staker silently vanishes from the orbit.
+const ALCHEMY = process.env.ALCHEMY_API_KEY;
+// eth.drpc.org is the reliable getLogs fallback — the other free mainnet RPCs
+// (publicnode/llama/ankr) reject or rate-limit eth_getLogs, which silently
+// emptied the MOR log scan and dropped stakers from the orbit. Verified: drpc
+// serves the exact referrer-filtered query in ~0.2s.
+const ethRpcs = [
+  ...(ALCHEMY ? [`https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY}`] : []),
+  "https://eth.drpc.org",
+  "https://ethereum.publicnode.com",
+  "https://eth.llamarpc.com",
+];
+const baseRpcs = [
+  ...(ALCHEMY ? [`https://base-mainnet.g.alchemy.com/v2/${ALCHEMY}`] : []),
+  "https://mainnet.base.org",
+  "https://base-rpc.publicnode.com",
+  "https://base.drpc.org",
+];
+
 const baseClient = createPublicClient({
   chain: base,
   batch: { multicall: true },
-  transport: fallback([
-    http("https://mainnet.base.org"),
-    http("https://base-rpc.publicnode.com"),
-    http("https://base.drpc.org"),
-  ]),
+  transport: fallback(baseRpcs.map((u) => http(u))),
 });
 const ethClient = createPublicClient({
   chain: mainnet,
   batch: { multicall: true },
-  transport: fallback([
-    http("https://ethereum.publicnode.com"),
-    http("https://eth.llamarpc.com"),
-    http("https://rpc.ankr.com/eth"),
-  ]),
+  transport: fallback(ethRpcs.map((u) => http(u))),
 });
 
 const userReferredEvent = {
@@ -119,8 +132,10 @@ async function morBackersByRider(ethUsd: number): Promise<Record<string, OrbitBa
 
   let latest: bigint;
   try { latest = await ethClient.getBlockNumber(); } catch { return byRider; }
-  const WINDOW = BigInt(90_000);
-  const CHUNK = BigInt(45_000);
+  // ~3-week window, chunked at 10k so both Alchemy and the public fallback RPCs
+  // accept each range (public nodes reject large getLogs spans).
+  const WINDOW = BigInt(150_000);
+  const CHUNK = BigInt(10_000);
   const from0 = latest > WINDOW ? latest - WINDOW : BigInt(0);
 
   const pools: Array<{ asset: "steth" | "usdc"; pool: Address; decimals: number }> = [


### PR DESCRIPTION
## The bug

MOR stakes never appeared in the orbit's green streams. Root cause: the `UserReferred` **eth_getLogs** scan only had free public RPCs (publicnode / llama / ankr) in its fallback — and **those reject or rate-limit `eth_getLogs`**. Every chunk failed and was silently swallowed (`.catch → []`), so the MOR scan always returned empty and stakers dropped off the orbit.

## Proof

Ran the exact referrer-filtered query across providers:
- `publicnode`: 15/15 chunks errored → 0 logs
- `llama`: HTTP 521 (down)
- **`eth.drpc.org`: works, ~0.2s**, and returned the real stake — a **1 USDC** Morpheus stake with a rider as referrer.

## Fix (own RPC first, public fallback — as suggested)

```
1. Alchemy (ALCHEMY_API_KEY, already used in prod)   ← own RPC
2. eth.drpc.org                                       ← reliable public getLogs
3. publicnode / llama                                 ← last resort
```

Also widened the window to ~3 weeks and chunked at 10k so every provider accepts each range.

`tsc` + `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)