### PR TITLE
chore: _morNote diagnostic

### DIFF
--- a/src/app/api/stake-graph/route.ts
+++ b/src/app/api/stake-graph/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getStakeGraph } from "@/services/stake-graph";
+import { getStakeGraph, lastMorNote } from "@/services/stake-graph";
 
 // Recompute at most once a minute; serve stale for 5 more while revalidating.
 export const revalidate = 60;
@@ -9,7 +9,7 @@ export async function GET() {
     const graph = await getStakeGraph();
     // Diagnostic: is the Etherscan key present in this deploy's env? (temporary)
     const _etherscanKey = Boolean(process.env.ETHERSCAN_API_KEY || process.env.BASESCAN_API_KEY);
-    return NextResponse.json({ ...graph, _etherscanKey }, {
+    return NextResponse.json({ ...graph, _etherscanKey, _morNote: lastMorNote() }, {
       headers: { "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300" },
     });
   } catch {

--- a/src/services/stake-graph.ts
+++ b/src/services/stake-graph.ts
@@ -143,6 +143,11 @@ const ETHERSCAN_KEY = process.env.ETHERSCAN_API_KEY || process.env.BASESCAN_API_
 const USER_REFERRED_SIG = keccak256(toHex("UserReferred(uint256,address,address,uint256)"));
 const pad32 = (a: Address) => `0x000000000000000000000000${a.slice(2).toLowerCase()}`;
 
+// Temporary: capture the last Etherscan response so /api/stake-graph can expose
+// why the MOR scan came back empty (rate limit vs bad key vs no records).
+let _morNote = "init";
+export function lastMorNote() { return _morNote; }
+
 /** A rider's referred stakes on a pool, straight from the UserReferred events. */
 async function etherscanReferred(pool: Address, referrer: Address, key: string): Promise<Array<{ user: Address; amount: bigint }>> {
   const url =
@@ -151,16 +156,15 @@ async function etherscanReferred(pool: Address, referrer: Address, key: string):
     `&fromBlock=0&toBlock=latest&page=1&offset=1000&apikey=${key}`;
   for (let i = 0; i < 3; i++) {
     try {
-      // no-store so each retry is a real call — the route's own cache (60s)
-      // handles caching, and a transient rate-limit won't stick in the data cache.
       const res = await fetch(url, { cache: "no-store" });
-      const j = (await res.json()) as { status?: string; message?: string; result?: Array<{ topics: string[]; data: string }> };
+      const j = (await res.json()) as { status?: string; message?: string; result?: unknown };
+      _morNote = `${j.status ?? "?"}|${String(j.message ?? "?").slice(0, 40)}|${Array.isArray(j.result) ? j.result.length : typeof j.result}`;
       if (j.status === "1" && Array.isArray(j.result)) {
-        return j.result.map((l) => ({ user: getAddress(`0x${l.topics[2].slice(26)}`), amount: BigInt(l.data) }));
+        return (j.result as Array<{ topics: string[]; data: string }>).map((l) => ({ user: getAddress(`0x${l.topics[2].slice(26)}`), amount: BigInt(l.data) }));
       }
       if (typeof j.message === "string" && /rate limit/i.test(j.message)) { await sleep(500); continue; }
       return []; // "No records found"
-    } catch { await sleep(300); }
+    } catch (e) { _morNote = `throw|${String(e).slice(0, 40)}`; await sleep(300); }
   }
   return [];
 }


### PR DESCRIPTION
Temporary: exposes the last Etherscan response status/message so we can see why the MOR scan is empty in prod.