### PR TITLE
feat(stake): redesign the stake dialog (Claude design v2) + Flow→Aura

### DIFF
--- a/messages/en/stake.json
+++ b/messages/en/stake.json
@@ -32,7 +32,7 @@
     "ollie": "Ollie",
     "spin": "Style",
     "rail": "Surf",
-    "flow": "Flow",
+    "flow": "Aura",
     "devSkills": "Dev Skills",
     "creativity": "Creativity"
   },
@@ -122,7 +122,17 @@
     "stakedMorDesc": "Earning MOR on Arbitrum — your principal unlocks after 7 days.",
     "yourPosition": "Your position",
     "principal": "principal",
-    "yield": "yield"
+    "yield": "yield",
+    "overall": "Overall",
+    "howRewardsFlow": "How rewards flow",
+    "yieldSource": "Yield source",
+    "yourShare": "Your share",
+    "perYearMor": "/ yr in MOR",
+    "stakeVerb": "Stake",
+    "lineEmpty": "Empty bag? Come on — drop something in and let's roll.",
+    "lineBig": "{amount} {asset}?! That's sponsor money. I'm dropping in.",
+    "lineStable": "Steady wins. {you} {asset} a year back to you — I'll take my cut in grip tape.",
+    "lineVar": "~{rate}% APR is a big air. Could land clean, could slam. You in?"
   },
   "lootbox": {
     "title": "Rewards ready",

--- a/messages/pt-br/stake.json
+++ b/messages/pt-br/stake.json
@@ -32,7 +32,7 @@
     "ollie": "Ollie",
     "spin": "Estilo",
     "rail": "Surf",
-    "flow": "Flow",
+    "flow": "Aura",
     "devSkills": "Habilidade Dev",
     "creativity": "Criatividade"
   },
@@ -122,7 +122,17 @@
     "stakedMorDesc": "Rendendo MOR na Arbitrum — o principal destrava após 7 dias.",
     "yourPosition": "Sua posição",
     "principal": "principal",
