### PR TITLE
fix(ci): satisfy react-hooks purity/refs lint (CI was red)

### DIFF
--- a/src/components/stake/MorLootbox.tsx
+++ b/src/components/stake/MorLootbox.tsx
@@ -39,6 +39,9 @@ export function MorLootbox() {
   const [open, setOpen] = useState(false);
   const [splitBalances, setSplitBalances] = useState<Partial<Record<MorpheusAsset, number>>>({});
   const [busyAsset, setBusyAsset] = useState<MorpheusAsset | null>(null);
+  // Read the clock once at mount (a lazy initializer is pure-in-render safe) —
+  // the 7-day unlock doesn't need a live tick; a refresh re-reads it.
+  const [nowSec] = useState(() => Math.floor(Date.now() / 1000));
 
   // Read what's already sitting at each position's split on Arbitrum.
   useEffect(() => {
@@ -187,7 +190,7 @@ export function MorLootbox() {
                 </p>
                 <div className="space-y-2">
                   {stakedPools.map((p) => {
-                    const unlocked = p.unlockAt > 0 && Date.now() / 1000 >= p.unlockAt;
+                    const unlocked = p.unlockAt > 0 && nowSec >= p.unlockAt;
                     return (
                       <div key={`w-${p.asset}`} className="flex items-center justify-between gap-2 rounded-lg border border-border/60 bg-surface-elevated px-3 py-2">
                         <span className="text-xs text-foreground-muted">

--- a/src/components/stake/StakeDialog.tsx
+++ b/src/components/stake/StakeDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
+import { useEffect, useState, type CSSProperties, type ReactNode } from "react";
 import { useTranslations } from "next-intl";
 import { useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -74,7 +74,7 @@ function fmtAmount(n: number, usdc: boolean) {
   return n < 0.001 ? n.toExponential(2) : n.toFixed(n < 1 ? 4 : 3);
 }
 
-export function StakeDialog({ open, onOpenChange, riderId, name, image, accent, overall, faceSize = "420%", facePos = "50% 6%" }: StakeDialogProps) {
+export function StakeDialog({ open, onOpenChange, riderId, name, image, overall, faceSize = "420%", facePos = "50% 6%" }: StakeDialogProps) {
   const t = useTranslations("stake");
   const { stake, withdrawAll, claimRewards, phase: stakePhase, error: stakeError, isStaking, account } = useStakeDeposit();
   const morpheus = useMorpheusStake();
@@ -121,13 +121,13 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, accent, 
     return t("opp.lineVar", { rate: rate.toFixed(1) });
   })();
   const [typed, setTyped] = useState(0);
-  const lineRef = useRef(line);
-  lineRef.current = line;
+  // Re-runs whenever `line` changes, so the interval closure always has the
+  // current line — no ref needed.
   useEffect(() => {
     setTyped(0);
     const id = setInterval(() => {
       setTyped((n) => {
-        if (n >= lineRef.current.length) { clearInterval(id); return n; }
+        if (n >= line.length) { clearInterval(id); return n; }
         return n + 1;
       });
     }, 24);


### PR DESCRIPTION
CI's **Lint** step (eslint, react-compiler rules) was failing since the dialog PRs, blocking green builds. Two errors:

- **`MorLootbox`** called `Date.now()` during render (`react-hooks/purity`) → read the clock once via a `useState` lazy initializer (the 7-day unlock needs no live tick).
- **`StakeDialog`** assigned `lineRef.current` during render (`react-hooks/refs`) → dropped the ref; the typewriter interval now closes over `line` directly (the effect already re-runs when `line` changes). Also removed the unused `accent` prop.

`eslint .` → **0 errors**. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)