### PR TITLE
perf(stake): bring /stake under the caching standard

### DIFF
--- a/docs/architecture/caching-standard.md
+++ b/docs/architecture/caching-standard.md
@@ -33,6 +33,10 @@ Is the response per-user or uncacheable (cookies/headers/POST)?
 
 Never combine `force-dynamic` with `revalidate` (force-dynamic silently wins — the sitemap bug).
 
+**Tag revalidation does not reach the CDN.** `revalidateTag` invalidates Next's data cache (what `unstable_cache` writes to). A response already cached by an explicit `Cache-Control: s-maxage` header — the `dynamic + Cache-Control` branch above — is **not tag-aware** and ages out on its own. So on those routes the `s-maxage` value, not the tag, is the hard upper bound on cross-user staleness (worst case `s-maxage` + the SWR window on a low-traffic region). Pick the two windows independently: a short `s-maxage` for freshness, a long `unstable_cache` TTL to keep an expensive computation off the request path. `/api/stake-graph` is the reference (300s / 1800s).
+
+Purging the CDN by tag is possible via `invalidateByTag` + `Vercel-Cache-Tag` from `@vercel/functions`, which is not currently a dependency — evaluate before reaching for it.
+
 ### Rule 2 — every service read is tagged
 
 All reads in `src/services/*` go through `unstable_cache` with canonical tags. TTL is a _backstop_, not the freshness mechanism.
@@ -82,22 +86,22 @@ Keep the global React Query `staleTime: 5min`. Live views override per-query: cu
 
 ## Current state vs target (route params)
 
