### PR TITLE
feat(stake): dialog face-crop + per-skater speech lines

### DIFF
--- a/src/components/stake/StakeDialog.tsx
+++ b/src/components/stake/StakeDialog.tsx
@@ -11,6 +11,7 @@ import { useMorpheusStake } from "@/hooks/use-morpheus-stake";
 import { useVaultPosition, useVaultEarned } from "@/hooks/use-vault-total";
 import type { StakeYields } from "@/services/yields";
 import { REWARD_SPLIT } from "./CharacterSelector";
+import { riderCustomLine } from "@/lib/rider-lines";
 
 // Adapted from the Claude-designed "Stake Dialog v2" — arcade-gold, three
 // columns (yield source / amount / your share) over a rewards-flow hero with the
@@ -108,10 +109,14 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, accent, 
   const share = (pct: number) =>
     isMor ? `≈$${fmt2(totalUsd * (pct / 100))}` : `${fmt2(totalAsset * (pct / 100))} ${opp.unit}`;
 
-  // Rider one-liner with a typewriter reveal.
+  // Rider one-liner with a typewriter reveal. A skater's own lines (rider-lines.ts)
+  // replace the flavor line when set; the empty/big prompts stay generic.
+  const oppIndex = OPPS.indexOf(opp);
   const line = (() => {
     if (!amountNum) return t("opp.lineEmpty");
     if (amountNum >= (isUsdc ? 5000 : 1)) return t("opp.lineBig", { amount: fmtAmount(amountNum, isUsdc), asset: opp.unit });
+    const custom = riderCustomLine(riderId, oppIndex);
+    if (custom) return custom;
     if (opp.kind === "vault") return t("opp.lineStable", { you: fmt2(totalAsset * 0.5), asset: opp.unit });
     return t("opp.lineVar", { rate: rate.toFixed(1) });
   })();
@@ -225,14 +230,14 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, accent, 
               />
             </div>
 
-            {/* Rider speech + cutout */}
-            <div className="relative hidden min-h-[300px] flex-col gap-4 pt-1.5 sm:flex">
+            {/* Rider speech + face crop */}
+            <div className="relative hidden min-h-[320px] flex-col gap-4 pt-1.5 sm:flex">
               <div
-                className="relative flex-none rounded-2xl p-3.5"
+                className="relative flex flex-1 flex-col justify-center rounded-2xl p-4"
                 style={{ background: "linear-gradient(180deg,#1c1714,#141110)", border: `2px solid ${GOLD}`, boxShadow: "0 12px 30px rgba(0,0,0,.55)" }}
               >
                 <div className="mb-1.5 text-[10px] font-extrabold uppercase tracking-[0.2em]" style={{ color: GOLD_HI }}>{name}</div>
-                <div className="min-h-[61px] text-[13.5px] font-semibold leading-relaxed" style={{ color: "#e8e4df" }}>
+                <div className="text-[13.5px] font-semibold leading-relaxed" style={{ color: "#e8e4df" }}>
                   {line.slice(0, typed)}
                   <span style={{ color: GOLD }}>{typed < line.length ? "▌" : ""}</span>
                 </div>
@@ -241,13 +246,14 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, accent, 
                   style={{ background: "#141110", borderRight: `2px solid ${GOLD}`, borderBottom: `2px solid ${GOLD}` }}
                 />
               </div>
+              {/* face crop — head only, so the speech bubble gets the room */}
               <div
                 aria-hidden
-                className="relative min-h-[200px] flex-1"
+                className="h-[156px] flex-none overflow-hidden rounded-2xl border border-white/[0.08]"
                 style={{
                   backgroundImage: `url(${image})`, backgroundRepeat: "no-repeat",
-                  backgroundSize: "contain", backgroundPosition: "bottom center",
-                  filter: "drop-shadow(0 20px 30px rgba(0,0,0,.6))",
+                  backgroundSize: faceSize, backgroundPosition: facePos,
+                  boxShadow: "inset 0 -46px 44px rgba(14,12,10,.55)",
                 }}
               />
             </div>

--- a/src/lib/rider-lines.ts
+++ b/src/lib/rider-lines.ts
@@ -1,0 +1,28 @@
+import type { RiderId } from "@/lib/gnars-vaults";
+
+// Custom one-liners per skater for the stake dialog speech bubble.
+//
+// Leave a rider's array empty to fall back to the generic contextual lines
+// (opp.lineEmpty / lineBig / lineStable / lineVar in the stake messages). When a
+// rider has entries here, they replace the "flavor" line — the empty-bag and
+// big-bag prompts stay generic since they're functional cues.
+//
+// These are the skater's OWN voice — plain strings, written however the skater
+// wants (any language). Real riders will supply their own; drop their sentences
+// straight into the array. Keep them short (they type out one character at a
+// time in a small bubble).
+export const RIDER_LINES: Record<RiderId, string[]> = {
+  vlad: [],
+  yan: [],
+  r4to: [],
+  pamtech: [],
+  v2: [],
+  zima: [],
+};
+
+/** A rider's custom flavor line for this context, or null to use the generic one. */
+export function riderCustomLine(id: string, seed: number): string | null {
+  const lines = RIDER_LINES[id as RiderId];
+  if (!lines || lines.length === 0) return null;
+  return lines[Math.abs(seed) % lines.length];
+}


### PR DESCRIPTION
- The dialog's rider portrait is now a **face crop** (using the roster head framing) instead of a full-body cutout, so the **speech bubble gets the vertical room** and reads cleaner.
- New **`src/lib/rider-lines.ts`** → `RIDER_LINES`, a per-rider store of custom speech one-liners. **Empty for now**, so it falls back to the current generic contextual lines (which stay). Real skaters will drop their own sentences into the array; when a rider has lines they replace the flavor line, while the empty-bag / big-bag prompts stay generic (they're functional cues).

`tsc` + `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)