### PR TITLE
fix(stake): per-asset Morpheus APR (was a wrong blended rate)

### DIFF
--- a/src/components/stake/StakeDialog.tsx
+++ b/src/components/stake/StakeDialog.tsx
@@ -107,8 +107,8 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, accent }
   const isMor = opp.kind === "mor";
   const isUsdc = opp.asset === "usdc";
 
-  // APR per opportunity: the Morpho vault's live APY, or the blended Morpheus rate.
-  const aprFor = (o: Opp) => (o.kind === "vault" ? yields?.usdc?.apy : yields?.mor?.apy) ?? 0;
+  // APR per opportunity: the Morpho vault's live APY, or the per-asset Morpheus rate.
+  const aprFor = (o: Opp) => (o.kind === "vault" ? yields?.usdc?.apy : yields?.mor?.[o.asset]?.apy) ?? 0;
   const rate = aprFor(opp);
   const source = isMor ? "Morpheus" : yields?.usdc?.source ?? "Morpho";
 

--- a/src/services/yields.ts
+++ b/src/services/yields.ts
@@ -1,11 +1,7 @@
 // Live staking/lending yields shown on the /stake page.
 // - Lido: stETH staking APR (Ethereum L1)
 // - Morpho: largest listed USDC vault net APY on Base
-// - Morpheus: blended MOR-reward APR on the shared Capital pool (Ethereum L1)
-
-import { createPublicClient, http } from "viem";
-import { mainnet } from "viem/chains";
-import { MORPHEUS_POOLS, MORPHEUS_DISTRIBUTOR, MOR_TOKEN } from "@/lib/morpheus";
+// - Morpheus: MOR-reward APR PER ASSET (see MORPHEUS_APR note)
 
 export interface StakeYield {
   /** Annual rate as a percentage, e.g. 4.35 */
@@ -18,11 +14,16 @@ export interface StakeYield {
   estimate?: boolean;
 }
 
+/** Morpheus shows a distinct APR per deposit asset, not one blended rate. */
+export interface MorpheusYields {
+  steth: StakeYield | null;
+  usdc: StakeYield | null;
+}
+
 export interface StakeYields {
   eth: StakeYield | null;
   usdc: StakeYield | null;
-  /** Blended Morpheus (MOR) reward APR — same rate for the stETH and USDC pools. */
-  mor: StakeYield | null;
+  mor: MorpheusYields;
   updatedAt: number;
 }
 
@@ -31,72 +32,19 @@ const MORPHO_GRAPHQL_URL = "https://blue-api.morpho.org/graphql";
 const BASE_CHAIN_ID = 8453;
 
 // ---- Morpheus (MOR) capital-pool APR ----------------------------------------
-// Emission for the shared reward pool (index 0) is minted MOR/day; it's split
-// across the stETH + USDC deposit pools by their oracle-valued deposits, so the
-// blended APR is: dailyMor * morUsd * 365 / totalTvlUsd. Verified live on-chain
-// (getPeriodRewards / totalDepositedInPublicPools) before wiring.
-const MOR_REWARD_POOL_INDEX = BigInt(0);
-const morMainnet = createPublicClient({
-  chain: mainnet,
-  transport: http(process.env.ETH_RPC_URL || "https://ethereum.publicnode.com"),
-});
-const distributorAbi = [
-  { type: "function", name: "rewardPool", stateMutability: "view", inputs: [], outputs: [{ type: "address" }] },
-] as const;
-const rewardPoolAbi = [
-  { type: "function", name: "getPeriodRewards", stateMutability: "view",
-    inputs: [{ type: "uint256" }, { type: "uint128" }, { type: "uint128" }], outputs: [{ type: "uint256" }] },
-] as const;
-const depositPoolAbi = [
-  { type: "function", name: "totalDepositedInPublicPools", stateMutability: "view", inputs: [], outputs: [{ type: "uint256" }] },
-] as const;
-
-async function coingeckoUsd(url: string, pick: (j: unknown) => number | undefined): Promise<number | null> {
-  try {
-    const res = await fetch(url, { next: { revalidate: 300 } });
-    if (!res.ok) return null;
-    const v = pick(await res.json());
-    return typeof v === "number" && v > 0 ? v : null;
-  } catch {
-    return null;
-  }
-}
-
-async function getMorpheusMorApr(): Promise<StakeYield | null> {
-  try {
-    const rewardPool = await morMainnet.readContract({
-      address: MORPHEUS_DISTRIBUTOR, abi: distributorAbi, functionName: "rewardPool",
-    });
-    const now = Math.floor(Date.now() / 1000);
-    const [daily, stDep, usdcDep, morUsd, ethUsd] = await Promise.all([
-      morMainnet.readContract({
-        address: rewardPool, abi: rewardPoolAbi, functionName: "getPeriodRewards",
-        args: [MOR_REWARD_POOL_INDEX, BigInt(now), BigInt(now + 86400)],
-      }),
-      morMainnet.readContract({ address: MORPHEUS_POOLS.stEth.pool, abi: depositPoolAbi, functionName: "totalDepositedInPublicPools" }),
-      morMainnet.readContract({ address: MORPHEUS_POOLS.usdc.pool, abi: depositPoolAbi, functionName: "totalDepositedInPublicPools" }),
-      coingeckoUsd(
-        `https://api.coingecko.com/api/v3/simple/token_price/arbitrum-one?contract_addresses=${MOR_TOKEN}&vs_currencies=usd`,
-        (j) => (j as Record<string, { usd?: number }>)?.[MOR_TOKEN.toLowerCase()]?.usd,
-      ),
-      coingeckoUsd(
-        "https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd",
-        (j) => (j as { ethereum?: { usd?: number } })?.ethereum?.usd,
-      ),
-    ]);
-    if (!morUsd || !ethUsd) return null;
-
-    const dailyMor = Number(daily) / 1e18;
-    const tvlUsd = (Number(stDep) / 1e18) * ethUsd + Number(usdcDep) / 1e6; // stETH ≈ ETH, USDC = $1
-    if (tvlUsd <= 0) return null;
-
-    const apr = (dailyMor * morUsd * 365) / tvlUsd * 100;
-    if (!isFinite(apr) || apr <= 0) return null;
-    return { apy: apr, source: "Morpheus", detail: "MOR", estimate: true };
-  } catch (error) {
-    console.error("[yields] Morpheus fetch failed:", error);
-    return null;
-  }
+// Morpheus splits its shared reward pool's emissions across deposit pools by an
+// internal virtual/power-adjusted weighting, so each asset shows a distinct APR
+// that can't be reproduced cleanly on-chain — and Morpheus exposes no public API
+// for it (their dashboard computes client-side). These are synced from the
+// Capital table on mor.org; refresh when they drift. Marked estimate=true since
+// MOR emissions and price move.
+const MORPHEUS_APR: Record<"steth" | "usdc", number> = {
+  usdc: 24.5,
+  steth: 16.78,
+};
+function morpheusYields(): MorpheusYields {
+  const mk = (apy: number): StakeYield => ({ apy, source: "Morpheus", detail: "MOR", estimate: true });
+  return { usdc: mk(MORPHEUS_APR.usdc), steth: mk(MORPHEUS_APR.steth) };
 }
 
 async function getLidoEthApr(): Promise<StakeYield | null> {
@@ -141,6 +89,6 @@ async function getMorphoUsdcApy(): Promise<StakeYield | null> {
 }
 
 export async function getStakeYields(): Promise<StakeYields> {
-  const [eth, usdc, mor] = await Promise.all([getLidoEthApr(), getMorphoUsdcApy(), getMorpheusMorApr()]);
-  return { eth, usdc, mor, updatedAt: Date.now() };
+  const [eth, usdc] = await Promise.all([getLidoEthApr(), getMorphoUsdcApy()]);
+  return { eth, usdc, mor: morpheusYields(), updatedAt: Date.now() };
 }


### PR DESCRIPTION
## The bug
The dialog showed **one blended MOR APR (~17.6%)** for both stETH and USDC. But Morpheus shows a **distinct APR per asset**:

| Asset | Morpheus site |
|---|---|
| USDC | 24.50% |
| stETH | 16.78% |

(Total Deposited matched my on-chain reads exactly, so the TVL was right — only the rate split was wrong.)

## Why not compute it on-chain
Morpheus splits the shared reward pool's emissions across deposit pools by an **internal virtual/power-adjusted weighting**. A naive on-chain compute (`getDistributedRewards` delta ÷ TVL) came out **1.5–2.3× too high and inconsistent** between pools, and Morpheus exposes **no public API** (dashboard computes client-side; `api.mor.org` is the inference API).

## Fix
`/api/yields.mor` is now **per-asset** (`{ steth, usdc }`), synced from the Capital table on mor.org and labelled `estimate`. The dialog reads the rate for the chosen asset. The two numbers are a small config to refresh when they drift — honest and matches what Morpheus actually shows, rather than a wrong blended figure.

`tsc` + `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)