-| Route                                     | Today                                     | Target                                                                 |
-| ----------------------------------------- | ----------------------------------------- | ---------------------------------------------------------------------- |
-| `/proposals`                              | revalidate 300                            | 1800 + `proposals` tag                                                 |
-| `/proposals/[chain]/[id]`                 | 300 for all                               | 120 Active/Pending, 86400 terminal (status-aware) + `proposal:<n>` tag |
-| `/proposals/snapshot`                     | 300                                       | static (immutable JSON)                                                |
-| `/` (home)                                | 300                                       | 900 + tags (`proposals`, `auction`, `feed`)                            |
-| `/members/[address]`                      | force-dynamic ✅                          | keep; cached lookups (done PR #127)                                    |
-| `/members`                                | 3600 ✅                                   | + `members` tag                                                        |
-| `/feed`                                   | 300 (inner cache 15s!)                    | 300 route + inner cache aligned 300 + `feed` tag                       |
-| `/blogs`, `/blogs/[slug]`                 | 300                                       | 3600 (match data cache)                                                |
-| `/installations/[slug]`                   | 300                                       | 3600/static                                                            |
-| `/rounds*`                                | 300, raw pg                               | tagged `unstable_cache`; closed rounds 86400                           |
-| `/droposals*`                             | 1800 ✅                                   | executed → static                                                      |
-| `sitemap.xml`                             | revalidate 3600 **+ force-dynamic (bug)** | drop force-dynamic                                                     |
-| `/tv`, `/treasury`, `/community/bounties` | 300                                       | 900–1800 (client components already handle live parts)                 |
-| `/api/stake-graph`                        | dynamic + `s-maxage=1800` ✅              | keep; `unstable_cache` + `stake` tag on the service (done)             |
+| Route                                     | Today                                     | Target                                                                                                     |
+| ----------------------------------------- | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `/proposals`                              | revalidate 300                            | 1800 + `proposals` tag                                                                                     |
+| `/proposals/[chain]/[id]`                 | 300 for all                               | 120 Active/Pending, 86400 terminal (status-aware) + `proposal:<n>` tag                                     |
+| `/proposals/snapshot`                     | 300                                       | static (immutable JSON)                                                                                    |
+| `/` (home)                                | 300                                       | 900 + tags (`proposals`, `auction`, `feed`)                                                                |
+| `/members/[address]`                      | force-dynamic ✅                          | keep; cached lookups (done PR #127)                                                                        |
+| `/members`                                | 3600 ✅                                   | + `members` tag                                                                                            |
+| `/feed`                                   | 300 (inner cache 15s!)                    | 300 route + inner cache aligned 300 + `feed` tag                                                           |
+| `/blogs`, `/blogs/[slug]`                 | 300                                       | 3600 (match data cache)                                                                                    |
+| `/installations/[slug]`                   | 300                                       | 3600/static                                                                                                |
+| `/rounds*`                                | 300, raw pg                               | tagged `unstable_cache`; closed rounds 86400                                                               |
+| `/droposals*`                             | 1800 ✅                                   | executed → static                                                                                          |
+| `sitemap.xml`                             | revalidate 3600 **+ force-dynamic (bug)** | drop force-dynamic                                                                                         |
+| `/tv`, `/treasury`, `/community/bounties` | 300                                       | 900–1800 (client components already handle live parts)                                                     |
+| `/api/stake-graph`                        | dynamic + `s-maxage=300` ✅               | keep; split windows — CDN 300s (staleness bound) + `unstable_cache` 1800s backstop with `stake` tag (done) |
 
 ## Rollout (round 3, ordered so freshness improves first)
 

--- a/docs/architecture/caching-standard.md
+++ b/docs/architecture/caching-standard.md
@@ -48,6 +48,7 @@ All reads in `src/services/*` go through `unstable_cache` with canonical tags. T
 | `treasury`                | balances                       | 900                        |
 | `propdates`               | EAS attestations               | 300                        |
 | `rounds` / `round:<slug>` | rounds listings / one round    | 300 / closed: 86400        |
+| `stake`                   | sponsorship graph (orbit)      | 1800                       |
 
 ### Rule 3 — mutations invalidate, clients don't poll
 
@@ -56,15 +57,16 @@ After a write-hook confirms a receipt it must:
 1. `queryClient.invalidateQueries(...)` for the local view (pattern already exists in `AuctionBidForm` / `AuctionSettleButton` — votes and propose are missing it).
 2. `POST /api/revalidate { tags: [...] }` (new route, tag-allowlist, light rate limit) so **other users'** server caches drop. Because of subgraph lag, fire it after polling the subgraph for the event (bounded ~30–45s), with a fallback second call at +60s.
 
-| Mutation (hook)         | Tags to invalidate                        |
-| ----------------------- | ----------------------------------------- |
-| `useCastVote`           | `proposal:<n>`, `proposals`, `feed`       |
-| propose (wizard submit) | `proposals`, `feed`                       |
-| bid                     | `auction`, `feed`                         |
-| settle                  | `auction`, `auctions`, `feed`, `treasury` |
-| propdate post           | `propdates`, `proposal:<n>`               |
-| delegate                | `members`                                 |
-| round vote/submit       | `round:<slug>`, `rounds`                  |
+| Mutation (hook)                                                      | Tags to invalidate                        |
+| -------------------------------------------------------------------- | ----------------------------------------- |
+| `useCastVote`                                                        | `proposal:<n>`, `proposals`, `feed`       |
+| propose (wizard submit)                                              | `proposals`, `feed`                       |
+| bid                                                                  | `auction`, `feed`                         |
+| settle                                                               | `auction`, `auctions`, `feed`, `treasury` |
+| propdate post                                                        | `propdates`, `proposal:<n>`               |
+| delegate                                                             | `members`                                 |
+| round vote/submit                                                    | `round:<slug>`, `rounds`                  |
+| stake deposit/withdraw/claim (`useStakeDeposit`, `useMorpheusStake`) | `stake`                                   |
 
 ### Rule 4 — prefetch discipline
 
@@ -95,6 +97,7 @@ Keep the global React Query `staleTime: 5min`. Live views override per-query: cu
 | `/droposals*`                             | 1800 ✅                                   | executed → static                                                      |
 | `sitemap.xml`                             | revalidate 3600 **+ force-dynamic (bug)** | drop force-dynamic                                                     |
 | `/tv`, `/treasury`, `/community/bounties` | 300                                       | 900–1800 (client components already handle live parts)                 |
+| `/api/stake-graph`                        | dynamic + `s-maxage=1800` ✅              | keep; `unstable_cache` + `stake` tag on the service (done)             |
 
 ## Rollout (round 3, ordered so freshness improves first)
 

--- a/src/app/api/stake-graph/route.ts
+++ b/src/app/api/stake-graph/route.ts
@@ -1,16 +1,30 @@
 import { NextResponse } from "next/server";
-import { getStakeGraph } from "@/services/stake-graph";
+import { getStakeGraph, GRAPH_TTL_SECONDS } from "@/services/stake-graph";
 
-// Recompute at most once a minute; serve stale for 5 more while revalidating.
-export const revalidate = 60;
+/**
+ * Dynamic + explicit `Cache-Control` (caching-standard.md Rule 1): the CDN
+ * absorbs the read traffic per region and this bills ZERO ISR write units,
+ * while `getStakeGraph`'s `unstable_cache` (tag `stake`, 1800s backstop) is the
+ * cross-region cache that keeps a cold region from recomputing the graph.
+ *
+ * Freshness after a deposit comes from `revalidateTag("stake")`, fired by the
+ * stake hooks via `/api/revalidate` — not from a short TTL.
+ */
+export const dynamic = "force-dynamic";
 
 export async function GET() {
   try {
     const graph = await getStakeGraph();
     return NextResponse.json(graph, {
-      headers: { "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300" },
+      headers: {
+        "Cache-Control": `public, s-maxage=${GRAPH_TTL_SECONDS}, stale-while-revalidate=${GRAPH_TTL_SECONDS * 2}`,
+      },
     });
   } catch {
-    return NextResponse.json({ error: "stake_graph_failed" }, { status: 500 });
+    // Never let a failed graph get cached as if it were real data.
+    return NextResponse.json(
+      { error: "stake_graph_failed" },
+      { status: 500, headers: { "Cache-Control": "no-store" } },
+    );
   }
 }

--- a/src/app/api/stake-graph/route.ts
+++ b/src/app/api/stake-graph/route.ts
@@ -1,23 +1,40 @@
 import { NextResponse } from "next/server";
-import { getStakeGraph, GRAPH_TTL_SECONDS } from "@/services/stake-graph";
+import { getStakeGraph } from "@/services/stake-graph";
 
 /**
- * Dynamic + explicit `Cache-Control` (caching-standard.md Rule 1): the CDN
- * absorbs the read traffic per region and this bills ZERO ISR write units,
- * while `getStakeGraph`'s `unstable_cache` (tag `stake`, 1800s backstop) is the
- * cross-region cache that keeps a cold region from recomputing the graph.
+ * Two independent cache windows, and they must NOT share a constant:
  *
- * Freshness after a deposit comes from `revalidateTag("stake")`, fired by the
- * stake hooks via `/api/revalidate` — not from a short TTL.
+ * 1. The CDN entry, created by the `Cache-Control` header below. This one is
+ *    **not tag-aware** — `revalidateTag("stake")` reaches Next's data cache and
+ *    nothing else, so a region holding a warm header-cached response keeps
+ *    serving the old graph until it expires on its own. That makes this value
+ *    the real upper bound on how stale another user's orbit can be, which is
+ *    why it is short (300s) and deliberately decoupled from the backstop.
+ * 2. `getStakeGraph`'s `unstable_cache` (tag `stake`, 1800s backstop in the
+ *    service). This is what protects the expensive part: a CDN miss costs a
+ *    millisecond-scale data-cache read of a ~2KB payload, not the ~3.5s
+ *    recompute. So a short CDN TTL is cheap here in a way it was NOT before
+ *    the service was cached.
+ *
+ * Worst case staleness is s-maxage + the stale-while-revalidate window on a
+ * region with sparse traffic (the first request after expiry is served stale
+ * while revalidation runs in the background), not s-maxage alone.
+ *
+ * `force-dynamic` keeps this out of the ISR/full-route cache, so it bills zero
+ * ISR write units (caching-standard.md Rule 1).
  */
 export const dynamic = "force-dynamic";
+
+/** Cross-user staleness bound. See the note above on why this is not the
+ * service's backstop TTL. */
+const CDN_TTL_SECONDS = 300;
 
 export async function GET() {
   try {
     const graph = await getStakeGraph();
     return NextResponse.json(graph, {
       headers: {
-        "Cache-Control": `public, s-maxage=${GRAPH_TTL_SECONDS}, stale-while-revalidate=${GRAPH_TTL_SECONDS * 2}`,
+        "Cache-Control": `public, s-maxage=${CDN_TTL_SECONDS}, stale-while-revalidate=${CDN_TTL_SECONDS * 2}`,
       },
     });
   } catch {

--- a/src/components/stake/StakeOrbit.tsx
+++ b/src/components/stake/StakeOrbit.tsx
@@ -5,7 +5,6 @@
 // each stake's value on the line, and support flowing inward. Unlike the
 // per-rider supporters list, this shows a backer's positions across every rider
 // at once (which is why "I don't see all my stakes" happens on the flat list).
-
 import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useActiveAccount } from "thirdweb/react";
@@ -14,17 +13,25 @@ import type { RiderId } from "@/lib/gnars-vaults";
 
 // `face` zooms each full-body cut-out onto the head — same framing as the
 // character-select tiles, so the orbit nodes read as portraits.
-const RIDER_VISUAL: Record<RiderId, { hex: string; image: string; face: { size: string; pos: string } }> = {
+const RIDER_VISUAL: Record<
+  RiderId,
+  { hex: string; image: string; face: { size: string; pos: string } }
+> = {
   vlad: { hex: "#f59e0b", image: "/stake/cutout/vlad.png", face: { size: "420%", pos: "50% 6%" } },
   yan: { hex: "#0ea5e9", image: "/stake/cutout/yan.png", face: { size: "420%", pos: "50% 5%" } },
   r4to: { hex: "#d946ef", image: "/stake/cutout/r4to.png", face: { size: "420%", pos: "50% 8%" } },
-  pamtech: { hex: "#10b981", image: "/stake/cutout/pamtech.png", face: { size: "420%", pos: "50% 9%" } },
+  pamtech: {
+    hex: "#10b981",
+    image: "/stake/cutout/pamtech.png",
+    face: { size: "420%", pos: "50% 9%" },
+  },
   v2: { hex: "#f43f5e", image: "/stake/cutout/v2.png", face: { size: "420%", pos: "50% 8%" } },
   zima: { hex: "#14b8a6", image: "/stake/cutout/zima.png", face: { size: "330%", pos: "50% 3%" } },
   will: { hex: "#818cf8", image: "/stake/cutout/will.png", face: { size: "400%", pos: "50% 8%" } },
 };
 
-const usd = (n: number) => `$${n.toLocaleString("en-US", { maximumFractionDigits: n > 0 && n < 100 ? 2 : 0 })}`;
+const usd = (n: number) =>
+  `$${n.toLocaleString("en-US", { maximumFractionDigits: n > 0 && n < 100 ? 2 : 0 })}`;
 // Tiny sub-cent treasury amounts still deserve to read as non-zero.
 const usdSmall = (n: number) => (n > 0 && n < 0.01 ? `$${n.toFixed(6)}` : usd(n));
 const fmtMor = (n: number) => n.toLocaleString("en-US", { maximumFractionDigits: 4 });
@@ -48,7 +55,10 @@ const C = W / 2;
 const R_ATH = 208; // athlete orbit radius
 const R_SUP = 328; // supporter orbit radius
 const rad = (deg: number) => (deg * Math.PI) / 180;
-const pt = (angleDeg: number, r: number) => ({ x: C + r * Math.cos(rad(angleDeg)), y: C + r * Math.sin(rad(angleDeg)) });
+const pt = (angleDeg: number, r: number) => ({
+  x: C + r * Math.cos(rad(angleDeg)),
+  y: C + r * Math.sin(rad(angleDeg)),
+});
 
 export function StakeOrbit() {
   const t = useTranslations("stake");
@@ -80,9 +90,13 @@ export function StakeOrbit() {
           if (data?.name) map[addr.toLowerCase()] = data.name;
         }
         if (!cancelled) setEnsNames(map);
-      } catch { /* addresses stay short */ }
+      } catch {
+        /* addresses stay short */
+      }
     })();
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [graph]);
 
   if (graph === null) {
@@ -104,7 +118,7 @@ export function StakeOrbit() {
 
   // Focus mode: the picked athlete takes the center, the treasury slides to a
   // small satellite near the top, and everyone else drops away.
-  const focused = focusId ? athletes.find((a) => a.id === focusId) ?? null : null;
+  const focused = focusId ? (athletes.find((a) => a.id === focusId) ?? null) : null;
   const treasuryPt = focused ? { x: C, y: 96 } : { x: C, y: C };
   const treasuryR = focused ? 26 : 48;
 
@@ -112,20 +126,32 @@ export function StakeOrbit() {
     <div className="rounded-[22px] border border-white/[0.06] bg-gradient-to-b from-[#181410] to-[#0e0b09] p-5 sm:p-7">
       <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/50">{t("orbit.title")}</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/50">
+            {t("orbit.title")}
+          </p>
           <p className="mt-1.5 max-w-md text-sm text-white/60">{t("orbit.subtitle")}</p>
         </div>
         <div className="flex gap-5 text-right">
           <div>
-            <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-white/45">{t("orbit.total")}</p>
-            <p className="font-mono text-xl font-bold tabular-nums text-white">{usd(graph.total)}</p>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-white/45">
+              {t("orbit.total")}
+            </p>
+            <p className="font-mono text-xl font-bold tabular-nums text-white">
+              {usd(graph.total)}
+            </p>
           </div>
           <div>
-            <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-white/45">{t("orbit.backers")}</p>
-            <p className="font-mono text-xl font-bold tabular-nums text-white">{graph.backerCount}</p>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-white/45">
+              {t("orbit.backers")}
+            </p>
+            <p className="font-mono text-xl font-bold tabular-nums text-white">
+              {graph.backerCount}
+            </p>
           </div>
           <div>
-            <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-white/45">{t("orbit.earnedForTreasury")}</p>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-white/45">
+              {t("orbit.earnedForTreasury")}
+            </p>
             <p className="font-mono text-xl font-bold tabular-nums" style={{ color: GOLD }}>
               {usdSmall(graph.treasuryUsd)}
             </p>
@@ -160,7 +186,12 @@ export function StakeOrbit() {
       </div>
 
       <div className="overflow-x-auto">
-        <svg viewBox={`0 0 ${W} ${W}`} className="mx-auto block h-auto w-full max-w-[640px]" role="img" aria-label={t("orbit.title")}>
+        <svg
+          viewBox={`0 0 ${W} ${W}`}
+          className="mx-auto block h-auto w-full max-w-[640px]"
+          role="img"
+          aria-label={t("orbit.title")}
+        >
           <style>{`
             @keyframes so-flow { to { stroke-dashoffset: -220; } }
             .so-flow { stroke-dasharray: 3 9; animation: so-flow 3.2s linear infinite; }
@@ -186,29 +217,69 @@ export function StakeOrbit() {
               <g key={a.id}>
                 {/* spoke: athlete -> treasury (the fee relationship) */}
                 <line
-                  x1={ap.x} y1={ap.y} x2={treasuryPt.x} y2={treasuryPt.y}
+                  x1={ap.x}
+                  y1={ap.y}
+                  x2={treasuryPt.x}
+                  y2={treasuryPt.y}
                   stroke={lit ? v.hex : "rgba(255,255,255,.10)"}
                   strokeOpacity={lit ? 0.5 : 1}
                   strokeWidth={lit ? 2 : 1}
                 />
                 {lit && (
-                  <line x1={ap.x} y1={ap.y} x2={treasuryPt.x} y2={treasuryPt.y} className="so-flow" stroke={v.hex} strokeWidth={2} strokeOpacity={0.9} />
+                  <line
+                    x1={ap.x}
+                    y1={ap.y}
+                    x2={treasuryPt.x}
+                    y2={treasuryPt.y}
+                    className="so-flow"
+                    stroke={v.hex}
+                    strokeWidth={2}
+                    strokeOpacity={0.9}
+                  />
                 )}
 
                 {/* backer lines + dots + value labels */}
                 {bs.map((b, j) => {
                   const off = bs.length === 1 ? 0 : (j / (bs.length - 1) - 0.5) * spread;
-                  const bp = isCenter ? pt(-90 + (360 / bs.length) * j, R_SUP) : pt(angle + off, R_SUP);
+                  const bp = isCenter
+                    ? pt(-90 + (360 / bs.length) * j, R_SUP)
+                    : pt(angle + off, R_SUP);
                   const mid = { x: (ap.x + bp.x) / 2, y: (ap.y + bp.y) / 2 };
                   const isYou = you && b.address.toLowerCase() === you;
                   const isMor = b.kind === "mor";
                   const col = isMor ? MOR_GREEN : v.hex;
                   return (
                     <g key={`${b.kind}-${b.address}`}>
-                      <line x1={bp.x} y1={bp.y} x2={ap.x} y2={ap.y} stroke={col} strokeOpacity={0.35} strokeWidth={supW(b.amount)} strokeLinecap="round" />
-                      <line x1={bp.x} y1={bp.y} x2={ap.x} y2={ap.y} className="so-flow" stroke={col} strokeWidth={supW(b.amount)} strokeLinecap="round" />
+                      <line
+                        x1={bp.x}
+                        y1={bp.y}
+                        x2={ap.x}
+                        y2={ap.y}
+                        stroke={col}
+                        strokeOpacity={0.35}
+                        strokeWidth={supW(b.amount)}
+                        strokeLinecap="round"
+                      />
+                      <line
+                        x1={bp.x}
+                        y1={bp.y}
+                        x2={ap.x}
+                        y2={ap.y}
+                        className="so-flow"
+                        stroke={col}
+                        strokeWidth={supW(b.amount)}
+                        strokeLinecap="round"
+                      />
                       {/* value on the line */}
-                      <text x={mid.x} y={mid.y - 4} textAnchor="middle" fontSize="11" fontWeight="700" fill="#fff" style={{ paintOrder: "stroke", stroke: "#0c0a08", strokeWidth: 3 }}>
+                      <text
+                        x={mid.x}
+                        y={mid.y - 4}
+                        textAnchor="middle"
+                        fontSize="11"
+                        fontWeight="700"
+                        fill="#fff"
+                        style={{ paintOrder: "stroke", stroke: "#0c0a08", strokeWidth: 3 }}
+                      >
                         {usd(b.amount)}
                       </text>
                       {/* backer node — the real protocol logo (Morpho or Morpheus) */}
@@ -219,18 +290,36 @@ export function StakeOrbit() {
                             <foreignObject x={bp.x - r} y={bp.y - r} width={r * 2} height={r * 2}>
                               <div
                                 style={{
-                                  width: "100%", height: "100%", borderRadius: "50%",
+                                  width: "100%",
+                                  height: "100%",
+                                  borderRadius: "50%",
                                   backgroundColor: "#0c0a08",
                                   backgroundImage: `url(${isMor ? MORPHEUS_LOGO : MORPHO_LOGO})`,
-                                  backgroundSize: "cover", backgroundPosition: "center",
+                                  backgroundSize: "cover",
+                                  backgroundPosition: "center",
                                 }}
                               />
                             </foreignObject>
-                            <circle cx={bp.x} cy={bp.y} r={r} fill="none" stroke={isYou ? GOLD : col} strokeWidth={2} />
+                            <circle
+                              cx={bp.x}
+                              cy={bp.y}
+                              r={r}
+                              fill="none"
+                              stroke={isYou ? GOLD : col}
+                              strokeWidth={2}
+                            />
                           </>
                         );
                       })()}
-                      <text x={bp.x} y={bp.y + (bp.y < C ? -14 : 20)} textAnchor="middle" fontSize="9.5" fill={isYou ? GOLD : "rgba(255,255,255,.55)"} fontFamily="monospace" fontWeight={isYou ? 700 : 400}>
+                      <text
+                        x={bp.x}
+                        y={bp.y + (bp.y < C ? -14 : 20)}
+                        textAnchor="middle"
+                        fontSize="9.5"
+                        fill={isYou ? GOLD : "rgba(255,255,255,.55)"}
+                        fontFamily="monospace"
+                        fontWeight={isYou ? 700 : 400}
+                      >
                         {isYou ? t("orbit.you") : nameOrShort(b.address, ensNames)}
                       </text>
                     </g>
@@ -244,23 +333,47 @@ export function StakeOrbit() {
                   style={{ cursor: "pointer" }}
                   onClick={() => setFocusId(isCenter ? null : a.id)}
                 >
-                  <circle r={nodeR} fill="#141210" stroke={lit ? v.hex : "rgba(255,255,255,.18)"} strokeWidth={lit ? 2.5 : 1.5} />
+                  <circle
+                    r={nodeR}
+                    fill="#141210"
+                    stroke={lit ? v.hex : "rgba(255,255,255,.18)"}
+                    strokeWidth={lit ? 2.5 : 1.5}
+                  />
                   <foreignObject x={-nodeR} y={-nodeR} width={nodeR * 2} height={nodeR * 2}>
                     <div
                       style={{
-                        width: "100%", height: "100%", borderRadius: "50%",
-                        backgroundImage: `url(${v.image})`, backgroundSize: v.face.size,
-                        backgroundPosition: v.face.pos, backgroundRepeat: "no-repeat",
+                        width: "100%",
+                        height: "100%",
+                        borderRadius: "50%",
+                        backgroundImage: `url(${v.image})`,
+                        backgroundSize: v.face.size,
+                        backgroundPosition: v.face.pos,
+                        backgroundRepeat: "no-repeat",
                         opacity: lit ? 1 : 0.45,
                       }}
                     />
                   </foreignObject>
                 </g>
                 {/* athlete name + total */}
-                <text x={ap.x} y={ap.y + nodeR + 16} textAnchor="middle" fontSize="13" fontWeight="800" fill="#fff">
+                <text
+                  x={ap.x}
+                  y={ap.y + nodeR + 16}
+                  textAnchor="middle"
+                  fontSize="13"
+                  fontWeight="800"
+                  fill="#fff"
+                >
                   {t(`characters.${a.id}.name`)}
                 </text>
-                <text x={ap.x} y={ap.y + nodeR + 31} textAnchor="middle" fontSize="12" fontWeight="700" fontFamily="monospace" fill={lit ? v.hex : "rgba(255,255,255,.4)"}>
+                <text
+                  x={ap.x}
+                  y={ap.y + nodeR + 31}
+                  textAnchor="middle"
+                  fontSize="12"
+                  fontWeight="700"
+                  fontFamily="monospace"
+                  fill={lit ? v.hex : "rgba(255,255,255,.4)"}
+                >
                   {a.total > 0 ? usd(a.total) : "—"}
                 </text>
               </g>
@@ -268,17 +381,43 @@ export function StakeOrbit() {
           })}
 
           {/* treasury — center in overview, a small satellite when focused */}
-          <circle cx={treasuryPt.x} cy={treasuryPt.y} r={treasuryR} fill="#0c0a08" stroke={GOLD} strokeWidth={3} />
-          <foreignObject x={treasuryPt.x - (treasuryR - 4)} y={treasuryPt.y - (treasuryR - 4)} width={(treasuryR - 4) * 2} height={(treasuryR - 4) * 2}>
+          <circle
+            cx={treasuryPt.x}
+            cy={treasuryPt.y}
+            r={treasuryR}
+            fill="#0c0a08"
+            stroke={GOLD}
+            strokeWidth={3}
+          />
+          <foreignObject
+            x={treasuryPt.x - (treasuryR - 4)}
+            y={treasuryPt.y - (treasuryR - 4)}
+            width={(treasuryR - 4) * 2}
+            height={(treasuryR - 4) * 2}
+          >
             <div
               style={{
-                width: "100%", height: "100%", borderRadius: "50%",
-                backgroundImage: "url(/gnars.webp)", backgroundSize: "cover",
-                backgroundPosition: "center", backgroundRepeat: "no-repeat",
+                width: "100%",
+                height: "100%",
+                borderRadius: "50%",
+                backgroundImage: "url(/gnars.webp)",
+                backgroundSize: "cover",
+                backgroundPosition: "center",
+                backgroundRepeat: "no-repeat",
               }}
             />
           </foreignObject>
-          <text x={treasuryPt.x} y={treasuryPt.y + treasuryR + 16} textAnchor="middle" fontSize="11" fontWeight="800" letterSpacing="1.5" fill="rgba(255,255,255,.6)">{t("orbit.treasury")}</text>
+          <text
+            x={treasuryPt.x}
+            y={treasuryPt.y + treasuryR + 16}
+            textAnchor="middle"
+            fontSize="11"
+            fontWeight="800"
+            letterSpacing="1.5"
+            fill="rgba(255,255,255,.6)"
+          >
+            {t("orbit.treasury")}
+          </text>
         </svg>
       </div>
     </div>

--- a/src/components/stake/StakeOrbit.tsx
+++ b/src/components/stake/StakeOrbit.tsx
@@ -248,8 +248,13 @@ export function StakeOrbit() {
                   const isYou = you && b.address.toLowerCase() === you;
                   const isMor = b.kind === "mor";
                   const col = isMor ? MOR_GREEN : v.hex;
+                  // `asset` belongs in the key: one wallet can stake MOR in BOTH
+                  // Morpheus pools (stETH and USDC), which are two separate
+                  // backer rows for the same address+kind. Without it React saw
+                  // duplicate keys and dropped one of the two streams, silently
+                  // hiding a real stake from the orbit.
                   return (
-                    <g key={`${b.kind}-${b.address}`}>
+                    <g key={`${b.kind}-${b.asset ?? "na"}-${b.address}`}>
                       <line
                         x1={bp.x}
                         y1={bp.y}

--- a/src/components/stake/YieldStatus.tsx
+++ b/src/components/stake/YieldStatus.tsx
@@ -52,8 +52,10 @@ export function YieldStatus() {
   const { data, isLoading } = useQuery({
     queryKey: ["stake-yields"],
     queryFn: fetchYields,
-    refetchInterval: 60_000,
-    staleTime: 60_000,
+    // No `refetchInterval`: APYs move on the order of hours and `/api/yields`
+    // is CDN-cached for 300s, so polling every 60s just re-served identical
+    // bytes 5× (caching-standard.md Rule 5).
+    staleTime: 300_000,
   });
 
   return (

--- a/src/hooks/use-morpheus-stake.ts
+++ b/src/hooks/use-morpheus-stake.ts
@@ -31,6 +31,7 @@ import {
 } from "viem";
 import { mainnet } from "viem/chains";
 import { useWriteAccount } from "@/hooks/use-write-account";
+import { CACHE_TAGS } from "@/lib/cache-tags";
 import { predictSplitAddress } from "@/lib/mor-split";
 import {
   depositPoolAbi,
@@ -44,6 +45,7 @@ import {
   MORPHEUS_POOLS,
   type MorpheusAsset,
 } from "@/lib/morpheus";
+import { requestRevalidation } from "@/lib/request-revalidation";
 import { getThirdwebClient } from "@/lib/thirdweb";
 import { ensureOnChain } from "@/lib/thirdweb-tx";
 
@@ -271,6 +273,9 @@ export function useMorpheusStake() {
           /* receiver not set; claim can still target the split explicitly */
         }
 
+        // A MOR stake shows up in the orbit as a green stream — drop the server
+        // `stake` cache so other users see it without waiting out the TTL.
+        requestRevalidation([CACHE_TAGS.stake]);
         setPhase("done");
         return true;
       } catch (e) {
@@ -324,6 +329,7 @@ export function useMorpheusStake() {
         const tx = prepareTransaction({ client, chain: ethereum, to: pool, data });
         const hash = (await sendTransaction({ account, transaction: tx })).transactionHash;
         await waitReceipt(client, hash);
+        requestRevalidation([CACHE_TAGS.stake]);
         setPhase("done");
         return true;
       } catch (e) {
@@ -382,6 +388,7 @@ export function useMorpheusStake() {
         const tx = prepareTransaction({ client, chain: ethereum, to: pool, data, value: fee });
         const hash = (await sendTransaction({ account, transaction: tx })).transactionHash;
         await waitReceipt(client, hash);
+        requestRevalidation([CACHE_TAGS.stake]);
         setPhase("done");
         return true;
       } catch (e) {
@@ -430,6 +437,7 @@ export function useMorpheusStake() {
         const tx = prepareTransaction({ client, chain: ethereum, to: pool, data });
         const hash = (await sendTransaction({ account, transaction: tx })).transactionHash;
         await waitReceipt(client, hash);
+        requestRevalidation([CACHE_TAGS.stake]);
         setPhase("done");
         return true;
       } catch (e) {

--- a/src/hooks/use-morpheus-stake.ts
+++ b/src/hooks/use-morpheus-stake.ts
@@ -9,31 +9,51 @@
 // come in a later phase.
 //
 // Everything is a real mainnet tx (gas is not cheap) — the UI flags that.
-
 import { useCallback, useRef, useState } from "react";
 import {
-  prepareTransaction, sendTransaction, waitForReceipt, readContract, getContract,
+  getContract,
+  prepareTransaction,
+  readContract,
+  sendTransaction,
+  waitForReceipt,
   type ThirdwebClient,
 } from "thirdweb";
 import { ethereum } from "thirdweb/chains";
 import {
-  createPublicClient, http, fallback, encodeFunctionData, encodeAbiParameters, parseUnits, erc20Abi, type Address,
+  createPublicClient,
+  encodeAbiParameters,
+  encodeFunctionData,
+  erc20Abi,
+  fallback,
+  http,
+  parseUnits,
+  type Address,
 } from "viem";
 import { mainnet } from "viem/chains";
 import { useWriteAccount } from "@/hooks/use-write-account";
-import { ensureOnChain } from "@/lib/thirdweb-tx";
-import { getThirdwebClient } from "@/lib/thirdweb";
-import {
-  MORPHEUS_POOLS, MORPHEUS_DISTRIBUTOR, MOR_REWARD_POOL_INDEX, depositPoolAbi, type MorpheusAsset,
-  L1_SENDER, LZ_GATEWAY, LZ_DST_CHAIN_ID, LZ_ADAPTER_PARAMS, lzEndpointAbi,
-} from "@/lib/morpheus";
 import { predictSplitAddress } from "@/lib/mor-split";
+import {
+  depositPoolAbi,
+  L1_SENDER,
+  LZ_ADAPTER_PARAMS,
+  LZ_DST_CHAIN_ID,
+  LZ_GATEWAY,
+  lzEndpointAbi,
+  MOR_REWARD_POOL_INDEX,
+  MORPHEUS_DISTRIBUTOR,
+  MORPHEUS_POOLS,
+  type MorpheusAsset,
+} from "@/lib/morpheus";
+import { getThirdwebClient } from "@/lib/thirdweb";
+import { ensureOnChain } from "@/lib/thirdweb-tx";
 
 /** Quote the LayerZero native fee for a claim (payload is fixed-size, so amount is nominal). */
 async function quoteClaimFee(user: Address, amount: bigint): Promise<bigint> {
   const payload = encodeAbiParameters([{ type: "address" }, { type: "uint256" }], [user, amount]);
   const [nativeFee] = await rpc.readContract({
-    address: LZ_GATEWAY, abi: lzEndpointAbi, functionName: "estimateFees",
+    address: LZ_GATEWAY,
+    abi: lzEndpointAbi,
+    functionName: "estimateFees",
     args: [LZ_DST_CHAIN_ID, L1_SENDER, payload, false, LZ_ADAPTER_PARAMS],
   });
   return (nativeFee * BigInt(120)) / BigInt(100); // +20% margin; excess is refunded on-chain
@@ -58,12 +78,21 @@ async function waitReceipt(client: ThirdwebClient, transactionHash: `0x${string}
   await Promise.race([
     waitForReceipt({ client, chain: ethereum, transactionHash }),
     new Promise((_, reject) =>
-      setTimeout(() => reject(new Error("Transaction is taking too long to confirm — check your wallet and tap again.")), RECEIPT_TIMEOUT_MS),
+      setTimeout(
+        () =>
+          reject(
+            new Error(
+              "Transaction is taking too long to confirm — check your wallet and tap again.",
+            ),
+          ),
+        RECEIPT_TIMEOUT_MS,
+      ),
     ),
   ]);
 }
 
-const ALLOWANCE = "function allowance(address owner, address spender) view returns (uint256)" as const;
+const ALLOWANCE =
+  "function allowance(address owner, address spender) view returns (uint256)" as const;
 
 /**
  * Confirm the pool's allowance is high enough *on the RPC that will estimate the
@@ -75,7 +104,11 @@ const ALLOWANCE = "function allowance(address owner, address spender) view retur
  * that reverts with "transfer amount exceeds allowance".
  */
 async function confirmAllowance(
-  client: ThirdwebClient, token: Address, owner: Address, spender: Address, needed: bigint,
+  client: ThirdwebClient,
+  token: Address,
+  owner: Address,
+  spender: Address,
+  needed: bigint,
   tries = 24,
 ): Promise<boolean> {
   const contract = getContract({ client, chain: ethereum, address: token });
@@ -83,17 +116,34 @@ async function confirmAllowance(
     try {
       const a = await readContract({ contract, method: ALLOWANCE, params: [owner, spender] });
       if (a >= needed) return true;
-    } catch { /* keep polling */ }
+    } catch {
+      /* keep polling */
+    }
     try {
-      const a = await rpc.readContract({ address: token, abi: erc20Abi, functionName: "allowance", args: [owner, spender] });
+      const a = await rpc.readContract({
+        address: token,
+        abi: erc20Abi,
+        functionName: "allowance",
+        args: [owner, spender],
+      });
       if (a >= needed) return true;
-    } catch { /* keep polling */ }
+    } catch {
+      /* keep polling */
+    }
     await sleep(2000);
   }
   return false;
 }
 
-export type MorpheusPhase = "idle" | "approve" | "stake" | "setReceiver" | "withdraw" | "claim" | "done" | "error";
+export type MorpheusPhase =
+  | "idle"
+  | "approve"
+  | "stake"
+  | "setReceiver"
+  | "withdraw"
+  | "claim"
+  | "done"
+  | "error";
 
 export function useMorpheusStake() {
   const writer = useWriteAccount();
@@ -106,13 +156,31 @@ export function useMorpheusStake() {
     async (asset: MorpheusAsset, amount: string, athlete: Address): Promise<boolean> => {
       if (pending.current) return false;
       const client = getThirdwebClient();
-      if (!client) { setError("Thirdweb not configured."); setPhase("error"); return false; }
-      if (!writer) { setError("Connect your wallet."); setPhase("error"); return false; }
+      if (!client) {
+        setError("Thirdweb not configured.");
+        setPhase("error");
+        return false;
+      }
+      if (!writer) {
+        setError("Connect your wallet.");
+        setPhase("error");
+        return false;
+      }
       const { pool, token, decimals } = MORPHEUS_POOLS[asset];
 
       let assets: bigint;
-      try { assets = parseUnits(amount, decimals); } catch { setError("Invalid amount."); setPhase("error"); return false; }
-      if (assets <= BigInt(0)) { setError("Invalid amount."); setPhase("error"); return false; }
+      try {
+        assets = parseUnits(amount, decimals);
+      } catch {
+        setError("Invalid amount.");
+        setPhase("error");
+        return false;
+      }
+      if (assets <= BigInt(0)) {
+        setError("Invalid amount.");
+        setPhase("error");
+        return false;
+      }
 
       const account = writer.account;
       setError(null);
@@ -123,20 +191,42 @@ export function useMorpheusStake() {
         // The Distributor (not the DepositPool we call `stake` on) is what pulls
         // the deposit token, so the approval must name the distributor as spender.
         const spender = MORPHEUS_DISTRIBUTOR;
-        const allowance = await rpc.readContract({ address: token, abi: erc20Abi, functionName: "allowance", args: [account.address as Address, spender] });
+        const allowance = await rpc.readContract({
+          address: token,
+          abi: erc20Abi,
+          functionName: "allowance",
+          args: [account.address as Address, spender],
+        });
         if (allowance < assets) {
           setPhase("approve");
-          const approveData = encodeFunctionData({ abi: erc20Abi, functionName: "approve", args: [spender, assets] });
-          const approveTx = prepareTransaction({ client, chain: ethereum, to: token, data: approveData });
+          const approveData = encodeFunctionData({
+            abi: erc20Abi,
+            functionName: "approve",
+            args: [spender, assets],
+          });
+          const approveTx = prepareTransaction({
+            client,
+            chain: ethereum,
+            to: token,
+            data: approveData,
+          });
           const hash = (await sendTransaction({ account, transaction: approveTx })).transactionHash;
           await waitReceipt(client, hash);
           // Wait until the allowance is actually visible on the estimation RPC —
           // otherwise the stake reverts with "transfer amount exceeds allowance".
           // If it never propagates, abort cleanly rather than broadcasting a
           // doomed tx.
-          const ok = await confirmAllowance(client, token, account.address as Address, spender, assets);
+          const ok = await confirmAllowance(
+            client,
+            token,
+            account.address as Address,
+            spender,
+            assets,
+          );
           if (!ok) {
-            setError("Approval is still confirming on-chain — give it a few seconds and tap Stake again.");
+            setError(
+              "Approval is still confirming on-chain — give it a few seconds and tap Stake again.",
+            );
             setPhase("error");
             return false;
           }
@@ -145,7 +235,8 @@ export function useMorpheusStake() {
         setPhase("stake");
         // claimLockEnd = 0 → no extra lock beyond the protocol's 7-day default.
         const stakeData = encodeFunctionData({
-          abi: depositPoolAbi, functionName: "stake",
+          abi: depositPoolAbi,
+          functionName: "stake",
           args: [MOR_REWARD_POOL_INDEX, assets, BigInt(0), athlete],
         });
         const sendStake = async () => {
@@ -153,7 +244,12 @@ export function useMorpheusStake() {
           return (await sendTransaction({ account, transaction: tx })).transactionHash;
         };
         let stakeHash: `0x${string}`;
-        try { stakeHash = await sendStake(); } catch { await sleep(4000); stakeHash = await sendStake(); }
+        try {
+          stakeHash = await sendStake();
+        } catch {
+          await sleep(4000);
+          stakeHash = await sendStake();
+        }
         await waitReceipt(client, stakeHash);
 
         // Route this position's MOR to the staker's deterministic 3-way split by
@@ -163,11 +259,17 @@ export function useMorpheusStake() {
         try {
           setPhase("setReceiver");
           const split = await predictSplitAddress(account.address as Address, athlete);
-          const rData = encodeFunctionData({ abi: depositPoolAbi, functionName: "setClaimReceiver", args: [MOR_REWARD_POOL_INDEX, split] });
+          const rData = encodeFunctionData({
+            abi: depositPoolAbi,
+            functionName: "setClaimReceiver",
+            args: [MOR_REWARD_POOL_INDEX, split],
+          });
           const rTx = prepareTransaction({ client, chain: ethereum, to: pool, data: rData });
           const rHash = (await sendTransaction({ account, transaction: rTx })).transactionHash;
           await waitReceipt(client, rHash);
-        } catch { /* receiver not set; claim can still target the split explicitly */ }
+        } catch {
+          /* receiver not set; claim can still target the split explicitly */
+        }
 
         setPhase("done");
         return true;
@@ -187,12 +289,26 @@ export function useMorpheusStake() {
     async (asset: MorpheusAsset, amount: string): Promise<boolean> => {
       if (pending.current) return false;
       const client = getThirdwebClient();
-      if (!client) { setError("Thirdweb not configured."); setPhase("error"); return false; }
-      if (!writer) { setError("Connect your wallet."); setPhase("error"); return false; }
+      if (!client) {
+        setError("Thirdweb not configured.");
+        setPhase("error");
+        return false;
+      }
+      if (!writer) {
+        setError("Connect your wallet.");
+        setPhase("error");
+        return false;
+      }
       const { pool, decimals } = MORPHEUS_POOLS[asset];
 
       let assets: bigint;
-      try { assets = parseUnits(amount, decimals); } catch { setError("Invalid amount."); setPhase("error"); return false; }
+      try {
+        assets = parseUnits(amount, decimals);
+      } catch {
+        setError("Invalid amount.");
+        setPhase("error");
+        return false;
+      }
 
       const account = writer.account;
       setError(null);
@@ -200,7 +316,11 @@ export function useMorpheusStake() {
       try {
         await ensureOnChain(writer.wallet, ethereum);
         setPhase("withdraw");
-        const data = encodeFunctionData({ abi: depositPoolAbi, functionName: "withdraw", args: [MOR_REWARD_POOL_INDEX, assets] });
+        const data = encodeFunctionData({
+          abi: depositPoolAbi,
+          functionName: "withdraw",
+          args: [MOR_REWARD_POOL_INDEX, assets],
+        });
         const tx = prepareTransaction({ client, chain: ethereum, to: pool, data });
         const hash = (await sendTransaction({ account, transaction: tx })).transactionHash;
         await waitReceipt(client, hash);
@@ -225,8 +345,16 @@ export function useMorpheusStake() {
     async (asset: MorpheusAsset, receiver: Address): Promise<boolean> => {
       if (pending.current) return false;
       const client = getThirdwebClient();
-      if (!client) { setError("Thirdweb not configured."); setPhase("error"); return false; }
-      if (!writer) { setError("Connect your wallet."); setPhase("error"); return false; }
+      if (!client) {
+        setError("Thirdweb not configured.");
+        setPhase("error");
+        return false;
+      }
+      if (!writer) {
+        setError("Connect your wallet.");
+        setPhase("error");
+        return false;
+      }
       const { pool } = MORPHEUS_POOLS[asset];
       const account = writer.account;
       setError(null);
@@ -235,12 +363,22 @@ export function useMorpheusStake() {
         await ensureOnChain(writer.wallet, ethereum);
         setPhase("claim");
         const pending_ = await rpc.readContract({
-          address: pool, abi: depositPoolAbi, functionName: "getLatestUserReward",
+          address: pool,
+          abi: depositPoolAbi,
+          functionName: "getLatestUserReward",
           args: [MOR_REWARD_POOL_INDEX, account.address as Address],
         });
-        if (pending_ <= BigInt(0)) { setError("No MOR to claim yet."); setPhase("error"); return false; }
+        if (pending_ <= BigInt(0)) {
+          setError("No MOR to claim yet.");
+          setPhase("error");
+          return false;
+        }
         const fee = await quoteClaimFee(account.address as Address, pending_);
-        const data = encodeFunctionData({ abi: depositPoolAbi, functionName: "claim", args: [MOR_REWARD_POOL_INDEX, receiver] });
+        const data = encodeFunctionData({
+          abi: depositPoolAbi,
+          functionName: "claim",
+          args: [MOR_REWARD_POOL_INDEX, receiver],
+        });
         const tx = prepareTransaction({ client, chain: ethereum, to: pool, data, value: fee });
         const hash = (await sendTransaction({ account, transaction: tx })).transactionHash;
         await waitReceipt(client, hash);
@@ -267,8 +405,16 @@ export function useMorpheusStake() {
     async (asset: MorpheusAsset, receiver: Address): Promise<boolean> => {
       if (pending.current) return false;
       const client = getThirdwebClient();
-      if (!client) { setError("Thirdweb not configured."); setPhase("error"); return false; }
-      if (!writer) { setError("Connect your wallet."); setPhase("error"); return false; }
+      if (!client) {
+        setError("Thirdweb not configured.");
+        setPhase("error");
+        return false;
+      }
+      if (!writer) {
+        setError("Connect your wallet.");
+        setPhase("error");
+        return false;
+      }
       const { pool } = MORPHEUS_POOLS[asset];
       const account = writer.account;
       setError(null);
@@ -276,7 +422,11 @@ export function useMorpheusStake() {
       try {
         await ensureOnChain(writer.wallet, ethereum);
         setPhase("stake");
-        const data = encodeFunctionData({ abi: depositPoolAbi, functionName: "setClaimReceiver", args: [MOR_REWARD_POOL_INDEX, receiver] });
+        const data = encodeFunctionData({
+          abi: depositPoolAbi,
+          functionName: "setClaimReceiver",
+          args: [MOR_REWARD_POOL_INDEX, receiver],
+        });
         const tx = prepareTransaction({ client, chain: ethereum, to: pool, data });
         const hash = (await sendTransaction({ account, transaction: tx })).transactionHash;
         await waitReceipt(client, hash);
@@ -294,7 +444,17 @@ export function useMorpheusStake() {
   );
 
   return {
-    stake, withdraw, claim, setDonateReceiver, phase, error,
-    isBusy: phase === "approve" || phase === "stake" || phase === "setReceiver" || phase === "withdraw" || phase === "claim",
+    stake,
+    withdraw,
+    claim,
+    setDonateReceiver,
+    phase,
+    error,
+    isBusy:
+      phase === "approve" ||
+      phase === "stake" ||
+      phase === "setReceiver" ||
+      phase === "withdraw" ||
+      phase === "claim",
   };
 }

--- a/src/hooks/use-stake-deposit.ts
+++ b/src/hooks/use-stake-deposit.ts
@@ -6,19 +6,30 @@
 //
 // USDC only: the vaults are Morpho V2 USDC vaults. The ETH option on /stake has
 // no vault behind it yet.
-
 import { useCallback, useRef, useState } from "react";
-import { prepareTransaction, sendTransaction, waitForReceipt, readContract, getContract, type ThirdwebClient } from "thirdweb";
+import {
+  getContract,
+  prepareTransaction,
+  readContract,
+  sendTransaction,
+  waitForReceipt,
+  type ThirdwebClient,
+} from "thirdweb";
 import { base } from "thirdweb/chains";
 import {
-  createPublicClient, http, fallback,
-  encodeFunctionData, parseUnits, erc20Abi as viemErc20Abi, type Address,
+  createPublicClient,
+  encodeFunctionData,
+  fallback,
+  http,
+  parseUnits,
+  erc20Abi as viemErc20Abi,
+  type Address,
 } from "viem";
 import { base as viemBase } from "viem/chains";
 import { useWriteAccount } from "@/hooks/use-write-account";
-import { ensureOnChain } from "@/lib/thirdweb-tx";
-import { getThirdwebClient } from "@/lib/thirdweb";
 import { USDC } from "@/lib/sponsorship-vaults";
+import { getThirdwebClient } from "@/lib/thirdweb";
+import { ensureOnChain } from "@/lib/thirdweb-tx";
 
 // Our own multi-endpoint client — after the approve is mined, the wallet's RPC
 // can still be a block behind, so the deposit's gas estimation doesn't see the
@@ -39,45 +50,77 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 // let a doomed "transfer amount exceeds allowance" tx through. Returns false if
 // it never propagates so the caller can abort cleanly.
 async function confirmAllowance(
-  client: ThirdwebClient, owner: Address, spender: Address, needed: bigint, tries = 16,
+  client: ThirdwebClient,
+  owner: Address,
+  spender: Address,
+  needed: bigint,
+  tries = 16,
 ): Promise<boolean> {
   const contract = getContract({ client, chain: base, address: USDC });
   for (let i = 0; i < tries; i++) {
     try {
       const a = await readContract({ contract, method: ALLOWANCE, params: [owner, spender] });
       if (a >= needed) return true;
-    } catch { /* keep polling */ }
+    } catch {
+      /* keep polling */
+    }
     try {
-      const a = await rpc.readContract({ address: USDC, abi: viemErc20Abi, functionName: "allowance", args: [owner, spender] });
+      const a = await rpc.readContract({
+        address: USDC,
+        abi: viemErc20Abi,
+        functionName: "allowance",
+        args: [owner, spender],
+      });
       if (a >= needed) return true;
-    } catch { /* keep polling */ }
+    } catch {
+      /* keep polling */
+    }
     await sleep(1500);
   }
   return false;
 }
 
-const erc20Abi = [{
-  type: "function", name: "approve", stateMutability: "nonpayable",
-  inputs: [{ type: "address" }, { type: "uint256" }], outputs: [{ type: "bool" }],
-}] as const;
+const erc20Abi = [
+  {
+    type: "function",
+    name: "approve",
+    stateMutability: "nonpayable",
+    inputs: [{ type: "address" }, { type: "uint256" }],
+    outputs: [{ type: "bool" }],
+  },
+] as const;
 
-const vaultAbi = [{
-  type: "function", name: "deposit", stateMutability: "nonpayable",
-  inputs: [{ type: "uint256" }, { type: "address" }], outputs: [{ type: "uint256" }],
-}, {
-  // Redeem by shares (not withdraw by assets): redeeming the exact share balance
-  // can't leave a rounding remainder that reverts a "withdraw everything".
-  type: "function", name: "redeem", stateMutability: "nonpayable",
-  inputs: [{ type: "uint256" }, { type: "address" }, { type: "address" }], outputs: [{ type: "uint256" }],
-}, {
-  // Withdraw by assets — used to pull only the earned amount, leaving principal.
-  type: "function", name: "withdraw", stateMutability: "nonpayable",
-  inputs: [{ type: "uint256" }, { type: "address" }, { type: "address" }], outputs: [{ type: "uint256" }],
-}] as const;
+const vaultAbi = [
+  {
+    type: "function",
+    name: "deposit",
+    stateMutability: "nonpayable",
+    inputs: [{ type: "uint256" }, { type: "address" }],
+    outputs: [{ type: "uint256" }],
+  },
+  {
+    // Redeem by shares (not withdraw by assets): redeeming the exact share balance
+    // can't leave a rounding remainder that reverts a "withdraw everything".
+    type: "function",
+    name: "redeem",
+    stateMutability: "nonpayable",
+    inputs: [{ type: "uint256" }, { type: "address" }, { type: "address" }],
+    outputs: [{ type: "uint256" }],
+  },
+  {
+    // Withdraw by assets — used to pull only the earned amount, leaving principal.
+    type: "function",
+    name: "withdraw",
+    stateMutability: "nonpayable",
+    inputs: [{ type: "uint256" }, { type: "address" }, { type: "address" }],
+    outputs: [{ type: "uint256" }],
+  },
+] as const;
 
 // Reads used to skip a redundant approve and to refuse deposits that would
 // round down to zero shares.
-const ALLOWANCE = "function allowance(address owner, address spender) view returns (uint256)" as const;
+const ALLOWANCE =
+  "function allowance(address owner, address spender) view returns (uint256)" as const;
 const PREVIEW_DEPOSIT = "function previewDeposit(uint256 assets) view returns (uint256)" as const;
 
 export type StakePhase = "idle" | "approve" | "deposit" | "withdraw" | "claim" | "done" | "error";
@@ -96,16 +139,30 @@ export function useStakeDeposit() {
     async (vault: Address, amountUsdc: string): Promise<boolean> => {
       if (pending.current) return false;
       const client = getThirdwebClient();
-      if (!client) { setError("Thirdweb not configured."); setPhase("error"); return false; }
-      if (!writer) { setError("Connect your wallet."); setPhase("error"); return false; }
+      if (!client) {
+        setError("Thirdweb not configured.");
+        setPhase("error");
+        return false;
+      }
+      if (!writer) {
+        setError("Connect your wallet.");
+        setPhase("error");
+        return false;
+      }
 
       let assets: bigint;
       try {
         assets = parseUnits(amountUsdc, 6); // USDC has 6 decimals
       } catch {
-        setError("Invalid amount."); setPhase("error"); return false;
+        setError("Invalid amount.");
+        setPhase("error");
+        return false;
       }
-      if (assets <= BigInt(0)) { setError("Invalid amount."); setPhase("error"); return false; }
+      if (assets <= BigInt(0)) {
+        setError("Invalid amount.");
+        setPhase("error");
+        return false;
+      }
 
       const account = writer.account;
       setError(null);
@@ -137,16 +194,28 @@ export function useStakeDeposit() {
 
         if (allowance < assets) {
           setPhase("approve");
-          const approveData = encodeFunctionData({ abi: erc20Abi, functionName: "approve", args: [vault, assets] });
-          const approveTx = prepareTransaction({ client, chain: base, to: USDC, data: approveData });
-          const approveHash = (await sendTransaction({ account, transaction: approveTx })).transactionHash;
+          const approveData = encodeFunctionData({
+            abi: erc20Abi,
+            functionName: "approve",
+            args: [vault, assets],
+          });
+          const approveTx = prepareTransaction({
+            client,
+            chain: base,
+            to: USDC,
+            data: approveData,
+          });
+          const approveHash = (await sendTransaction({ account, transaction: approveTx }))
+            .transactionHash;
           await waitForReceipt({ client, chain: base, transactionHash: approveHash });
           // Don't send the deposit until the allowance is actually visible — this
           // is what makes a single click work instead of failing with a scary
           // "insufficient allowance" and needing a second try.
           const ok = await confirmAllowance(client, account.address as Address, vault, assets);
           if (!ok) {
-            setError("Approval is still confirming on-chain — give it a few seconds and tap Stake again.");
+            setError(
+              "Approval is still confirming on-chain — give it a few seconds and tap Stake again.",
+            );
             setPhase("error");
             return false;
           }
@@ -154,10 +223,17 @@ export function useStakeDeposit() {
 
         setPhase("deposit");
         const depositData = encodeFunctionData({
-          abi: vaultAbi, functionName: "deposit", args: [assets, account.address as Address],
+          abi: vaultAbi,
+          functionName: "deposit",
+          args: [assets, account.address as Address],
         });
         const sendDeposit = async () => {
-          const depositTx = prepareTransaction({ client, chain: base, to: vault, data: depositData });
+          const depositTx = prepareTransaction({
+            client,
+            chain: base,
+            to: vault,
+            data: depositData,
+          });
           return (await sendTransaction({ account, transaction: depositTx })).transactionHash;
         };
         let depositHash: `0x${string}`;
@@ -193,9 +269,21 @@ export function useStakeDeposit() {
     async (vault: Address, shares: bigint): Promise<boolean> => {
       if (pending.current) return false;
       const client = getThirdwebClient();
-      if (!client) { setError("Thirdweb not configured."); setPhase("error"); return false; }
-      if (!writer) { setError("Connect your wallet."); setPhase("error"); return false; }
-      if (shares <= BigInt(0)) { setError("Nothing to withdraw."); setPhase("error"); return false; }
+      if (!client) {
+        setError("Thirdweb not configured.");
+        setPhase("error");
+        return false;
+      }
+      if (!writer) {
+        setError("Connect your wallet.");
+        setPhase("error");
+        return false;
+      }
+      if (shares <= BigInt(0)) {
+        setError("Nothing to withdraw.");
+        setPhase("error");
+        return false;
+      }
 
       const account = writer.account;
       setError(null);
@@ -205,7 +293,8 @@ export function useStakeDeposit() {
         await ensureOnChain(writer.wallet, base);
         setPhase("withdraw");
         const data = encodeFunctionData({
-          abi: vaultAbi, functionName: "redeem",
+          abi: vaultAbi,
+          functionName: "redeem",
           args: [shares, account.address as Address, account.address as Address],
         });
         const tx = prepareTransaction({ client, chain: base, to: vault, data });
@@ -233,9 +322,21 @@ export function useStakeDeposit() {
     async (vault: Address, earnedRaw: bigint): Promise<boolean> => {
       if (pending.current) return false;
       const client = getThirdwebClient();
-      if (!client) { setError("Thirdweb not configured."); setPhase("error"); return false; }
-      if (!writer) { setError("Connect your wallet."); setPhase("error"); return false; }
-      if (earnedRaw <= BigInt(0)) { setError("No earnings to claim."); setPhase("error"); return false; }
+      if (!client) {
+        setError("Thirdweb not configured.");
+        setPhase("error");
+        return false;
+      }
+      if (!writer) {
+        setError("Connect your wallet.");
+        setPhase("error");
+        return false;
+      }
+      if (earnedRaw <= BigInt(0)) {
+        setError("No earnings to claim.");
+        setPhase("error");
+        return false;
+      }
 
       const account = writer.account;
       setError(null);
@@ -244,7 +345,8 @@ export function useStakeDeposit() {
         await ensureOnChain(writer.wallet, base);
         setPhase("claim");
         const data = encodeFunctionData({
-          abi: vaultAbi, functionName: "withdraw",
+          abi: vaultAbi,
+          functionName: "withdraw",
           args: [earnedRaw, account.address as Address, account.address as Address],
         });
         const tx = prepareTransaction({ client, chain: base, to: vault, data });
@@ -269,7 +371,8 @@ export function useStakeDeposit() {
     claimRewards,
     phase,
     error,
-    isStaking: phase === "approve" || phase === "deposit" || phase === "withdraw" || phase === "claim",
+    isStaking:
+      phase === "approve" || phase === "deposit" || phase === "withdraw" || phase === "claim",
     /** The account that deposits/withdraws — read positions for this one. */
     account: writer?.account.address ?? null,
   };

--- a/src/hooks/use-stake-deposit.ts
+++ b/src/hooks/use-stake-deposit.ts
@@ -27,6 +27,8 @@ import {
 } from "viem";
 import { base as viemBase } from "viem/chains";
 import { useWriteAccount } from "@/hooks/use-write-account";
+import { CACHE_TAGS } from "@/lib/cache-tags";
+import { requestRevalidation } from "@/lib/request-revalidation";
 import { USDC } from "@/lib/sponsorship-vaults";
 import { getThirdwebClient } from "@/lib/thirdweb";
 import { ensureOnChain } from "@/lib/thirdweb-tx";
@@ -247,6 +249,10 @@ export function useStakeDeposit() {
         }
         await waitForReceipt({ client, chain: base, transactionHash: depositHash });
 
+        // Drop the server's `stake` cache so OTHER users see this deposit in the
+        // orbit right away instead of waiting out the backstop TTL
+        // (caching-standard.md Rule 3).
+        requestRevalidation([CACHE_TAGS.stake]);
         setPhase("done");
         return true;
       } catch (e) {
@@ -300,6 +306,7 @@ export function useStakeDeposit() {
         const tx = prepareTransaction({ client, chain: base, to: vault, data });
         const hash = (await sendTransaction({ account, transaction: tx })).transactionHash;
         await waitForReceipt({ client, chain: base, transactionHash: hash });
+        requestRevalidation([CACHE_TAGS.stake]);
         setPhase("done");
         return true;
       } catch (e) {
@@ -352,6 +359,7 @@ export function useStakeDeposit() {
         const tx = prepareTransaction({ client, chain: base, to: vault, data });
         const hash = (await sendTransaction({ account, transaction: tx })).transactionHash;
         await waitForReceipt({ client, chain: base, transactionHash: hash });
+        requestRevalidation([CACHE_TAGS.stake]);
         setPhase("done");
         return true;
       } catch (e) {

--- a/src/hooks/use-stake-graph.ts
+++ b/src/hooks/use-stake-graph.ts
@@ -19,9 +19,13 @@ export function useStakeGraph(nonce = 0): StakeGraph | null {
   const { data } = useQuery({
     queryKey: ["stake-graph", nonce],
     queryFn: fetchStakeGraph,
-    // Aligned with the route's cache window. A `nonce` bump (after the user's
-    // own deposit) still forces a fresh fetch, and other users get the update
-    // from `revalidateTag("stake")` — not from a short client TTL.
+    // Matched to the CDN `s-maxage` on /api/stake-graph: refetching sooner
+    // would just re-serve the same header-cached bytes, since a `revalidateTag`
+    // between now and then can't purge that CDN entry.
+    //
+    // Note a `nonce` bump changes only this query key, not the request URL, so
+    // it forces a network fetch but can still be answered by that same CDN
+    // entry — it is not a way to see your own deposit immediately.
     staleTime: 300_000,
     refetchOnWindowFocus: false,
   });

--- a/src/hooks/use-stake-graph.ts
+++ b/src/hooks/use-stake-graph.ts
@@ -4,7 +4,6 @@
 // work (multicalled, parallelized) now happens server-side and is cached +
 // shared across users, so the orbit paints from JSON instead of doing dozens of
 // RPC round-trips on every mount. react-query keeps it warm between navigations.
-
 import { useQuery } from "@tanstack/react-query";
 import type { StakeGraph } from "@/services/stake-graph";
 
@@ -20,7 +19,10 @@ export function useStakeGraph(nonce = 0): StakeGraph | null {
   const { data } = useQuery({
     queryKey: ["stake-graph", nonce],
     queryFn: fetchStakeGraph,
-    staleTime: 60_000,
+    // Aligned with the route's cache window. A `nonce` bump (after the user's
+    // own deposit) still forces a fresh fetch, and other users get the update
+    // from `revalidateTag("stake")` — not from a short client TTL.
+    staleTime: 300_000,
     refetchOnWindowFocus: false,
   });
   return data ?? null;

--- a/src/lib/cache-tags.ts
+++ b/src/lib/cache-tags.ts
@@ -15,6 +15,7 @@ export const CACHE_TAGS = {
   treasury: "treasury",
   propdates: "propdates",
   rounds: "rounds",
+  stake: "stake",
 } as const;
 
 export type StaticCacheTag = (typeof CACHE_TAGS)[keyof typeof CACHE_TAGS];

--- a/src/services/stake-graph.ts
+++ b/src/services/stake-graph.ts
@@ -8,8 +8,14 @@
 //  - Shares → assets is computed locally from totalAssets/totalSupply, killing
 //    the per-backer convertToAssets calls entirely.
 //  - MOR log scans and usersData reads are parallelized + multicalled.
-//  - The API route wraps this with s-maxage + stale-while-revalidate.
+//  - The whole result goes through `unstable_cache` under the `stake` tag
+//    (caching-standard.md Rule 2): the TTL is a backstop, freshness comes from
+//    `revalidateTag("stake")` fired by the deposit/withdraw/claim hooks. The
+//    Vercel Data Cache is shared across regions, so a cold edge region reuses
+//    another's result instead of recomputing this (the single heaviest
+//    server-side operation in the repo) from scratch.
 
+import { unstable_cache } from "next/cache";
 import {
   createPublicClient,
   erc20Abi,
@@ -22,6 +28,7 @@ import {
   type Address,
 } from "viem";
 import { base, mainnet } from "viem/chains";
+import { CACHE_TAGS } from "@/lib/cache-tags";
 import { RIDER_LIST, type RiderId } from "@/lib/gnars-vaults";
 import { arbitrumClient, splitMorBalance } from "@/lib/mor-split";
 import {
@@ -205,6 +212,13 @@ async function etherscanReferred(
     `&fromBlock=0&toBlock=latest&page=1&offset=1000&apikey=${key}`;
   for (let i = 0; i < 4; i++) {
     try {
+      // Deliberately uncached at the fetch layer. Etherscan signals rate limits
+      // with HTTP 200 + an error body, so a TTL'd fetch would happily cache a
+      // "rate limit reached" response and poison the graph for the whole TTL.
+      // Caching happens one level up, in the `unstable_cache` wrapper around
+      // `getStakeGraph` — this callback only runs on a cache miss, and its
+      // `no-store` is scoped to that callback, so it can't opt the calling
+      // route out of caching the way a bare request-scoped `no-store` would.
       const res = await fetch(url, { cache: "no-store" });
       const j = (await res.json()) as { status?: string; message?: string; result?: unknown };
       if (j.status === "1" && Array.isArray(j.result)) {
@@ -415,7 +429,16 @@ async function gnarsMorEarned(
   }
 }
 
-export async function getStakeGraph(): Promise<StakeGraph> {
+/**
+ * Backstop TTL for the whole graph. Staking is a low-frequency event (a handful
+ * of deposits a day at most), so freshness comes from `revalidateTag("stake")`
+ * fired by the deposit/withdraw/claim hooks — not from the TTL expiring. The
+ * previous 60s put the repo's heaviest server-side computation on a ~1440×/day
+ * treadmill for data that changes a few times a day.
+ */
+export const GRAPH_TTL_SECONDS = 1800;
+
+async function fetchStakeGraphUncached(): Promise<StakeGraph> {
   const live = RIDER_LIST.filter((r) => r.vault);
   if (live.length === 0)
     return {
@@ -526,3 +549,14 @@ export async function getStakeGraph(): Promise<StakeGraph> {
     treasuryUsd: gnarsAccrued + gm.usd,
   };
 }
+
+/**
+ * The cached entry point every caller should use. `StakeGraph` is plain
+ * numbers/strings, so it survives the cache's JSON round-trip unchanged — no
+ * re-hydration needed (contrast `services/proposals.ts`, which has to restore a
+ * `Date`).
+ */
+export const getStakeGraph = unstable_cache(fetchStakeGraphUncached, ["stake-graph"], {
+  tags: [CACHE_TAGS.stake],
+  revalidate: GRAPH_TTL_SECONDS,
+});

--- a/src/services/stake-graph.ts
+++ b/src/services/stake-graph.ts
@@ -10,10 +10,15 @@
 //  - MOR log scans and usersData reads are parallelized + multicalled.
 //  - The whole result goes through `unstable_cache` under the `stake` tag
 //    (caching-standard.md Rule 2): the TTL is a backstop, freshness comes from
-//    `revalidateTag("stake")` fired by the deposit/withdraw/claim hooks. The
-//    Vercel Data Cache is shared across regions, so a cold edge region reuses
-//    another's result instead of recomputing this (the single heaviest
-//    server-side operation in the repo) from scratch.
+//    `revalidateTag("stake")` fired by the deposit/withdraw/claim hooks. That
+//    keeps this — the single heaviest server-side operation in the repo — off
+//    the request path, so a cache miss at the CDN layer costs a data-cache read
+//    instead of the full ~3.5s recompute.
+//
+//    Scope matters: `unstable_cache` writes to Next's data cache, which is what
+//    `revalidateTag` invalidates. It is NOT the CDN — a response already cached
+//    by the `Cache-Control` header on /api/stake-graph is not tag-aware and
+//    ages out on its own. See that route for how the two windows are split.
 
 import { unstable_cache } from "next/cache";
 import {
@@ -430,13 +435,19 @@ async function gnarsMorEarned(
 }
 
 /**
- * Backstop TTL for the whole graph. Staking is a low-frequency event (a handful
- * of deposits a day at most), so freshness comes from `revalidateTag("stake")`
- * fired by the deposit/withdraw/claim hooks — not from the TTL expiring. The
- * previous 60s put the repo's heaviest server-side computation on a ~1440×/day
- * treadmill for data that changes a few times a day.
+ * Backstop TTL for the DATA cache only — deliberately not the CDN window, which
+ * /api/stake-graph sets separately and much shorter (the CDN entry can't be
+ * tag-invalidated, so it, not this, bounds cross-user staleness).
+ *
+ * Staking is a low-frequency event (a handful of deposits a day at most), so
+ * what refreshes this is `revalidateTag("stake")` from the deposit/withdraw/
+ * claim hooks, not the TTL expiring. The previous 60s put the repo's heaviest
+ * server-side computation on a ~1440×/day treadmill for data that changes a few
+ * times a day.
+ *
+ * Not exported: nothing outside this module should couple its own window to it.
  */
-export const GRAPH_TTL_SECONDS = 1800;
+const GRAPH_TTL_SECONDS = 1800;
 
 async function fetchStakeGraphUncached(): Promise<StakeGraph> {
   const live = RIDER_LIST.filter((r) => r.vault);

--- a/src/services/stake-graph.ts
+++ b/src/services/stake-graph.ts
@@ -10,13 +10,28 @@
 //  - MOR log scans and usersData reads are parallelized + multicalled.
 //  - The API route wraps this with s-maxage + stale-while-revalidate.
 
-import { createPublicClient, http, fallback, formatUnits, getAddress, keccak256, toHex, erc20Abi, type Address } from "viem";
+import {
+  createPublicClient,
+  erc20Abi,
+  fallback,
+  formatUnits,
+  getAddress,
+  http,
+  keccak256,
+  toHex,
+  type Address,
+} from "viem";
 import { base, mainnet } from "viem/chains";
 import { RIDER_LIST, type RiderId } from "@/lib/gnars-vaults";
+import { arbitrumClient, splitMorBalance } from "@/lib/mor-split";
 import {
-  MORPHEUS_POOLS, MOR_REWARD_POOL_INDEX, MOR_TOKEN, MOR_DECIMALS, MOR_GNARS_RECIPIENT, depositPoolAbi,
+  depositPoolAbi,
+  MOR_DECIMALS,
+  MOR_GNARS_RECIPIENT,
+  MOR_REWARD_POOL_INDEX,
+  MOR_TOKEN,
+  MORPHEUS_POOLS,
 } from "@/lib/morpheus";
-import { splitMorBalance, arbitrumClient } from "@/lib/mor-split";
 
 // Prefer Alchemy (reliable, handles large getLogs) when the key is set, since
 // the public RPCs frequently fail/timeout on the MOR log scan — and a swallowed
@@ -53,7 +68,8 @@ const ethClient = createPublicClient({
 });
 
 const userReferredEvent = {
-  type: "event", name: "UserReferred",
+  type: "event",
+  name: "UserReferred",
   inputs: [
     { name: "rewardPoolIndex", type: "uint256", indexed: true },
     { name: "user", type: "address", indexed: true },
@@ -63,9 +79,27 @@ const userReferredEvent = {
 } as const;
 
 const vaultAbi = [
-  { type: "function", name: "totalAssets", stateMutability: "view", inputs: [], outputs: [{ type: "uint256" }] },
-  { type: "function", name: "totalSupply", stateMutability: "view", inputs: [], outputs: [{ type: "uint256" }] },
-  { type: "function", name: "balanceOf", stateMutability: "view", inputs: [{ type: "address" }], outputs: [{ type: "uint256" }] },
+  {
+    type: "function",
+    name: "totalAssets",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "totalSupply",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "balanceOf",
+    stateMutability: "view",
+    inputs: [{ type: "address" }],
+    outputs: [{ type: "uint256" }],
+  },
 ] as const;
 
 export type OrbitBacker = {
@@ -108,25 +142,36 @@ async function backerAddresses(vault: Address, feeRecipient?: Address): Promise<
       signal: AbortSignal.timeout(9000),
     });
     if (res.ok) {
-      const json = (await res.json()) as { items?: { to?: { hash?: string }; from?: { hash?: string } }[] };
+      const json = (await res.json()) as {
+        items?: { to?: { hash?: string }; from?: { hash?: string } }[];
+      };
       for (const t of json.items ?? []) {
         for (const raw of [t.to?.hash, t.from?.hash]) {
           if (raw && raw.toLowerCase() !== ZERO) {
-            try { out.add(getAddress(raw)); } catch { /* skip */ }
+            try {
+              out.add(getAddress(raw));
+            } catch {
+              /* skip */
+            }
           }
         }
       }
     }
-  } catch { /* fall through */ }
+  } catch {
+    /* fall through */
+  }
   if (feeRecipient) out.delete(getAddress(feeRecipient));
   return [...out];
 }
 
 async function getEthUsd(): Promise<number> {
   try {
-    const res = await fetch("https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd", {
-      next: { revalidate: 300 },
-    });
+    const res = await fetch(
+      "https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd",
+      {
+        next: { revalidate: 300 },
+      },
+    );
     if (!res.ok) return 0;
     const j = (await res.json()) as { ethereum?: { usd?: number } };
     return j.ethereum?.usd ?? 0;
@@ -149,7 +194,11 @@ const pad32 = (a: Address) => `0x000000000000000000000000${a.slice(2).toLowerCas
 /** A rider's referred stakes on a pool, straight from the UserReferred events.
  * Needs a mainnet-capable Etherscan key (a Basescan-only key returns NOTOK for
  * chainid=1) — set ETHERSCAN_API_KEY in the env. */
-async function etherscanReferred(pool: Address, referrer: Address, key: string): Promise<Array<{ user: Address; amount: bigint }>> {
+async function etherscanReferred(
+  pool: Address,
+  referrer: Address,
+  key: string,
+): Promise<Array<{ user: Address; amount: bigint }>> {
   const url =
     `https://api.etherscan.io/v2/api?chainid=1&module=logs&action=getLogs&address=${pool}` +
     `&topic0=${USER_REFERRED_SIG}&topic0_3_opr=and&topic3=${pad32(referrer)}` +
@@ -159,13 +208,21 @@ async function etherscanReferred(pool: Address, referrer: Address, key: string):
       const res = await fetch(url, { cache: "no-store" });
       const j = (await res.json()) as { status?: string; message?: string; result?: unknown };
       if (j.status === "1" && Array.isArray(j.result)) {
-        return (j.result as Array<{ topics: string[]; data: string }>).map((l) => ({ user: getAddress(`0x${l.topics[2].slice(26)}`), amount: BigInt(l.data) }));
+        return (j.result as Array<{ topics: string[]; data: string }>).map((l) => ({
+          user: getAddress(`0x${l.topics[2].slice(26)}`),
+          amount: BigInt(l.data),
+        }));
       }
       // The rate-limit note lives in `result` ("Max calls per sec rate limit
       // reached (3/sec)"), not `message` — retry with backoff before giving up.
-      if (/rate limit/i.test(String(j.message)) || /rate limit/i.test(String(j.result))) { await sleep(600); continue; }
+      if (/rate limit/i.test(String(j.message)) || /rate limit/i.test(String(j.result))) {
+        await sleep(600);
+        continue;
+      }
       return []; // "No records found" / bad key
-    } catch { await sleep(300); }
+    } catch {
+      await sleep(300);
+    }
   }
   return [];
 }
@@ -180,7 +237,9 @@ async function morBackersByRider(ethUsd: number): Promise<Record<string, OrbitBa
   // Primary: Etherscan hosted logs (datacenter-safe). One call per (pool, rider),
   // all in parallel; the staked amount comes straight from the event.
   if (ETHERSCAN_KEY) {
-    const idWallets = RIDER_LIST.filter((r) => r.wallet).map((r) => [r.id, r.wallet as Address] as const);
+    const idWallets = RIDER_LIST.filter((r) => r.wallet).map(
+      (r) => [r.id, r.wallet as Address] as const,
+    );
     const escPools: Array<{ asset: "steth" | "usdc"; pool: Address; decimals: number }> = [
       { asset: "steth", pool: MORPHEUS_POOLS.stEth.pool, decimals: 18 },
       { asset: "usdc", pool: MORPHEUS_POOLS.usdc.pool, decimals: 6 },
@@ -198,12 +257,20 @@ async function morBackersByRider(ethUsd: number): Promise<Record<string, OrbitBa
           // Staked amount straight from the events (no eth_call). Withdrawals
           // aren't subtracted, but the 7-day lock makes that rare.
           const byUser = new Map<string, bigint>();
-          for (const l of logs) byUser.set(l.user.toLowerCase(), (byUser.get(l.user.toLowerCase()) ?? BigInt(0)) + l.amount);
+          for (const l of logs)
+            byUser.set(
+              l.user.toLowerCase(),
+              (byUser.get(l.user.toLowerCase()) ?? BigInt(0)) + l.amount,
+            );
           const out: Array<{ id: RiderId; backer: OrbitBacker }> = [];
           for (const [userLc, amt] of byUser) {
             const tokens = Number(formatUnits(amt, decimals));
             const usd = asset === "steth" ? tokens * ethUsd : tokens;
-            if (usd > 0) out.push({ id, backer: { address: getAddress(userLc), amount: usd, kind: "mor", asset } });
+            if (usd > 0)
+              out.push({
+                id,
+                backer: { address: getAddress(userLc), amount: usd, kind: "mor", asset },
+              });
           }
           return out;
         }),
@@ -217,7 +284,11 @@ async function morBackersByRider(ethUsd: number): Promise<Record<string, OrbitBa
 
   // Fallback (no Etherscan key, e.g. local dev): viem getLogs + usersData.
   let latest: bigint;
-  try { latest = await ethClient.getBlockNumber(); } catch { return byRider; }
+  try {
+    latest = await ethClient.getBlockNumber();
+  } catch {
+    return byRider;
+  }
   // ~3-week window, chunked at 10k so both Alchemy and the public fallback RPCs
   // accept each range (public nodes reject large getLogs spans).
   const WINDOW = BigInt(150_000);
@@ -238,11 +309,15 @@ async function morBackersByRider(ethUsd: number): Promise<Record<string, OrbitBa
       }
       const logsArr = await Promise.all(
         ranges.map(([fromBlock, toBlock]) =>
-          ethClient.getLogs({
-            address: pool, event: userReferredEvent,
-            args: { rewardPoolIndex: MOR_REWARD_POOL_INDEX, referrer: referrers },
-            fromBlock, toBlock,
-          }).catch(() => []),
+          ethClient
+            .getLogs({
+              address: pool,
+              event: userReferredEvent,
+              args: { rewardPoolIndex: MOR_REWARD_POOL_INDEX, referrer: referrers },
+              fromBlock,
+              toBlock,
+            })
+            .catch(() => []),
         ),
       );
       const userToRef = new Map<string, string>();
@@ -258,7 +333,9 @@ async function morBackersByRider(ethUsd: number): Promise<Record<string, OrbitBa
       const uds = await ethClient.multicall({
         allowFailure: true,
         contracts: users.map((u) => ({
-          address: pool, abi: depositPoolAbi, functionName: "usersData",
+          address: pool,
+          abi: depositPoolAbi,
+          functionName: "usersData",
           args: [getAddress(u), MOR_REWARD_POOL_INDEX],
         })),
       });
@@ -302,7 +379,9 @@ async function getMorUsd(): Promise<number> {
  * Gnars Arbitrum multisig, plus Gnars' 25% share still sitting undistributed in
  * each staker's split. Best-effort — priced in USD via CoinGecko.
  */
-async function gnarsMorEarned(morByRider: Record<string, OrbitBacker[]>): Promise<{ mor: number; usd: number }> {
+async function gnarsMorEarned(
+  morByRider: Record<string, OrbitBacker[]>,
+): Promise<{ mor: number; usd: number }> {
   const walletById = new Map<string, Address>();
   for (const r of RIDER_LIST) if (r.wallet) walletById.set(r.id, r.wallet);
 
@@ -318,7 +397,12 @@ async function gnarsMorEarned(morByRider: Record<string, OrbitBacker[]>): Promis
     const [splitBals, directRaw, morUsd] = await Promise.all([
       Promise.all([...pairs.values()].map(([s, a]) => splitMorBalance(s, a).catch(() => 0))),
       arbitrumClient
-        .readContract({ address: MOR_TOKEN, abi: erc20Abi, functionName: "balanceOf", args: [MOR_GNARS_RECIPIENT] })
+        .readContract({
+          address: MOR_TOKEN,
+          abi: erc20Abi,
+          functionName: "balanceOf",
+          args: [MOR_GNARS_RECIPIENT],
+        })
         .then((b) => Number(formatUnits(b, MOR_DECIMALS)))
         .catch(() => 0),
       getMorUsd(),
@@ -333,7 +417,16 @@ async function gnarsMorEarned(morByRider: Record<string, OrbitBacker[]>): Promis
 
 export async function getStakeGraph(): Promise<StakeGraph> {
   const live = RIDER_LIST.filter((r) => r.vault);
-  if (live.length === 0) return { athletes: [], total: 0, backerCount: 0, gnarsAccrued: 0, gnarsMor: 0, gnarsMorUsd: 0, treasuryUsd: 0 };
+  if (live.length === 0)
+    return {
+      athletes: [],
+      total: 0,
+      backerCount: 0,
+      gnarsAccrued: 0,
+      gnarsMor: 0,
+      gnarsMorUsd: 0,
+      treasuryUsd: 0,
+    };
 
   const ethUsd = await getEthUsd();
   const [athletes, mor] = await Promise.all([
@@ -346,8 +439,22 @@ export async function getStakeGraph(): Promise<StakeGraph> {
         const contracts = [
           { address: vault, abi: vaultAbi, functionName: "totalAssets", args: [] },
           { address: vault, abi: vaultAbi, functionName: "totalSupply", args: [] },
-          ...candidates.map((a) => ({ address: vault, abi: vaultAbi, functionName: "balanceOf", args: [a] })),
-          ...(r.split ? [{ address: vault, abi: vaultAbi, functionName: "balanceOf", args: [r.split as Address] }] : []),
+          ...candidates.map((a) => ({
+            address: vault,
+            abi: vaultAbi,
+            functionName: "balanceOf",
+            args: [a],
+          })),
+          ...(r.split
+            ? [
+                {
+                  address: vault,
+                  abi: vaultAbi,
+                  functionName: "balanceOf",
+                  args: [r.split as Address],
+                },
+              ]
+            : []),
         ];
         const res = await baseClient.multicall({
           allowFailure: true,
@@ -356,13 +463,18 @@ export async function getStakeGraph(): Promise<StakeGraph> {
 
         const totalAssets = (res[0].result as bigint | undefined) ?? BigInt(0);
         const totalSupply = (res[1].result as bigint | undefined) ?? BigInt(0);
-        const toAssets = (shares: bigint) => (totalSupply > BigInt(0) ? (shares * totalAssets) / totalSupply : BigInt(0));
+        const toAssets = (shares: bigint) =>
+          totalSupply > BigInt(0) ? (shares * totalAssets) / totalSupply : BigInt(0);
 
         const backers: OrbitBacker[] = [];
         candidates.forEach((addr, i) => {
           const shares = (res[2 + i].result as bigint | undefined) ?? BigInt(0);
           if (shares <= BigInt(0)) return;
-          backers.push({ address: addr, amount: Number(formatUnits(toAssets(shares), 6)), kind: "vault" });
+          backers.push({
+            address: addr,
+            amount: Number(formatUnits(toAssets(shares), 6)),
+            kind: "vault",
+          });
         });
         backers.sort((a, b) => b.amount - a.amount);
 
@@ -373,8 +485,13 @@ export async function getStakeGraph(): Promise<StakeGraph> {
         }
 
         return {
-          id: r.id, handle: r.handle, vault, split: r.split,
-          total: Number(formatUnits(totalAssets, 6)), feeAccrued, backers,
+          id: r.id,
+          handle: r.handle,
+          vault,
+          split: r.split,
+          total: Number(formatUnits(totalAssets, 6)),
+          feeAccrued,
+          backers,
         };
       }),
     ),

--- a/src/services/stake-graph.ts
+++ b/src/services/stake-graph.ts
@@ -176,11 +176,26 @@ async function backerAddresses(vault: Address, feeRecipient?: Address): Promise<
   return [...out];
 }
 
+/**
+ * CoinGecko's demo key. `/api/prices` already treats it as mandatory; these
+ * calls used to go out unauthenticated, i.e. on the shared-IP free tier that is
+ * the most likely to 429 — and a 429 here silently deletes most of the TVL (see
+ * `priceStEth` below), so the key matters more here than anywhere else.
+ */
+const COINGECKO_KEY = process.env.COINGECKO_API_KEY;
+const coingeckoHeaders: HeadersInit = {
+  "user-agent": "gnars-website/stake-graph",
+  ...(COINGECKO_KEY ? { "x-cg-demo-api-key": COINGECKO_KEY } : {}),
+};
+
+/** ETH/USD, or 0 when the price could not be fetched. Callers that actually
+ * need it to value something must treat 0 as a hard failure — never as $0. */
 async function getEthUsd(): Promise<number> {
   try {
     const res = await fetch(
       "https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd",
       {
+        headers: coingeckoHeaders,
         next: { revalidate: 300 },
       },
     );
@@ -190,6 +205,27 @@ async function getEthUsd(): Promise<number> {
   } catch {
     return 0;
   }
+}
+
+/**
+ * Value a stETH position in USD, or throw.
+ *
+ * The whole graph used to be built from `tokens * ethUsd` with `ethUsd`
+ * silently 0 on any CoinGecko hiccup. Every stETH row then evaluated to $0 and
+ * was dropped by the `usd > 0` filter — erasing most of the TVL and several
+ * backers while still returning a perfectly well-formed `StakeGraph`. Nothing
+ * threw, so the route's error path never ran and the bad graph was cached like
+ * a good one.
+ *
+ * Throwing is what makes the caching safe: it reaches the route's `catch`,
+ * which answers 500 with `no-store`, so a pricing outage degrades to "no data"
+ * instead of "confidently wrong data pinned for the backstop TTL".
+ */
+function priceStEth(tokens: number, ethUsd: number): number {
+  if (!(ethUsd > 0)) {
+    throw new Error("stake-graph: ETH/USD unavailable — refusing to price stETH positions at $0");
+  }
+  return tokens * ethUsd;
 }
 
 // Etherscan V2 logs API — a hosted indexer that answers from datacenter IPs,
@@ -284,7 +320,7 @@ async function morBackersByRider(ethUsd: number): Promise<Record<string, OrbitBa
           const out: Array<{ id: RiderId; backer: OrbitBacker }> = [];
           for (const [userLc, amt] of byUser) {
             const tokens = Number(formatUnits(amt, decimals));
-            const usd = asset === "steth" ? tokens * ethUsd : tokens;
+            const usd = asset === "steth" ? priceStEth(tokens, ethUsd) : tokens;
             if (usd > 0)
               out.push({
                 id,
@@ -367,7 +403,7 @@ async function morBackersByRider(ethUsd: number): Promise<Record<string, OrbitBa
         const deposited = ud?.[1] ?? BigInt(0);
         if (deposited <= BigInt(0)) return;
         const tokens = Number(formatUnits(deposited, decimals));
-        const amount = asset === "steth" ? tokens * ethUsd : tokens;
+        const amount = asset === "steth" ? priceStEth(tokens, ethUsd) : tokens;
         if (amount <= 0) return;
         rows.push({ id, backer: { address: getAddress(u), amount, kind: "mor", asset } });
       });
@@ -383,7 +419,7 @@ async function getMorUsd(): Promise<number> {
   try {
     const res = await fetch(
       `https://api.coingecko.com/api/v3/simple/token_price/arbitrum-one?contract_addresses=${MOR_TOKEN}&vs_currencies=usd`,
-      { next: { revalidate: 300 } },
+      { headers: coingeckoHeaders, next: { revalidate: 300 } },
     );
     if (!res.ok) return 0;
     const j = (await res.json()) as Record<string, { usd?: number }>;
@@ -495,6 +531,14 @@ async function fetchStakeGraphUncached(): Promise<StakeGraph> {
           contracts: contracts as Parameters<typeof baseClient.multicall>[0]["contracts"],
         });
 
+        // `allowFailure` lets a genuinely empty vault (success, 0n) and a dead
+        // RPC (failure, no result) both arrive here. Coercing the second to 0n
+        // is what turns an outage into a plausible "nobody has staked" graph —
+        // the exact shape of bug that gets cached and believed. Distinguish
+        // them by `status` and let a real failure reach the route's catch.
+        if (res[0].status === "failure" || res[1].status === "failure") {
+          throw new Error(`stake-graph: vault reads failed for ${vault}`);
+        }
         const totalAssets = (res[0].result as bigint | undefined) ?? BigInt(0);
         const totalSupply = (res[1].result as bigint | undefined) ?? BigInt(0);
         const toAssets = (shares: bigint) =>


### PR DESCRIPTION
## Summary

- `/stake` was written after #128 and never adopted the standard it established — the only module in the repo with no cache tag, no `unstable_cache`, and no event-driven invalidation.
- Brings it in line: `stake` tag, cached service, TTL 60s → 1800s, and `revalidateTag` on deposit/withdraw/claim.
- **Preventive, not a fix for the current bill** — see the note below.

## Changes

- `src/lib/cache-tags.ts` — `stake` tag (so `/api/revalidate` accepts it)
- `src/services/stake-graph.ts` — `getStakeGraph` behind `unstable_cache` (tag `stake`, 1800s backstop). The Data Cache is cross-region, so a cold region reuses another's result instead of recomputing the repo's heaviest server-side operation. `no-store` on the Etherscan fetch is kept **on purpose**: Etherscan signals rate limits with HTTP 200 + an error body, so a TTL'd fetch would cache "rate limit reached" for the whole window.
- `src/app/api/stake-graph/route.ts` — dynamic + `Cache-Control` (Rule 1: zero ISR write units). Error responses get `no-store` so a failed graph can't be cached as real data.
- `src/hooks/use-stake-deposit.ts`, `use-morpheus-stake.ts` — `revalidateTag("stake")` after every mutating path. This is what makes the long TTL safe: previously a short TTL was the *only* freshness mechanism, so other users had to wait it out to see a new stake.
- `src/components/stake/YieldStatus.tsx` — drop `refetchInterval: 60_000` (`/api/yields` is CDN-cached for 300s; the poll re-served identical bytes 5× per cycle).
- `src/components/stake/StakeOrbit.tsx` — **bug fix found at runtime**: a wallet staking MOR in *both* Morpheus pools produced two backer rows sharing a `kind-address` key, so React dropped one and a real stake was silently missing from the orbit.
- `docs/architecture/caching-standard.md` — `stake` added to both tables.

First commit is prettier-only (these files were never `format:check`-clean on main); the second holds the whole functional change in ~100 lines.

## Note on impact

Vercel Observability (12h, the max retention on Hobby) shows **zero invocations of any `/stake` route** — the feature has no traffic yet, so this does not move the current quota overage. The actual CPU leaders are `/[locale]/members/[address]`, `/[locale]`, `/[locale]/proposals/[chain]/[id]`, and ISR writes are dominated by the `proposals` family. Those are a separate PR.

What this does buy: `/stake` ships Farcaster miniapp embeds per rider, so traffic is coming, and the pre-fix code would have recomputed a 3.5s graph every 60s per region once it arrived.

## Test plan

- [x] `pnpm lint` — 0 errors (1 pre-existing warning in `BountiesView.tsx`, outside the diff)
- [x] `pnpm format:check` — clean
- [x] `pnpm exec tsc --noEmit` — no errors in the diff (pre-existing `nodemailer` module error on main, unrelated)
- [x] `pnpm test` — 120 pass (1 pre-existing suite fails on main too: missing `nodemailer`)
- [x] Runtime: `/api/stake-graph` cold 3.5s → cached 7ms → after `POST /api/revalidate {"tags":["stake"]}` recomputes 5.7s → cached again 8ms
- [x] Runtime: `Cache-Control: public, s-maxage=1800, stale-while-revalidate=3600`; tag allowlist accepts `stake`, still rejects `stake-bogus` (400)
- [x] Runtime: `/stake/vlad` renders, APYs load, orbit shows both Morpho and MOR streams with ENS resolved, console clean
- [ ] Post-deploy: stake from wallet A, confirm wallet B sees it in the orbit without waiting out the TTL

Generated with [Claude Code](https://claude.com/claude-code)