### PR TITLE
chore(stake): diagnose Etherscan key in prod + no-store logs fetch

### DIFF
--- a/src/app/api/stake-graph/route.ts
+++ b/src/app/api/stake-graph/route.ts
@@ -7,7 +7,9 @@ export const revalidate = 60;
 export async function GET() {
   try {
     const graph = await getStakeGraph();
-    return NextResponse.json(graph, {
+    // Diagnostic: is the Etherscan key present in this deploy's env? (temporary)
+    const _etherscanKey = Boolean(process.env.ETHERSCAN_API_KEY || process.env.BASESCAN_API_KEY);
+    return NextResponse.json({ ...graph, _etherscanKey }, {
       headers: { "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300" },
     });
   } catch {

--- a/src/services/stake-graph.ts
+++ b/src/services/stake-graph.ts
@@ -151,7 +151,9 @@ async function etherscanReferred(pool: Address, referrer: Address, key: string):
     `&fromBlock=0&toBlock=latest&page=1&offset=1000&apikey=${key}`;
   for (let i = 0; i < 3; i++) {
     try {
-      const res = await fetch(url, { next: { revalidate: 60 } });
+      // no-store so each retry is a real call — the route's own cache (60s)
+      // handles caching, and a transient rate-limit won't stick in the data cache.
+      const res = await fetch(url, { cache: "no-store" });
       const j = (await res.json()) as { status?: string; message?: string; result?: Array<{ topics: string[]; data: string }> };
       if (j.status === "1" && Array.isArray(j.result)) {
         return j.result.map((l) => ({ user: getAddress(`0x${l.topics[2].slice(26)}`), amount: BigInt(l.data) }));


### PR DESCRIPTION
Adds a temporary `_etherscanKey` boolean to `/api/stake-graph` to confirm whether the Etherscan/Basescan key is actually present in the Vercel deploy (MOR backers went empty again, suggesting the Etherscan path isn't running and it's falling back to the datacenter-blocked drpc RPC). Also switches the Etherscan logs fetch to `cache: no-store` so the in-function retries are real calls instead of hitting a stuck data-cache entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)