-    "yield": "rendimento"
+    "yield": "rendimento",
+    "overall": "Geral",
+    "howRewardsFlow": "Como as recompensas fluem",
+    "yieldSource": "Fonte de rendimento",
+    "yourShare": "Sua parte",
+    "perYearMor": "/ ano em MOR",
+    "stakeVerb": "Stake",
+    "lineEmpty": "Bolsa vazia? Vai, joga algo aí e bora.",
+    "lineBig": "{amount} {asset}?! Isso é dinheiro de patrocínio. Tô dentro.",
+    "lineStable": "Devagar e sempre. {you} {asset} por ano de volta pra você — meu corte eu pego em fita.",
+    "lineVar": "~{rate}% APR é um baita air. Pode cair limpo ou levar tombo. Tá dentro?"
   },
   "lootbox": {
     "title": "Recompensas prontas",

--- a/src/components/stake/CharacterSelector.tsx
+++ b/src/components/stake/CharacterSelector.tsx
@@ -450,6 +450,9 @@ export function CharacterSelector({ initialRider }: { initialRider?: string } = 
         name={name}
         image={active.image}
         accent={active.hex}
+        overall={overall}
+        faceSize={active.face.size}
+        facePos={active.face.pos}
       />
     </div>
   );

--- a/src/components/stake/StakeDialog.tsx
+++ b/src/components/stake/StakeDialog.tsx
@@ -1,59 +1,57 @@
 "use client";
 
-import { useState, type CSSProperties, type ReactNode } from "react";
+import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { useTranslations } from "next-intl";
 import { useQuery } from "@tanstack/react-query";
-import { Info, Zap, Gift, TrendingUp, ShieldCheck, AlertTriangle, User } from "lucide-react";
 import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { getRider } from "@/lib/gnars-vaults";
 import { useStakeDeposit } from "@/hooks/use-stake-deposit";
 import { useMorpheusStake } from "@/hooks/use-morpheus-stake";
 import { useVaultPosition, useVaultEarned } from "@/hooks/use-vault-total";
-
-// Only offer a rewards claim once it's worth more than the gas to take it.
-const CLAIM_FLOOR_USD = 1;
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { cn } from "@/lib/utils";
 import type { StakeYields } from "@/services/yields";
 import { REWARD_SPLIT } from "./CharacterSelector";
-import { StakeFlowChart } from "./StakeFlowChart";
 
-// The opportunities a rider "offers" — a stable Morpho vault plus the two
-// higher-upside Morpheus (MOR) pools. Each drives a different stake flow.
+// Adapted from the Claude-designed "Stake Dialog v2" — arcade-gold, three
+// columns (yield source / amount / your share) over a rewards-flow hero with the
+// rider talking. Real data + the real Morpho/Morpheus logos on each pool.
+
+const GOLD = "#f5a623";
+const GOLD_HI = "#f7c948";
+const CLAIM_FLOOR_USD = 1;
+const MORPHO_LOGO = "/logos/morpho.webp";
+const MORPHEUS_LOGO = "/logos/morpheus.webp";
+
 type OppId = "vault-usdc" | "mor-steth" | "mor-usdc";
 interface Opp {
   id: OppId;
   kind: "vault" | "mor";
-  /** deposit asset */
   asset: "usdc" | "steth";
   unit: string;
   labelKey: string;
+  venue: string;
+  logo: string;
   presets: number[];
   default: string;
 }
 const OPPS: Opp[] = [
-  { id: "vault-usdc", kind: "vault", asset: "usdc", unit: "USDC", labelKey: "opp.vaultUsdc", presets: [100, 500, 1000, 5000], default: "1000" },
-  { id: "mor-steth", kind: "mor", asset: "steth", unit: "stETH", labelKey: "opp.morSteth", presets: [0.01, 0.1, 0.5, 1], default: "0.1" },
-  { id: "mor-usdc", kind: "mor", asset: "usdc", unit: "USDC", labelKey: "opp.morUsdc", presets: [100, 500, 1000, 5000], default: "1000" },
+  { id: "vault-usdc", kind: "vault", asset: "usdc", unit: "USDC", labelKey: "opp.vaultUsdc", venue: "Morpho", logo: MORPHO_LOGO, presets: [100, 500, 1000, 5000], default: "1000" },
+  { id: "mor-steth", kind: "mor", asset: "steth", unit: "stETH", labelKey: "opp.morSteth", venue: "Morpheus", logo: MORPHEUS_LOGO, presets: [0.01, 0.1, 0.5, 1], default: "0.1" },
+  { id: "mor-usdc", kind: "mor", asset: "usdc", unit: "USDC", labelKey: "opp.morUsdc", venue: "Morpheus", logo: MORPHEUS_LOGO, presets: [100, 500, 1000, 5000], default: "1000" },
 ];
 
 interface StakeDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  /** Rider id — picks which sponsorship vault the deposit goes into. */
   riderId: string;
   name: string;
   image: string;
-  accent: string; // hex
+  accent: string;
+  /** Rider overall score (from the roster) — shown as a badge. */
+  overall?: number;
+  /** Head-crop framing for the flow avatar, mirrors the roster tiles. */
+  faceSize?: string;
+  facePos?: string;
 }
 
 async function fetchYields(): Promise<StakeYields> {
@@ -61,7 +59,6 @@ async function fetchYields(): Promise<StakeYields> {
   if (!res.ok) throw new Error("yields");
   return res.json();
 }
-
 async function fetchEthPrice(): Promise<number> {
   const res = await fetch("/api/eth-price");
   if (!res.ok) return 0;
@@ -69,55 +66,36 @@ async function fetchEthPrice(): Promise<number> {
   return json.usd ?? 0;
 }
 
+const fmt2 = (n: number) => n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 function fmtAmount(n: number, usdc: boolean) {
   if (!isFinite(n) || n === 0) return "0";
   if (usdc) return n.toFixed(2);
   return n < 0.001 ? n.toExponential(2) : n.toFixed(n < 1 ? 4 : 3);
 }
 
-function fmtUsd(n: number) {
-  return n.toLocaleString(undefined, {
-    style: "currency",
-    currency: "USD",
-    maximumFractionDigits: n < 100 ? 2 : 0,
-  });
-}
-
-export function StakeDialog({ open, onOpenChange, riderId, name, image, accent }: StakeDialogProps) {
+export function StakeDialog({ open, onOpenChange, riderId, name, image, accent, overall, faceSize = "420%", facePos = "50% 6%" }: StakeDialogProps) {
   const t = useTranslations("stake");
-  const { stake, withdrawAll, claimRewards, phase: stakePhase, error: stakeError, isStaking, account } =
-    useStakeDeposit();
+  const { stake, withdrawAll, claimRewards, phase: stakePhase, error: stakeError, isStaking, account } = useStakeDeposit();
   const morpheus = useMorpheusStake();
   const [refresh, setRefresh] = useState(0);
   const [oppId, setOppId] = useState<OppId>("vault-usdc");
   const [amount, setAmount] = useState(OPPS[0].default);
 
-  const { data: yields } = useQuery({
-    queryKey: ["stake-yields"],
-    queryFn: fetchYields,
-    staleTime: 60_000,
-  });
-  const { data: ethUsd = 0 } = useQuery({
-    queryKey: ["eth-price"],
-    queryFn: fetchEthPrice,
-    staleTime: 60_000,
-  });
+  const { data: yields } = useQuery({ queryKey: ["stake-yields"], queryFn: fetchYields, staleTime: 60_000 });
+  const { data: ethUsd = 0 } = useQuery({ queryKey: ["eth-price"], queryFn: fetchEthPrice, staleTime: 60_000 });
 
   const opp = OPPS.find((o) => o.id === oppId)!;
   const isMor = opp.kind === "mor";
   const isUsdc = opp.asset === "usdc";
 
-  // APR per opportunity: the Morpho vault's live APY, or the per-asset Morpheus rate.
   const aprFor = (o: Opp) => (o.kind === "vault" ? yields?.usdc?.apy : yields?.mor?.[o.asset]?.apy) ?? 0;
   const rate = aprFor(opp);
-  const source = isMor ? "Morpheus" : yields?.usdc?.source ?? "Morpho";
+  const rateKind = isMor ? "APR" : "APY";
 
-  const assetUsd = opp.asset === "steth" ? ethUsd : 1; // stETH ≈ ETH, USDC ≈ $1
+  const assetUsd = opp.asset === "steth" ? ethUsd : 1;
   const amountNum = Math.max(0, parseFloat(amount) || 0);
-  const amountUsd = amountNum * assetUsd;
-  const annualUsd = (amountUsd * rate) / 100; // value/yr; for MOR it's paid in MOR
-  const annualAsset = (amountNum * rate) / 100; // vault: yield in the deposit asset
-
+  const totalAsset = (amountNum * rate) / 100; // yield in the deposit asset
+  const totalUsd = totalAsset * assetUsd;
   const busy = isMor ? morpheus.isBusy : isStaking;
 
   const switchOpp = (next: OppId) => {
@@ -126,332 +104,364 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, accent }
     setAmount(o.default);
   };
 
-  const shares = [
-    { key: "you" as const, label: t("youLabel"), percent: REWARD_SPLIT.you },
-    { key: "skater" as const, label: name, percent: REWARD_SPLIT.skater, image },
-    {
-      key: "treasury" as const,
-      label: t("treasuryLabel"),
-      percent: REWARD_SPLIT.treasury,
-      image: "/gnars.webp",
-    },
-  ];
+  // Shares of the yield — the 3-way split (mirrors the vault and the MOR split).
+  const share = (pct: number) =>
+    isMor ? `≈$${fmt2(totalUsd * (pct / 100))}` : `${fmt2(totalAsset * (pct / 100))} ${opp.unit}`;
 
-  // Vault position (USDC Morpho) — only relevant for the stable opportunity.
+  // Rider one-liner with a typewriter reveal.
+  const line = (() => {
+    if (!amountNum) return t("opp.lineEmpty");
+    if (amountNum >= (isUsdc ? 5000 : 1)) return t("opp.lineBig", { amount: fmtAmount(amountNum, isUsdc), asset: opp.unit });
+    if (opp.kind === "vault") return t("opp.lineStable", { you: fmt2(totalAsset * 0.5), asset: opp.unit });
+    return t("opp.lineVar", { rate: rate.toFixed(1) });
+  })();
+  const [typed, setTyped] = useState(0);
+  const lineRef = useRef(line);
+  lineRef.current = line;
+  useEffect(() => {
+    setTyped(0);
+    const id = setInterval(() => {
+      setTyped((n) => {
+        if (n >= lineRef.current.length) { clearInterval(id); return n; }
+        return n + 1;
+      });
+    }, 24);
+    return () => clearInterval(id);
+  }, [line]);
+
   const rider = getRider(riderId);
   const position = useVaultPosition(rider?.vault, account ?? undefined, refresh);
   const earned = useVaultEarned(rider?.vault, account ?? undefined, refresh);
-
-  const handleClaim = async () => {
-    if (!rider?.vault || !earned || earned.earnedRaw <= BigInt(0)) return;
-    const ok = await claimRewards(rider.vault, earned.earnedRaw);
-    if (ok) {
-      toast.success(t("dlg.claimedTitle"), { description: t("dlg.claimedDesc") });
-      setRefresh((n) => n + 1);
-    } else {
-      toast.error(t("dlg.claimFailTitle"), { description: stakeError ?? undefined });
-    }
-  };
-
-  const handleWithdraw = async () => {
-    if (!rider?.vault || !position || position.shares <= BigInt(0)) return;
-    const ok = await withdrawAll(rider.vault, position.shares);
-    if (ok) {
-      toast.success(t("dlg.withdrewTitle"), { description: t("dlg.withdrewDesc") });
-      setRefresh((n) => n + 1);
-    } else {
-      toast.error(t("dlg.withdrawFailTitle"), { description: stakeError ?? undefined });
-    }
-  };
 
   const handleConfirm = async () => {
     if (isMor) {
       if (!rider?.wallet) return;
       const ok = await morpheus.stake(opp.asset === "steth" ? "stEth" : "usdc", amount, rider.wallet);
-      if (ok) {
-        toast.success(t("opp.stakedMorTitle", { name }), { description: t("opp.stakedMorDesc") });
-        setRefresh((n) => n + 1);
-        onOpenChange(false);
-      } else {
-        toast.error(t("dlg.failTitle"), { description: morpheus.error ?? undefined });
-      }
+      if (ok) { toast.success(t("opp.stakedMorTitle", { name }), { description: t("opp.stakedMorDesc") }); setRefresh((n) => n + 1); onOpenChange(false); }
+      else toast.error(t("dlg.failTitle"), { description: morpheus.error ?? undefined });
       return;
     }
-    if (!rider?.vault) {
-      toast.info(t("dlg.noVaultTitle"), { description: t("dlg.noVaultDesc", { name }) });
-      return;
-    }
+    if (!rider?.vault) { toast.info(t("dlg.noVaultTitle"), { description: t("dlg.noVaultDesc", { name }) }); return; }
     const ok = await stake(rider.vault, amount);
-    if (ok) {
-      toast.success(t("stakeToast", { name }), { description: t("dlg.stakedDesc") });
-      setRefresh((n) => n + 1);
-      onOpenChange(false);
-    } else {
-      toast.error(t("dlg.failTitle"), { description: stakeError ?? undefined });
-    }
+    if (ok) { toast.success(t("stakeToast", { name }), { description: t("dlg.stakedDesc") }); setRefresh((n) => n + 1); onOpenChange(false); }
+    else toast.error(t("dlg.failTitle"), { description: stakeError ?? undefined });
+  };
+  const handleClaim = async () => {
+    if (!rider?.vault || !earned || earned.earnedRaw <= BigInt(0)) return;
+    const ok = await claimRewards(rider.vault, earned.earnedRaw);
+    if (ok) { toast.success(t("dlg.claimedTitle"), { description: t("dlg.claimedDesc") }); setRefresh((n) => n + 1); }
+    else toast.error(t("dlg.claimFailTitle"), { description: stakeError ?? undefined });
+  };
+  const handleWithdraw = async () => {
+    if (!rider?.vault || !position || position.shares <= BigInt(0)) return;
+    const ok = await withdrawAll(rider.vault, position.shares);
+    if (ok) { toast.success(t("dlg.withdrewTitle"), { description: t("dlg.withdrewDesc") }); setRefresh((n) => n + 1); }
+    else toast.error(t("dlg.withdrawFailTitle"), { description: stakeError ?? undefined });
   };
 
   const confirmLabel = isMor
-    ? morpheus.phase === "approve"
-      ? t("opp.approving")
-      : morpheus.phase === "stake"
-        ? t("opp.staking")
-        : t("stakeCta", { name })
-    : stakePhase === "approve"
-      ? t("dlg.approving")
-      : stakePhase === "deposit"
-        ? t("dlg.depositing")
-        : t("stakeCta", { name });
+    ? morpheus.phase === "approve" ? t("opp.approving")
+      : morpheus.phase === "stake" ? t("opp.staking")
+      : morpheus.phase === "setReceiver" ? t("opp.staking")
+      : `${t("opp.stakeVerb")} ${fmtAmount(amountNum, isUsdc)} ${opp.unit}`
+    : stakePhase === "approve" ? t("dlg.approving")
+      : stakePhase === "deposit" ? t("dlg.depositing")
+      : `${t("opp.stakeVerb")} ${fmtAmount(amountNum, isUsdc)} ${opp.unit}`;
+
+  const muted = "#8a857e";
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[92vh] gap-0 overflow-y-auto sm:max-w-3xl">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <Zap className="h-4 w-4" style={{ color: accent }} />
-            {t("stakeCta", { name })}
-          </DialogTitle>
-          <DialogDescription>{t("dialogIntro", { name })}</DialogDescription>
-        </DialogHeader>
-
-        {/* Opportunity chooser */}
-        <div className="mt-5">
-          <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-            {t("opp.choose", { name })}
-          </p>
-          <div className="grid gap-2 sm:grid-cols-3">
-            {OPPS.map((o) => {
-              const active = o.id === oppId;
-              const mor = o.kind === "mor";
-              const apr = aprFor(o);
-              return (
-                <button
-                  key={o.id}
-                  type="button"
-                  onClick={() => switchOpp(o.id)}
-                  aria-pressed={active}
-                  className={cn(
-                    "flex flex-col items-start gap-1 rounded-xl border p-3 text-left transition",
-                    active
-                      ? "border-transparent ring-2"
-                      : "border-border/60 hover:border-border-strong hover:bg-muted/40",
-                  )}
-                  style={active ? ({ "--tw-ring-color": accent } as CSSProperties) : undefined}
-                >
-                  <span className="flex w-full items-center justify-between">
-                    <span className="text-sm font-bold">{t(o.labelKey)}</span>
-                    <span
-                      className={cn(
-                        "inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-semibold",
-                        mor ? "bg-violet-500/15 text-violet-400" : "bg-emerald-500/15 text-emerald-500",
-                      )}
-                    >
-                      {mor ? <TrendingUp className="h-2.5 w-2.5" /> : <ShieldCheck className="h-2.5 w-2.5" />}
-                      {mor ? t("opp.morTag") : t("opp.stableTag")}
-                    </span>
+      <DialogContent
+        showCloseButton
+        className="max-h-[94vh] gap-0 overflow-y-auto border-white/[0.08] bg-[#0e0c0a] p-0 text-white sm:max-w-[1080px]"
+        style={{ fontFamily: "var(--font-sans, system-ui), sans-serif" }}
+      >
+        <div className="flex flex-col gap-5 p-6 sm:p-8">
+          {/* Header */}
+          <div className="flex items-start justify-between gap-6 pr-6">
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2.5">
+                <span style={{ color: GOLD, fontSize: 20 }}>⚡</span>
+                <h2 className="m-0 text-2xl font-black tracking-tight sm:text-[27px]">{t("stakeCta", { name })}</h2>
+                {typeof overall === "number" && (
+                  <span
+                    className="rounded-full px-2.5 py-1 text-[11px] font-bold tracking-widest"
+                    style={{ color: GOLD_HI, background: "rgba(245,166,35,.14)", border: "1px solid rgba(245,166,35,.3)" }}
+                  >
+                    {t("opp.overall")} {overall}
                   </span>
-                  <span className="flex items-baseline gap-1">
-                    <span className="text-xl font-black tabular-nums" style={{ color: accent }}>
-                      {apr ? `${mor ? "~" : ""}${apr.toFixed(1)}%` : "—"}
-                    </span>
-                    <span className="text-[10px] font-medium uppercase text-muted-foreground">
-                      {mor ? "APR · est." : "APY"}
-                    </span>
-                  </span>
-                  <span className="text-[11px] text-muted-foreground">{o.unit}</span>
-                </button>
-              );
-            })}
+                )}
+              </div>
+              <p className="mt-2 max-w-[660px] text-[14.5px] leading-relaxed" style={{ color: muted }}>
+                {t("dialogIntro", { name })}
+              </p>
+            </div>
           </div>
-        </div>
 
-        {/* Controls + flow, side by side on desktop */}
-        <div className="mt-5 grid gap-6 lg:grid-cols-2 lg:items-center">
-          {/* Left: amount */}
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                {t("amountLabel")}
-              </label>
-              <div className="relative">
-                <Input
-                  inputMode="decimal"
-                  value={amount}
-                  onChange={(e) => setAmount(e.target.value.replace(/[^0-9.]/g, ""))}
-                  className="pr-16 text-lg font-semibold"
-                />
-                <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm font-medium text-muted-foreground">
-                  {opp.unit}
+          {/* Hero: rewards flow + rider */}
+          <div
+            className="relative grid items-stretch gap-3 rounded-[20px] border border-white/[0.07] px-5 pt-[18px] sm:grid-cols-[minmax(0,1fr)_260px]"
+            style={{ background: "radial-gradient(90% 120% at 88% 100%, rgba(245,140,30,.22) 0%, rgba(245,140,30,0) 58%), rgba(255,255,255,.03)" }}
+          >
+            <div className="min-w-0 pb-[18px]">
+              <div className="mb-1.5 flex items-baseline justify-between gap-4">
+                <span className="text-[11px] font-bold uppercase tracking-[0.22em]" style={{ color: muted }}>{t("opp.howRewardsFlow")}</span>
+                <span className="text-[15px] font-black" style={{ color: GOLD_HI }}>
+                  {isMor ? `≈$${fmt2(totalUsd)} ${t("opp.perYearMor")}` : `${fmt2(totalAsset)} ${opp.unit} / ${t("perYear")}`}
                 </span>
               </div>
-              <div className="flex flex-wrap gap-2">
-                {opp.presets.map((p) => (
-                  <button
-                    key={p}
-                    type="button"
-                    onClick={() => setAmount(String(p))}
-                    className="cursor-pointer rounded-md border border-border/60 px-2.5 py-1 text-xs font-medium text-muted-foreground transition hover:bg-muted"
-                  >
-                    {p} {opp.unit}
-                  </button>
-                ))}
-              </div>
-              {rate > 0 ? (
-                <p className="text-xs text-muted-foreground">
-                  {isMor
-                    ? t("opp.estNote", { rate: rate.toFixed(1) })
-                    : t("aprNote", { rate: rate.toFixed(2), rateType: "APY", source })}
-                </p>
-              ) : null}
-              {isMor ? (
-                <p className="flex items-start gap-1.5 text-[11px] leading-snug text-warning">
-                  <AlertTriangle className="mt-px h-3.5 w-3.5 shrink-0" />
-                  {t("opp.mainnetWarn")}
-                </p>
-              ) : null}
-            </div>
-          </div>
-
-          {/* Right: flow — 3-way vault split, or the MOR explainer */}
-          <div>
-            <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-              {isMor ? t("opp.morHow") : t("flowTitle")}
-            </p>
-            {isMor ? (
-              <div className="space-y-2 rounded-xl border border-violet-500/30 bg-violet-500/[0.04] p-3">
-                <MorRow icon={<TrendingUp className="h-4 w-4 text-violet-400" />} title={t("opp.youKeepMor")} />
-                <MorRow icon={<Zap className="h-4 w-4 text-violet-400" />} title={t("opp.athleteBonus", { name })} />
-                <MorRow icon={<Gift className="h-4 w-4 text-violet-400" />} title={t("opp.donateOpt")} />
-              </div>
-            ) : (
-              <StakeFlowChart
-                accent={accent}
-                sourceLabel={t("flowSource")}
-                targets={shares.map((s) => (s.key === "treasury" ? { ...s, label: "Gnars" } : s))}
+              <RewardFlow
+                riderName={name}
+                riderImg={image}
+                faceSize={faceSize}
+                facePos={facePos}
+                youVal={share(REWARD_SPLIT.you)}
+                ridVal={share(REWARD_SPLIT.skater)}
+                gnaVal={share(REWARD_SPLIT.treasury)}
+                youLabel={t("youLabel")}
+                gnarsLabel="Gnars"
+                srcLabel={t("flowSource")}
               />
-            )}
+            </div>
+
+            {/* Rider speech + cutout */}
+            <div className="relative hidden min-h-[300px] flex-col gap-4 pt-1.5 sm:flex">
+              <div
+                className="relative flex-none rounded-2xl p-3.5"
+                style={{ background: "linear-gradient(180deg,#1c1714,#141110)", border: `2px solid ${GOLD}`, boxShadow: "0 12px 30px rgba(0,0,0,.55)" }}
+              >
+                <div className="mb-1.5 text-[10px] font-extrabold uppercase tracking-[0.2em]" style={{ color: GOLD_HI }}>{name}</div>
+                <div className="min-h-[61px] text-[13.5px] font-semibold leading-relaxed" style={{ color: "#e8e4df" }}>
+                  {line.slice(0, typed)}
+                  <span style={{ color: GOLD }}>{typed < line.length ? "▌" : ""}</span>
+                </div>
+                <div
+                  className="absolute -bottom-2.5 left-1/2 h-4 w-4 -translate-x-1/2 rotate-45"
+                  style={{ background: "#141110", borderRight: `2px solid ${GOLD}`, borderBottom: `2px solid ${GOLD}` }}
+                />
+              </div>
+              <div
+                aria-hidden
+                className="relative min-h-[200px] flex-1"
+                style={{
+                  backgroundImage: `url(${image})`, backgroundRepeat: "no-repeat",
+                  backgroundSize: "contain", backgroundPosition: "bottom center",
+                  filter: "drop-shadow(0 20px 30px rgba(0,0,0,.6))",
+                }}
+              />
+            </div>
           </div>
-        </div>
 
-        {/* Earnings preview */}
-        <div className="mt-6">
-          <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-            {t("projected")}
-          </p>
-          {isMor ? (
-            <div className="rounded-lg border border-violet-500/30 bg-violet-500/[0.04] p-4 text-center">
-              <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-                {t("opp.estYearLabel")}
-              </p>
-              <p className="mt-1 text-2xl font-black tabular-nums" style={{ color: accent }}>
-                ≈ {fmtUsd(annualUsd)}
-              </p>
-              <p className="mt-1 text-[11px] text-muted-foreground">{t("opp.estYearNote")}</p>
-            </div>
-          ) : (
-            <div className="grid grid-cols-3 gap-3">
-              {shares.map((s) => {
-                const share = annualAsset * (s.percent / 100);
-                return (
-                  <div
-                    key={s.key}
-                    className="rounded-lg border border-border/60 bg-muted/30 p-3 text-center"
-                  >
-                    <div
-                      className="mx-auto mb-2 flex h-9 w-9 items-center justify-center overflow-hidden rounded-full border border-border/60 bg-surface-elevated"
-                      style={{ boxShadow: `0 0 0 2px ${accent}22` }}
+          {/* Three columns */}
+          <div className="grid items-start gap-5 sm:grid-cols-3">
+            {/* Yield source */}
+            <div className="min-w-0">
+              <div className="mb-3 text-[11px] font-bold uppercase tracking-[0.24em]" style={{ color: muted }}>{t("opp.yieldSource")}</div>
+              <div className="flex flex-col gap-2.5">
+                {OPPS.map((o) => {
+                  const active = o.id === oppId;
+                  const apr = aprFor(o);
+                  return (
+                    <button
+                      key={o.id}
+                      type="button"
+                      onClick={() => switchOpp(o.id)}
+                      aria-pressed={active}
+                      className="flex cursor-pointer items-center gap-3 rounded-[13px] px-3.5 py-3 text-left transition"
+                      style={{
+                        border: active ? `2px solid ${GOLD}` : "1px solid rgba(255,255,255,.09)",
+                        background: active ? "rgba(245,166,35,.09)" : "rgba(255,255,255,.035)",
+                      }}
                     >
-                      {s.image ? (
-                        // eslint-disable-next-line @next/next/no-img-element
-                        <img src={s.image} alt={s.label} className="h-full w-full object-cover object-top" />
-                      ) : (
-                        <User className="h-4 w-4 text-muted-foreground" />
-                      )}
-                    </div>
-                    <p className="truncate text-[11px] font-medium text-muted-foreground">{s.label}</p>
-                    <p className="mt-1 text-base font-bold tabular-nums" style={{ color: accent }}>
-                      {fmtAmount(share, isUsdc)}
-                    </p>
-                    <p className="text-[10px] text-muted-foreground">
-                      {opp.unit} {t("perYear")}
-                    </p>
-                  </div>
-                );
-              })}
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img src={o.logo} alt="" className="h-6 w-6 flex-none rounded-full" />
+                      <div className="min-w-0 flex-1">
+                        <div className="text-sm font-bold">{t(o.labelKey)}</div>
+                        <div className="mt-0.5 text-[11.5px] font-semibold" style={{ color: muted }}>
+                          {o.kind === "vault" ? t("opp.stableTag") : t("opp.morTag")} · {o.unit}
+                        </div>
+                      </div>
+                      <div className="flex-none text-[17px] font-black" style={{ color: GOLD_HI }}>
+                        {apr ? `${o.kind === "mor" ? "~" : ""}${apr.toFixed(1)}%` : "—"}
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
             </div>
-          )}
-        </div>
 
-        <p className="mt-4 flex items-start gap-1.5 text-[11px] leading-snug text-muted-foreground">
-          <Info className="mt-px h-3.5 w-3.5 shrink-0" />
-          {t("disclaimer")}
-        </p>
+            {/* Amount */}
+            <div className="min-w-0">
+              <div className="mb-3 text-[11px] font-bold uppercase tracking-[0.24em]" style={{ color: muted }}>{t("amountLabel")}</div>
+              <div className="flex h-[58px] items-center gap-2.5 rounded-[14px] border border-white/[0.11] px-4" style={{ background: "rgba(255,255,255,.045)" }}>
+                <input
+                  value={amount}
+                  onChange={(e) => setAmount(e.target.value.replace(/[^0-9.]/g, ""))}
+                  inputMode="decimal"
+                  className="min-w-0 flex-1 border-none bg-transparent text-2xl font-extrabold tracking-tight text-white outline-none"
+                />
+                <span className="text-sm font-bold" style={{ color: "#8f8a83" }}>{opp.unit}</span>
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {opp.presets.map((v) => {
+                  const on = String(v) === amount;
+                  return (
+                    <button
+                      key={v}
+                      type="button"
+                      onClick={() => setAmount(String(v))}
+                      className="cursor-pointer rounded-[10px] px-3 py-2 text-[12.5px] font-bold"
+                      style={{
+                        color: on ? "#1a1205" : "#c9c6c2",
+                        background: on ? "linear-gradient(90deg,#f7c948,#f5851f)" : "rgba(255,255,255,.05)",
+                        border: on ? "1px solid transparent" : "1px solid rgba(255,255,255,.09)",
+                      }}
+                    >
+                      {v}
+                    </button>
+                  );
+                })}
+              </div>
+              {rate > 0 && (
+                <div className="mt-3 text-[12.5px] font-semibold" style={{ color: muted }}>
+                  {t("aprNote", { rate: rate.toFixed(2), rateType: rateKind, source: opp.venue })}
+                </div>
+              )}
+              {isMor && (
+                <div className="mt-2 text-[11.5px] font-semibold" style={{ color: "#b8741a" }}>{t("opp.mainnetWarn")}</div>
+              )}
+            </div>
 
-        <DialogFooter className="mt-4">
+            {/* Your share */}
+            <div className="flex min-w-0 flex-col gap-3 rounded-[18px] border border-white/[0.07] p-[18px]" style={{ background: "rgba(255,255,255,.035)" }}>
+              <div className="text-[11px] font-bold uppercase tracking-[0.22em]" style={{ color: muted }}>{t("opp.yourShare")}</div>
+              <div className="flex items-baseline gap-2">
+                <span className="text-[34px] font-black leading-none tracking-tight" style={{ color: GOLD_HI }}>
+                  {isMor ? `≈$${fmt2(totalUsd * 0.5)}` : fmt2(totalAsset * 0.5)}
+                </span>
+                <span className="text-[13px] font-bold" style={{ color: muted }}>
+                  {isMor ? t("opp.perYearMor") : `${opp.unit} / ${t("perYear")}`}
+                </span>
+              </div>
+              <div className="h-px bg-white/[0.08]" />
+              {[
+                { label: t("youLabel"), color: GOLD_HI, pct: REWARD_SPLIT.you },
+                { label: name, color: "#b8741a", pct: REWARD_SPLIT.skater },
+                { label: t("treasuryLabel"), color: "#5c4520", pct: REWARD_SPLIT.treasury },
+              ].map((s) => (
+                <div key={s.label} className="flex items-center gap-2.5">
+                  <div className="h-2 w-2 flex-none rounded-[2px]" style={{ background: s.color }} />
+                  <span className="min-w-0 flex-1 truncate text-[13px] font-bold">{s.label}</span>
+                  <span className="text-[13px] font-extrabold" style={{ color: "#c9c6c2" }}>{share(s.pct)}</span>
+                </div>
+              ))}
+              <button
+                type="button"
+                onClick={handleConfirm}
+                disabled={busy}
+                className="mt-auto cursor-pointer rounded-[13px] px-5 py-3.5 text-center text-[14.5px] font-extrabold disabled:opacity-70"
+                style={{ color: "#1a1205", background: "linear-gradient(90deg,#f7c948,#f5851f)", boxShadow: "0 8px 24px rgba(245,133,31,.28)" }}
+              >
+                {confirmLabel}
+              </button>
+            </div>
+          </div>
+
+          {/* Vault position management — only when a live position exists */}
           {!isMor && position && position.shares > BigInt(0) && (
-            <div className="mr-auto flex flex-wrap items-center gap-x-4 gap-y-2">
-              <span className="text-xs text-muted-foreground">
-                {t("opp.yourPosition")}:{" "}
-                <strong className="font-mono text-foreground">${position.assets.toFixed(2)}</strong>
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-2 rounded-xl border border-white/[0.07] px-4 py-3 text-xs" style={{ background: "rgba(255,255,255,.02)" }}>
+              <span style={{ color: muted }}>
+                {t("opp.yourPosition")}: <strong className="font-mono text-white">${position.assets.toFixed(2)}</strong>
                 {earned && earned.principal > 0 && (
-                  <>
-                    {" "}
-                    <span className="opacity-70">
-                      ({t("opp.principal")} ${earned.principal.toFixed(2)} · {t("opp.yield")}{" "}
-                      <span className="text-emerald-500">${earned.earned.toFixed(2)}</span>)
-                    </span>
-                  </>
+                  <span className="opacity-80"> ({t("opp.principal")} ${earned.principal.toFixed(2)} · {t("opp.yield")} <span style={{ color: "#4ade80" }}>${earned.earned.toFixed(2)}</span>)</span>
                 )}
               </span>
-              <div className="flex items-center gap-2">
+              <div className="ml-auto flex items-center gap-2">
                 {earned && earned.earned >= CLAIM_FLOOR_USD && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleClaim}
-                    disabled={isStaking}
-                    className="cursor-pointer"
-                  >
+                  <button type="button" onClick={handleClaim} disabled={isStaking} className="cursor-pointer rounded-lg border border-white/15 px-3 py-1.5 font-semibold hover:bg-white/5 disabled:opacity-60">
                     {stakePhase === "claim" ? t("dlg.claiming") : t("dlg.claim", { amount: `$${earned.earned.toFixed(2)}` })}
-                  </Button>
+                  </button>
                 )}
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleWithdraw}
-                  disabled={isStaking}
-                  className="cursor-pointer"
-                >
+                <button type="button" onClick={handleWithdraw} disabled={isStaking} className="cursor-pointer rounded-lg border border-white/15 px-3 py-1.5 font-semibold hover:bg-white/5 disabled:opacity-60">
                   {stakePhase === "withdraw" ? t("dlg.withdrawing") : t("dlg.withdrawAll")}
-                </Button>
+                </button>
               </div>
             </div>
           )}
-          <Button variant="outline" onClick={() => onOpenChange(false)} className="cursor-pointer">
-            {t("cancel")}
-          </Button>
-          <Button
-            onClick={handleConfirm}
-            disabled={busy}
-            className="cursor-pointer gap-2 text-white"
-            style={{ backgroundColor: accent }}
-          >
-            <Zap className="h-4 w-4" />
-            {confirmLabel}
-          </Button>
-        </DialogFooter>
+
+          {/* Footer */}
+          <div className="flex items-start gap-2 border-t border-white/[0.07] pt-3.5 text-xs leading-normal" style={{ color: "#7d7871" }}>
+            <span className="flex-none">ⓘ</span>
+            <span>{t("disclaimer")}</span>
+          </div>
+        </div>
       </DialogContent>
     </Dialog>
   );
 }
 
-function MorRow({ icon, title }: { icon: ReactNode; title: string }) {
+/** The rewards-flow SVG (gold streams → You / rider / Gnars) with real avatars overlaid. */
+function RewardFlow({
+  riderName, riderImg, faceSize, facePos, youVal, ridVal, gnaVal, youLabel, gnarsLabel, srcLabel,
+}: {
+  riderName: string; riderImg: string; faceSize: string; facePos: string;
+  youVal: string; ridVal: string; gnaVal: string; youLabel: string; gnarsLabel: string; srcLabel: string;
+}) {
+  const P = {
+    you: "M126,181 C280,181 320,70 403,70",
+    rid: "M126,190 L403,190",
+    gna: "M126,199 C280,199 320,310 403,310",
+  };
+  const stream = (id: string, d: string, n: number) =>
+    Array.from({ length: n }, (_, i) => (
+      <circle key={id + i} r={4} fill={GOLD_HI}>
+        <animateMotion dur="2.8s" repeatCount="indefinite" begin={`${((i * 2.8) / n).toFixed(2)}s`} path={d} />
+      </circle>
+    ));
+  const node = (key: string, cy: number, label: string, pct: string, val: string, inner?: ReactNode) => (
+    <g key={key}>
+      <circle cx={430} cy={cy} r={27} fill="#14110e" stroke={GOLD} strokeWidth={3} />
+      {inner}
+      <text x={470} y={cy - 10} fill="#fff" fontSize={20} fontWeight={800}>{label}</text>
+      <text x={470} y={cy + 13} fill={GOLD} fontSize={17} fontWeight={800}>{pct}</text>
+      <text x={470} y={cy + 33} fill="#8a857e" fontSize={13} fontWeight={600}>{val}</text>
+    </g>
+  );
+  const overlay = (topPct: number, size: string, pos: string, url: string): CSSProperties => ({
+    position: "absolute", left: "66.67%", top: `${topPct}%`, width: "7.13%", aspectRatio: "1",
+    transform: "translate(-50%,-50%)", borderRadius: "50%", overflow: "hidden",
+    backgroundImage: `url(${url})`, backgroundRepeat: "no-repeat", backgroundSize: size, backgroundPosition: pos,
+  });
+
   return (
-    <div className="flex items-center gap-2.5">
-      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-violet-500/10">
-        {icon}
-      </span>
-      <span className="text-sm font-medium">{title}</span>
+    <div className="relative w-full">
+      <svg viewBox="0 0 645 385" style={{ width: "100%", height: "auto", display: "block" }}>
+        <defs>
+          <linearGradient id="flowG2" x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stopColor={GOLD} stopOpacity={0.3} />
+            <stop offset="100%" stopColor={GOLD_HI} stopOpacity={0.95} />
+          </linearGradient>
+        </defs>
+        <path d={P.you} stroke="url(#flowG2)" strokeWidth={15} fill="none" strokeLinecap="round" />
+        <path d={P.gna} stroke="url(#flowG2)" strokeWidth={8} fill="none" strokeLinecap="round" />
+        <path d={P.rid} stroke="url(#flowG2)" strokeWidth={8} fill="none" strokeLinecap="round" />
+        {stream("y", P.you, 3)}
+        {stream("r", P.rid, 2)}
+        {stream("g", P.gna, 2)}
+
+        <circle cx={110} cy={190} r={15} fill={GOLD} />
+        <text x={110} y={152} fill="#fff" fontSize={17} fontWeight={700} textAnchor="middle">{srcLabel}</text>
+
+        {node("n1", 70, youLabel, "50%", youVal, (
+          <text x={430} y={76} fill={GOLD_HI} fontSize={13} fontWeight={800} textAnchor="middle">{youLabel.slice(0, 3).toUpperCase()}</text>
+        ))}
+        {node("n2", 190, riderName, "25%", ridVal)}
+        {node("n3", 310, gnarsLabel, "25%", gnaVal)}
+      </svg>
+      {/* real avatars over the rider + Gnars nodes */}
+      <div aria-hidden style={overlay(49.35, faceSize, facePos, riderImg)} />
+      <div aria-hidden style={overlay(80.5, "cover", "center", "/gnars.webp")} />
     </div>
   );
 }


### PR DESCRIPTION
Ports the Claude-designed **Stake Dialog v2** (imported via the design MCP) into React.

## Design
- Arcade-gold card with a **rewards-flow hero**: gold streams → **You / rider / Gnars**, with the **real rider + Gnars avatars** overlaid on their nodes.
- The **rider talks** in a speech bubble with a **typewriter** reveal — lines react to the amount and pool.
- Clean **three columns**: **Yield source · Amount · Your share**, with a gold gradient **CTA**.
- Header shows the rider's **OVERALL**.

## Wired to real data (no mock)
- The three pools are the live opportunities — **Morpho USDC** + **Morpheus stETH/USDC** — with **per-asset APR**.
- Projected split is the **3-way** (you 50 / rider 25 / Gnars 25), which now applies to both the vault and the MOR split.
- Confirm routes through the existing stake hooks; vault claim/withdraw kept as a compact position row when a position exists.
- **Real Morpho/Morpheus logos** on the pool rows — no dot-placeholder regression (the "logos oversight" to avoid).
- Localized en + pt-br.

Also renames the **Flow** rider stat to **Aura**.

`tsc` + `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)