### PR TITLE
refactor(prices): one source of truth for USD prices

### DIFF
--- a/docs/architecture/caching-standard.md
+++ b/docs/architecture/caching-standard.md
@@ -41,18 +41,19 @@ Purging the CDN by tag is possible via `invalidateByTag` + `Vercel-Cache-Tag` fr
 
 All reads in `src/services/*` go through `unstable_cache` with canonical tags. TTL is a _backstop_, not the freshness mechanism.
 
-| Tag                       | Covers                         | Backstop TTL               |
-| ------------------------- | ------------------------------ | -------------------------- |
-| `proposals`               | proposal lists (all consumers) | 1800                       |
-| `proposal:<number>`       | one proposal detail + votes    | 1800 (Active/Pending: 120) |
-| `auction`                 | current auction state          | 60                         |
-| `auctions`                | settled auction history        | 3600                       |
-| `feed`                    | activity feed events           | 300                        |
-| `members`                 | holders list, overviews        | 3600                       |
-| `treasury`                | balances                       | 900                        |
-| `propdates`               | EAS attestations               | 300                        |
-| `rounds` / `round:<slug>` | rounds listings / one round    | 300 / closed: 86400        |
-| `stake`                   | sponsorship graph (orbit)      | 1800                       |
+| Tag                       | Covers                                | Backstop TTL               |
+| ------------------------- | ------------------------------------- | -------------------------- |
+| `proposals`               | proposal lists (all consumers)        | 1800                       |
+| `proposal:<number>`       | one proposal detail + votes           | 1800 (Active/Pending: 120) |
+| `auction`                 | current auction state                 | 60                         |
+| `auctions`                | settled auction history               | 3600                       |
+| `feed`                    | activity feed events                  | 300                        |
+| `members`                 | holders list, overviews               | 3600                       |
+| `treasury`                | balances                              | 900                        |
+| `propdates`               | EAS attestations                      | 300                        |
+| `rounds` / `round:<slug>` | rounds listings / one round           | 300 / closed: 86400        |
+| `stake`                   | sponsorship graph (orbit)             | 1800                       |
+| `prices`                  | all USD prices (`services/prices.ts`) | 300                        |
 
 ### Rule 3 — mutations invalidate, clients don't poll
 
@@ -71,6 +72,18 @@ After a write-hook confirms a receipt it must:
 | delegate                                                             | `members`                                 |
 | round vote/submit                                                    | `round:<slug>`, `rounds`                  |
 | stake deposit/withdraw/claim (`useStakeDeposit`, `useMorpheusStake`) | `stake`                                   |
+
+### Rule 3b — a missing value is `null`, never `0`
+
+Prices, balances and rates that could not be fetched must surface as `null` and
+be rendered as unavailable. Defaulting them to `0` produces a well-formed,
+confident, wrong number that then gets cached like a good one — the treasury
+rendered "$0.00" on any price-feed hiccup, and the stake graph silently dropped
+most of its TVL. `services/prices.ts` is the reference: `UsdPrice = number | null`.
+
+Server-side callers should import the service directly. Fetching the app's own
+`/api/*` route from a Server Component is a self-HTTP round trip to read a value
+already sitting in the data cache.
 
 ### Rule 4 — prefetch discipline
 

--- a/src/app/[locale]/treasury/opengraph-image.tsx
+++ b/src/app/[locale]/treasury/opengraph-image.tsx
@@ -1,8 +1,7 @@
-import { headers } from "next/headers";
 import { ImageResponse } from "next/og";
-import { formatEther } from "viem";
-import { DAO_ADDRESSES, TREASURY_TOKEN_ADDRESSES, TREASURY_TOKEN_ALLOWLIST } from "@/lib/config";
+import { DAO_ADDRESSES } from "@/lib/config";
 import { formatEthDisplay, formatUsdDisplay, OG_COLORS, OG_FONTS, OG_SIZE } from "@/lib/og-utils";
+import { loadTreasurySnapshot } from "@/services/treasury";
 
 export const alt = "Gnars DAO Treasury";
 export const size = OG_SIZE;
@@ -13,131 +12,24 @@ export const contentType = "image/png";
 // served from the edge with zero function CPU. Keeps us under Hobby CPU/transfer.
 const OG_CACHE_CONTROL = "public, max-age=0, s-maxage=1800, stale-while-revalidate=3600";
 
-type TokenBalance = {
-  contractAddress?: string;
-  tokenBalance: string;
-  decimals?: number;
-};
-
-type AlchemyTokenResponse = {
-  result?: {
-    tokenBalances?: TokenBalance[];
-  };
-};
-
-type PriceResponse = {
-  prices?: Record<string, { usd?: number }>;
-};
-
-type EthPriceResponse = {
-  usd: number;
-  error?: string;
-};
-
-async function fetchTreasurySnapshot(): Promise<{ ethBalance: string; usdTotal: number } | null> {
+async function fetchTreasurySnapshot(): Promise<{
+  ethBalance: string;
+  usdTotal: number | null;
+} | null> {
+  // Delegates to the same service the treasury page uses. This function used to
+  // re-implement the whole balance+price computation and reach it over HTTP via
+  // the app's own /api/alchemy, /api/prices and /api/eth-price — two copies of
+  // financial logic that could disagree, plus four self-requests per render.
   try {
-    const baseUrl = await getBaseUrl();
-
-    const [ethRes, tokenRes, priceRes, ethPriceRes] = await Promise.all([
-      fetchJson<{ result?: string }>(`${baseUrl}/api/alchemy`, {
-        method: "POST",
-        body: JSON.stringify({
-          method: "eth_getBalance",
-          params: [DAO_ADDRESSES.treasury, "latest"],
-        }),
-      }),
-      fetchJson<AlchemyTokenResponse>(`${baseUrl}/api/alchemy`, {
-        method: "POST",
-        body: JSON.stringify({
-          method: "alchemy_getTokenBalances",
-          params: [DAO_ADDRESSES.treasury, TREASURY_TOKEN_ADDRESSES.filter(Boolean)],
-        }),
-      }),
-      fetchJson<PriceResponse>(`${baseUrl}/api/prices`, {
-        method: "POST",
-        body: JSON.stringify({
-          addresses: TREASURY_TOKEN_ADDRESSES.map((a) => String(a).toLowerCase()),
-        }),
-      }).catch(() => ({ prices: {} })),
-      fetchJson<EthPriceResponse>(`${baseUrl}/api/eth-price`, {
-        method: "GET",
-      }).catch(() => ({ usd: 0 })),
-    ]);
-
-    const ethBalanceWei = BigInt(ethRes.result ?? "0x0");
-    const ethBalance = Number(formatEther(ethBalanceWei));
-    const ethPrice = ethPriceRes?.usd ?? 0;
-
-    const tokenBalances = (tokenRes.result?.tokenBalances ?? []).filter((token) => {
-      const balance = token.tokenBalance?.toLowerCase();
-      return balance && balance !== "0" && balance !== "0x0";
-    });
-
-    const prices: Record<string, { usd: number }> = priceRes.prices ?? {};
-    const wethAddress = String(TREASURY_TOKEN_ALLOWLIST.WETH).toLowerCase();
-
-    const priceLookup = Object.fromEntries(
-      Object.entries(prices).map(([address, value]) => [
-        address.toLowerCase(),
-        address.toLowerCase() === wethAddress ? ethPrice : Number(value?.usd ?? 0) || 0,
-      ]),
-    );
-    priceLookup[wethAddress] = ethPrice;
-
-    const decimals: Record<string, number> = {
-      [String(TREASURY_TOKEN_ALLOWLIST.USDC).toLowerCase()]: 6,
-      [String(TREASURY_TOKEN_ALLOWLIST.WETH).toLowerCase()]: 18,
-      [String(TREASURY_TOKEN_ALLOWLIST.SENDIT).toLowerCase()]: 18,
-    };
-
-    const tokensUsd = tokenBalances.reduce((sum, token) => {
-      const address = token.contractAddress ? String(token.contractAddress).toLowerCase() : null;
-      if (!address) return sum;
-      const tokenDecimals = decimals[address] ?? 18;
-      const raw = token.tokenBalance ?? "0x0";
-      const parsed = Number.parseInt(raw, 16);
-      const balance = Number.isFinite(parsed) ? parsed / Math.pow(10, tokenDecimals) : 0;
-      const price = priceLookup[address] ?? 0;
-      return sum + balance * price;
-    }, 0);
-
-    const usdTotal = tokensUsd + ethBalance * ethPrice;
-
+    const snapshot = await loadTreasurySnapshot(DAO_ADDRESSES.treasury);
     return {
-      ethBalance: formatEthDisplay(ethBalance),
-      usdTotal,
+      ethBalance: formatEthDisplay(snapshot.ethBalance),
+      usdTotal: snapshot.usdTotal,
     };
   } catch (error) {
     console.error("[treasury OG] error fetching snapshot:", error);
     return null;
   }
-}
-
-async function getBaseUrl() {
-  const h = await headers();
-  const protocol = h.get("x-forwarded-proto") ?? "https";
-  const host = h.get("x-forwarded-host") ?? h.get("host");
-  if (!host) {
-    throw new Error("Unable to determine request host");
-  }
-  return `${protocol}://${host}`;
-}
-
-async function fetchJson<T>(url: string, init: RequestInit): Promise<T> {
-  const response = await fetch(url, {
-    ...init,
-    headers: {
-      "Content-Type": "application/json",
-      ...(init.headers || {}),
-    },
-    cache: "no-store",
-  });
-
-  if (!response.ok) {
-    throw new Error(`Request failed: ${response.status}`);
-  }
-
-  return (await response.json()) as T;
 }
 
 export default async function Image({ params }: { params: Promise<{ locale: string }> }) {
@@ -157,7 +49,8 @@ export default async function Image({ params }: { params: Promise<{ locale: stri
   }
 
   const ethBalance = treasuryData.ethBalance;
-  const usdTotal = formatUsdDisplay(treasuryData.usdTotal);
+  // An unpriced treasury renders as a dash, never as "$0".
+  const usdTotal = treasuryData.usdTotal == null ? "—" : formatUsdDisplay(treasuryData.usdTotal);
   const labels = {
     title: isPt ? "TESOURO" : "TREASURY",
     subtitle: isPt ? "Visão Geral Financeira da Gnars DAO" : "Gnars DAO Financial Overview",

--- a/src/app/api/eth-price/route.ts
+++ b/src/app/api/eth-price/route.ts
@@ -1,42 +1,32 @@
 import { NextResponse } from "next/server";
+import { getEthUsd } from "@/services/prices";
+
+/**
+ * Thin wrapper over `services/prices`. Provider choice, TTL and failure
+ * semantics all live there — this route exists only so client components can
+ * reach the price without the Alchemy key.
+ *
+ * `usd` is `null` when the price is unknown, deliberately NOT `0`: this route
+ * used to answer `{ usd: 0 }` on every failure path and `services/treasury.ts`
+ * multiplied the treasury's ETH balance by it, rendering a confident $0.
+ * Clients that do `?? 0` keep working — `formatEthToUsd` already renders "—"
+ * for a falsy price.
+ */
+export const dynamic = "force-dynamic";
+
+const CDN_TTL_SECONDS = 300;
 
 export async function GET() {
-  const apiKey = process.env.ALCHEMY_API_KEY;
-
-  if (!apiKey) {
-    console.error("[eth-price] ALCHEMY_API_KEY not set");
-    return NextResponse.json({ usd: 0, error: "missing_api_key" });
-  }
-
-  try {
-    const res = await fetch("https://api.g.alchemy.com/prices/v1/tokens/by-symbol?symbols=ETH", {
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-      },
-      cache: "no-store",
-    });
-
-    if (!res.ok) {
-      console.error("[eth-price] Alchemy API error:", res.status);
-      return NextResponse.json({ usd: 0, error: `api_error_${res.status}` });
-    }
-
-    const data = await res.json();
-    const ethData = data?.data?.find((d: { symbol: string }) => d.symbol === "ETH");
-    const usdPrice = ethData?.prices?.find(
-      (p: { currency: string }) => p.currency.toLowerCase() === "usd",
-    );
-    const usd = Number(usdPrice?.value ?? 0) || 0;
-
-    console.log("[eth-price] ETH price:", usd);
-    return NextResponse.json(
-      { usd },
-      {
-        headers: { "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300" },
-      },
-    );
-  } catch (error) {
-    console.error("[eth-price] Error:", error);
-    return NextResponse.json({ usd: 0, error: "fetch_error" });
-  }
+  const usd = await getEthUsd();
+  return NextResponse.json(
+    { usd },
+    {
+      headers: usd
+        ? {
+            "Cache-Control": `public, s-maxage=${CDN_TTL_SECONDS}, stale-while-revalidate=${CDN_TTL_SECONDS * 2}`,
+          }
+        : // Never pin an outage to the CDN for the full window.
+          { "Cache-Control": "no-store" },
+    },
+  );
 }

--- a/src/app/api/prices/route.ts
+++ b/src/app/api/prices/route.ts
@@ -1,35 +1,23 @@
 import { NextResponse } from "next/server";
+import { getEthUsd, getTokenPricesUsd, type UsdPrice } from "@/services/prices";
 
-// Cache external CoinGecko fetches for 4 hours
-const COINGECKO_REVALIDATE_SECONDS = 60 * 60 * 4;
+/**
+ * Thin wrapper over `services/prices` — see that module for provider choice,
+ * TTL and failure semantics.
+ *
+ * A price of `null` means "unknown", never "$0". Callers must branch on it.
+ *
+ * WETH stays special-cased to the ETH feed (they are 1:1 by construction, and
+ * Alchemy's ETH price is the fresher of the two), which is what the previous
+ * implementation did too.
+ */
+export const dynamic = "force-dynamic";
 
-// WETH address on Base - we'll use ETH price for this
+const CDN_TTL_SECONDS = 300;
 const WETH_ADDRESS_BASE = "0x4200000000000000000000000000000000000006";
 
-type PricesRequest = {
-  addresses?: string[];
-};
-
 function normalizeAddresses(addrs: string[]): string[] {
-  return addrs
-    .map((a) => (typeof a === "string" ? a : ""))
-    .map((a) => a.toLowerCase())
-    .filter(Boolean);
-}
-
-async function fetchEthPrice(apiKey: string): Promise<number> {
-  const url = "https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd";
-  const res = await fetch(url, {
-    headers: { "user-agent": "gnars-website/treasury", "x-cg-demo-api-key": apiKey },
-    next: { revalidate: COINGECKO_REVALIDATE_SECONDS },
-  });
-
-  if (!res.ok) {
-    return 0;
-  }
-
-  const data = (await res.json()) as { ethereum?: { usd?: number } };
-  return Number(data?.ethereum?.usd ?? 0) || 0;
+  return addrs.map((a) => (typeof a === "string" ? a.toLowerCase() : "")).filter(Boolean);
 }
 
 async function handlePrices(addresses: string[]) {
@@ -37,71 +25,47 @@ async function handlePrices(addresses: string[]) {
     return NextResponse.json({ error: "addresses required" }, { status: 400 });
   }
 
-  const apiKey = process.env.COINGECKO_API_KEY;
-  if (!apiKey) {
-    return NextResponse.json({ error: "missing_coingecko_key" }, { status: 400 });
-  }
+  const weth = WETH_ADDRESS_BASE.toLowerCase();
+  const wantsWeth = addresses.includes(weth);
+  const tokenAddresses = addresses.filter((a) => a !== weth);
 
-  // Filter out WETH since we'll fetch ETH price separately
-  const tokenAddresses = addresses.filter(
-    (a) => a.toLowerCase() !== WETH_ADDRESS_BASE.toLowerCase(),
-  );
-  const includesWeth = addresses.some((a) => a.toLowerCase() === WETH_ADDRESS_BASE.toLowerCase());
-
-  // Fetch token prices and ETH price in parallel
-  const [tokenData, ethPrice] = await Promise.all([
-    tokenAddresses.length > 0
-      ? (async () => {
-          const params = new URLSearchParams({
-            contract_addresses: tokenAddresses.join(","),
-            vs_currencies: "usd",
-          });
-          const url = `https://api.coingecko.com/api/v3/simple/token_price/base?${params.toString()}`;
-          const res = await fetch(url, {
-            headers: { "user-agent": "gnars-website/treasury", "x-cg-demo-api-key": apiKey },
-            next: { revalidate: COINGECKO_REVALIDATE_SECONDS },
-          });
-          if (!res.ok) return {} as Record<string, { usd?: number }>;
-          return (await res.json()) as Record<string, { usd?: number }>;
-        })()
-      : Promise.resolve({} as Record<string, { usd?: number }>),
-    includesWeth ? fetchEthPrice(apiKey) : Promise.resolve(0),
+  const [tokenPrices, ethUsd] = await Promise.all([
+    getTokenPricesUsd(tokenAddresses, "base"),
+    wantsWeth ? getEthUsd() : Promise.resolve(null),
   ]);
 
-  const normalized: Record<string, { usd: number }> = {};
-
-  // Add token prices
-  for (const [addr, price] of Object.entries(tokenData)) {
-    const key = addr.toLowerCase();
-    const usd = Number(price?.usd ?? 0) || 0;
-    normalized[key] = { usd };
+  const prices: Record<string, { usd: UsdPrice }> = {};
+  for (const [address, usd] of Object.entries(tokenPrices)) {
+    prices[address] = { usd };
   }
+  if (wantsWeth) prices[weth] = { usd: ethUsd };
 
-  // Add WETH price using ETH price
-  if (includesWeth && ethPrice > 0) {
-    normalized[WETH_ADDRESS_BASE.toLowerCase()] = { usd: ethPrice };
-  }
+  // A fully-null map is an outage, not an answer — don't let the CDN hold it
+  // for the whole window.
+  const anyResolved = Object.values(prices).some((p) => p.usd !== null);
 
   return NextResponse.json(
-    { prices: normalized },
+    { prices },
     {
-      headers: { "Cache-Control": "public, s-maxage=300, stale-while-revalidate=3600" },
+      headers: anyResolved
+        ? {
+            "Cache-Control": `public, s-maxage=${CDN_TTL_SECONDS}, stale-while-revalidate=${CDN_TTL_SECONDS * 2}`,
+          }
+        : { "Cache-Control": "no-store" },
     },
   );
 }
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const addressesParam = searchParams.get("addresses") || "";
-  const addresses = normalizeAddresses(addressesParam.split(","));
+  const addresses = normalizeAddresses((searchParams.get("addresses") || "").split(","));
   return handlePrices(addresses);
 }
 
 export async function POST(req: Request) {
   try {
-    const body = (await req.json()) as PricesRequest;
-    const raw = Array.isArray(body?.addresses) ? body.addresses : [];
-    const addresses = normalizeAddresses(raw);
+    const body = (await req.json()) as { addresses?: string[] };
+    const addresses = normalizeAddresses(Array.isArray(body?.addresses) ? body.addresses : []);
     return handlePrices(addresses);
   } catch {
     return NextResponse.json({ error: "invalid-request" }, { status: 400 });

--- a/src/components/home/HeroStatsValues.tsx
+++ b/src/components/home/HeroStatsValues.tsx
@@ -21,13 +21,16 @@ export async function HeroStatsValues() {
   const [daoStats, snapshot] = await Promise.all([
     fetchDaoStats().catch(() => ({ totalSupply: 0, ownerCount: 0 })),
     loadTreasurySnapshot(DAO_ADDRESSES.treasury).catch(() => ({
-      usdTotal: 0,
+      usdTotal: null,
       ethBalance: 0,
       totalAuctionSales: 0,
     })),
   ]);
 
-  const formattedTreasury = formatLargeNumber(snapshot.usdTotal);
+  // A null total means the price feed failed. Show a dash — rendering "$0" for
+  // a treasury we simply could not price is worse than showing nothing.
+  const formattedTreasury =
+    snapshot.usdTotal == null ? "—" : `$${formatLargeNumber(snapshot.usdTotal)}`;
 
   return (
     <div className="flex flex-wrap gap-4 pt-4">
@@ -58,7 +61,7 @@ export async function HeroStatsValues() {
           <TrendingUp className="h-4 w-4 text-green-600 dark:text-green-400" />
         </div>
         <div>
-          <div className="font-semibold">${formattedTreasury}</div>
+          <div className="font-semibold">{formattedTreasury}</div>
           <div className="text-xs text-muted-foreground">{t("treasury")}</div>
         </div>
       </div>

--- a/src/components/stake/StakeDialog.tsx
+++ b/src/components/stake/StakeDialog.tsx
@@ -3,17 +3,18 @@
 import { useEffect, useState, type CSSProperties, type ReactNode } from "react";
 import { useTranslations } from "next-intl";
 import { useQuery } from "@tanstack/react-query";
-import { useActiveAccount } from "thirdweb/react";
 import { toast } from "sonner";
+import { useActiveAccount } from "thirdweb/react";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
-import { getRider } from "@/lib/gnars-vaults";
-import { useStakeDeposit } from "@/hooks/use-stake-deposit";
-import { useMorpheusStake } from "@/hooks/use-morpheus-stake";
-import { useVaultPosition, useVaultEarned } from "@/hooks/use-vault-total";
 import { useEnsNameAndAvatar } from "@/hooks/use-ens";
+import { useEthPrice } from "@/hooks/use-eth-price";
+import { useMorpheusStake } from "@/hooks/use-morpheus-stake";
+import { useStakeDeposit } from "@/hooks/use-stake-deposit";
+import { useVaultEarned, useVaultPosition } from "@/hooks/use-vault-total";
+import { getRider } from "@/lib/gnars-vaults";
+import { riderCustomLine } from "@/lib/rider-lines";
 import type { StakeYields } from "@/services/yields";
 import { REWARD_SPLIT } from "./CharacterSelector";
-import { riderCustomLine } from "@/lib/rider-lines";
 
 // Adapted from the Claude-designed "Stake Dialog v2" — arcade-gold, three
 // columns (yield source / amount / your share) over a rewards-flow hero with the
@@ -39,9 +40,39 @@ interface Opp {
   default: string;
 }
 const OPPS: Opp[] = [
-  { id: "vault-usdc", kind: "vault", asset: "usdc", unit: "USDC", labelKey: "opp.vaultUsdc", venue: "Morpho", logo: MORPHO_LOGO, presets: [100, 500, 1000, 5000], default: "1000" },
-  { id: "mor-steth", kind: "mor", asset: "steth", unit: "stETH", labelKey: "opp.morSteth", venue: "Morpheus", logo: MORPHEUS_LOGO, presets: [0.011, 0.1, 0.5, 1], default: "0.011" },
-  { id: "mor-usdc", kind: "mor", asset: "usdc", unit: "USDC", labelKey: "opp.morUsdc", venue: "Morpheus", logo: MORPHEUS_LOGO, presets: [100, 500, 1000, 5000], default: "1000" },
+  {
+    id: "vault-usdc",
+    kind: "vault",
+    asset: "usdc",
+    unit: "USDC",
+    labelKey: "opp.vaultUsdc",
+    venue: "Morpho",
+    logo: MORPHO_LOGO,
+    presets: [100, 500, 1000, 5000],
+    default: "1000",
+  },
+  {
+    id: "mor-steth",
+    kind: "mor",
+    asset: "steth",
+    unit: "stETH",
+    labelKey: "opp.morSteth",
+    venue: "Morpheus",
+    logo: MORPHEUS_LOGO,
+    presets: [0.011, 0.1, 0.5, 1],
+    default: "0.011",
+  },
+  {
+    id: "mor-usdc",
+    kind: "mor",
+    asset: "usdc",
+    unit: "USDC",
+    labelKey: "opp.morUsdc",
+    venue: "Morpheus",
+    logo: MORPHEUS_LOGO,
+    presets: [100, 500, 1000, 5000],
+    default: "1000",
+  },
 ];
 
 interface StakeDialogProps {
@@ -63,38 +94,59 @@ async function fetchYields(): Promise<StakeYields> {
   if (!res.ok) throw new Error("yields");
   return res.json();
 }
-async function fetchEthPrice(): Promise<number> {
-  const res = await fetch("/api/eth-price");
-  if (!res.ok) return 0;
-  const json = (await res.json()) as { usd?: number };
-  return json.usd ?? 0;
-}
 
-const fmt2 = (n: number) => n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+const fmt2 = (n: number) =>
+  n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 function fmtAmount(n: number, usdc: boolean) {
   if (!isFinite(n) || n === 0) return "0";
   if (usdc) return n.toFixed(2);
   return n < 0.001 ? n.toExponential(2) : n.toFixed(n < 1 ? 4 : 3);
 }
 
-export function StakeDialog({ open, onOpenChange, riderId, name, image, overall, faceSize = "420%", facePos = "50% 6%" }: StakeDialogProps) {
+export function StakeDialog({
+  open,
+  onOpenChange,
+  riderId,
+  name,
+  image,
+  overall,
+  faceSize = "420%",
+  facePos = "50% 6%",
+}: StakeDialogProps) {
   const t = useTranslations("stake");
   const you = useActiveAccount()?.address;
   const { ensAvatar: youAvatar } = useEnsNameAndAvatar(you);
-  const { stake, withdrawAll, claimRewards, phase: stakePhase, error: stakeError, isStaking, account } = useStakeDeposit();
+  const {
+    stake,
+    withdrawAll,
+    claimRewards,
+    phase: stakePhase,
+    error: stakeError,
+    isStaking,
+    account,
+  } = useStakeDeposit();
   const morpheus = useMorpheusStake();
   const [refresh, setRefresh] = useState(0);
   const [oppId, setOppId] = useState<OppId>("vault-usdc");
   const [amount, setAmount] = useState(OPPS[0].default);
 
-  const { data: yields } = useQuery({ queryKey: ["stake-yields"], queryFn: fetchYields, staleTime: 60_000 });
-  const { data: ethUsd = 0 } = useQuery({ queryKey: ["eth-price"], queryFn: fetchEthPrice, staleTime: 60_000 });
+  const { data: yields } = useQuery({
+    queryKey: ["stake-yields"],
+    queryFn: fetchYields,
+    // Same window as YieldStatus, which shares this key.
+    staleTime: 300_000,
+  });
+  // Shared hook, not a private query: this used to declare the same
+  // ["eth-price"] key with a different staleTime than useEthPrice, so the two
+  // observers kept invalidating each other's idea of freshness.
+  const { ethPrice: ethUsd } = useEthPrice();
 
   const opp = OPPS.find((o) => o.id === oppId)!;
   const isMor = opp.kind === "mor";
   const isUsdc = opp.asset === "usdc";
 
-  const aprFor = (o: Opp) => (o.kind === "vault" ? yields?.usdc?.apy : yields?.mor?.[o.asset]?.apy) ?? 0;
+  const aprFor = (o: Opp) =>
+    (o.kind === "vault" ? yields?.usdc?.apy : yields?.mor?.[o.asset]?.apy) ?? 0;
   const rate = aprFor(opp);
   const rateKind = isMor ? "APR" : "APY";
 
@@ -119,10 +171,12 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, overall,
   const oppIndex = OPPS.indexOf(opp);
   const line = (() => {
     if (!amountNum) return t("opp.lineEmpty");
-    if (amountNum >= (isUsdc ? 5000 : 1)) return t("opp.lineBig", { amount: fmtAmount(amountNum, isUsdc), asset: opp.unit });
+    if (amountNum >= (isUsdc ? 5000 : 1))
+      return t("opp.lineBig", { amount: fmtAmount(amountNum, isUsdc), asset: opp.unit });
     const custom = riderCustomLine(riderId, oppIndex);
     if (custom) return custom;
-    if (opp.kind === "vault") return t("opp.lineStable", { you: fmt2(totalAsset * 0.5), asset: opp.unit });
+    if (opp.kind === "vault")
+      return t("opp.lineStable", { you: fmt2(totalAsset * 0.5), asset: opp.unit });
     return t("opp.lineVar", { rate: rate.toFixed(1) });
   })();
   const [typed, setTyped] = useState(0);
@@ -132,7 +186,10 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, overall,
     setTyped(0);
     const id = setInterval(() => {
       setTyped((n) => {
-        if (n >= line.length) { clearInterval(id); return n; }
+        if (n >= line.length) {
+          clearInterval(id);
+          return n;
+        }
         return n + 1;
       });
     }, 24);
@@ -146,37 +203,59 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, overall,
   const handleConfirm = async () => {
     if (isMor) {
       if (!rider?.wallet) return;
-      const ok = await morpheus.stake(opp.asset === "steth" ? "stEth" : "usdc", amount, rider.wallet);
-      if (ok) { toast.success(t("opp.stakedMorTitle", { name }), { description: t("opp.stakedMorDesc") }); setRefresh((n) => n + 1); onOpenChange(false); }
-      else toast.error(t("dlg.failTitle"), { description: morpheus.error ?? undefined });
+      const ok = await morpheus.stake(
+        opp.asset === "steth" ? "stEth" : "usdc",
+        amount,
+        rider.wallet,
+      );
+      if (ok) {
+        toast.success(t("opp.stakedMorTitle", { name }), { description: t("opp.stakedMorDesc") });
+        setRefresh((n) => n + 1);
+        onOpenChange(false);
+      } else toast.error(t("dlg.failTitle"), { description: morpheus.error ?? undefined });
       return;
     }
-    if (!rider?.vault) { toast.info(t("dlg.noVaultTitle"), { description: t("dlg.noVaultDesc", { name }) }); return; }
+    if (!rider?.vault) {
+      toast.info(t("dlg.noVaultTitle"), { description: t("dlg.noVaultDesc", { name }) });
+      return;
+    }
     const ok = await stake(rider.vault, amount);
-    if (ok) { toast.success(t("stakeToast", { name }), { description: t("dlg.stakedDesc") }); setRefresh((n) => n + 1); onOpenChange(false); }
-    else toast.error(t("dlg.failTitle"), { description: stakeError ?? undefined });
+    if (ok) {
+      toast.success(t("stakeToast", { name }), { description: t("dlg.stakedDesc") });
+      setRefresh((n) => n + 1);
+      onOpenChange(false);
+    } else toast.error(t("dlg.failTitle"), { description: stakeError ?? undefined });
   };
   const handleClaim = async () => {
     if (!rider?.vault || !earned || earned.earnedRaw <= BigInt(0)) return;
     const ok = await claimRewards(rider.vault, earned.earnedRaw);
-    if (ok) { toast.success(t("dlg.claimedTitle"), { description: t("dlg.claimedDesc") }); setRefresh((n) => n + 1); }
-    else toast.error(t("dlg.claimFailTitle"), { description: stakeError ?? undefined });
+    if (ok) {
+      toast.success(t("dlg.claimedTitle"), { description: t("dlg.claimedDesc") });
+      setRefresh((n) => n + 1);
+    } else toast.error(t("dlg.claimFailTitle"), { description: stakeError ?? undefined });
   };
   const handleWithdraw = async () => {
     if (!rider?.vault || !position || position.shares <= BigInt(0)) return;
     const ok = await withdrawAll(rider.vault, position.shares);
-    if (ok) { toast.success(t("dlg.withdrewTitle"), { description: t("dlg.withdrewDesc") }); setRefresh((n) => n + 1); }
-    else toast.error(t("dlg.withdrawFailTitle"), { description: stakeError ?? undefined });
+    if (ok) {
+      toast.success(t("dlg.withdrewTitle"), { description: t("dlg.withdrewDesc") });
+      setRefresh((n) => n + 1);
+    } else toast.error(t("dlg.withdrawFailTitle"), { description: stakeError ?? undefined });
   };
 
   const confirmLabel = isMor
-    ? morpheus.phase === "approve" ? t("opp.approving")
-      : morpheus.phase === "stake" ? t("opp.staking")
-      : morpheus.phase === "setReceiver" ? t("opp.staking")
-      : `${t("opp.stakeVerb")} ${fmtAmount(amountNum, isUsdc)} ${opp.unit}`
-    : stakePhase === "approve" ? t("dlg.approving")
-      : stakePhase === "deposit" ? t("dlg.depositing")
-      : `${t("opp.stakeVerb")} ${fmtAmount(amountNum, isUsdc)} ${opp.unit}`;
+    ? morpheus.phase === "approve"
+      ? t("opp.approving")
+      : morpheus.phase === "stake"
+        ? t("opp.staking")
+        : morpheus.phase === "setReceiver"
+          ? t("opp.staking")
+          : `${t("opp.stakeVerb")} ${fmtAmount(amountNum, isUsdc)} ${opp.unit}`
+    : stakePhase === "approve"
+      ? t("dlg.approving")
+      : stakePhase === "deposit"
+        ? t("dlg.depositing")
+        : `${t("opp.stakeVerb")} ${fmtAmount(amountNum, isUsdc)} ${opp.unit}`;
 
   const muted = "#8a857e";
 
@@ -193,17 +272,26 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, overall,
             <div className="min-w-0">
               <div className="flex flex-wrap items-center gap-2.5">
                 <span style={{ color: GOLD, fontSize: 20 }}>⚡</span>
-                <h2 className="m-0 text-2xl font-black tracking-tight sm:text-[27px]">{t("stakeCta", { name })}</h2>
+                <h2 className="m-0 text-2xl font-black tracking-tight sm:text-[27px]">
+                  {t("stakeCta", { name })}
+                </h2>
                 {typeof overall === "number" && (
                   <span
                     className="rounded-full px-2.5 py-1 text-[11px] font-bold tracking-widest"
-                    style={{ color: GOLD_HI, background: "rgba(245,166,35,.14)", border: "1px solid rgba(245,166,35,.3)" }}
+                    style={{
+                      color: GOLD_HI,
+                      background: "rgba(245,166,35,.14)",
+                      border: "1px solid rgba(245,166,35,.3)",
+                    }}
                   >
                     {t("opp.overall")} {overall}
                   </span>
                 )}
               </div>
-              <p className="mt-2 max-w-[660px] text-[14.5px] leading-relaxed" style={{ color: muted }}>
+              <p
+                className="mt-2 max-w-[660px] text-[14.5px] leading-relaxed"
+                style={{ color: muted }}
+              >
                 {t("dialogIntro", { name })}
               </p>
             </div>
@@ -216,9 +304,16 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, overall,
           >
             <div className="min-w-0 pb-[18px]">
               <div className="mb-1.5 flex items-baseline justify-between gap-4">
-                <span className="text-[11px] font-bold uppercase tracking-[0.22em]" style={{ color: muted }}>{t("opp.howRewardsFlow")}</span>
+                <span
+                  className="text-[11px] font-bold uppercase tracking-[0.22em]"
+                  style={{ color: muted }}
+                >
+                  {t("opp.howRewardsFlow")}
+                </span>
                 <span className="text-[15px] font-black" style={{ color: GOLD_HI }}>
-                  {isMor ? `≈$${fmt2(totalUsd)} ${t("opp.perYearMor")}` : `${fmt2(totalAsset)} ${opp.unit} / ${t("perYear")}`}
+                  {isMor
+                    ? `≈$${fmt2(totalUsd)} ${t("opp.perYearMor")}`
+                    : `${fmt2(totalAsset)} ${opp.unit} / ${t("perYear")}`}
                 </span>
               </div>
               <RewardFlow
@@ -241,9 +336,17 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, overall,
             <div className="relative hidden min-h-[280px] flex-col gap-[15px] pt-1 sm:flex">
               <div
                 className="relative flex-none rounded-2xl px-3.5 py-3"
-                style={{ background: "linear-gradient(180deg,#1c1714,#141110)", border: `2px solid ${GOLD}` }}
+                style={{
+                  background: "linear-gradient(180deg,#1c1714,#141110)",
+                  border: `2px solid ${GOLD}`,
+                }}
               >
-                <div className="mb-1.5 text-[10px] font-extrabold uppercase tracking-[0.2em]" style={{ color: GOLD_HI }}>{name}</div>
+                <div
+                  className="mb-1.5 text-[10px] font-extrabold uppercase tracking-[0.2em]"
+                  style={{ color: GOLD_HI }}
+                >
+                  {name}
+                </div>
                 {/* reserve the full line's height (invisible) so typing never reflows the bubble */}
                 <div className="relative text-[13px] font-semibold leading-relaxed">
                   <span className="invisible">{line}</span>
@@ -254,7 +357,11 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, overall,
                 </div>
                 <div
                   className="absolute -bottom-2.5 left-1/2 h-4 w-4 -translate-x-1/2 rotate-45"
-                  style={{ background: "#141110", borderRight: `2px solid ${GOLD}`, borderBottom: `2px solid ${GOLD}` }}
+                  style={{
+                    background: "#141110",
+                    borderRight: `2px solid ${GOLD}`,
+                    borderBottom: `2px solid ${GOLD}`,
+                  }}
                 />
               </div>
               {/* face crop with a soft bottom fade — no box, blends into the panel */}
@@ -262,8 +369,10 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, overall,
                 aria-hidden
                 className="min-h-[170px] flex-1"
                 style={{
-                  backgroundImage: `url(${image})`, backgroundRepeat: "no-repeat",
-                  backgroundSize: faceSize, backgroundPosition: facePos,
+                  backgroundImage: `url(${image})`,
+                  backgroundRepeat: "no-repeat",
+                  backgroundSize: faceSize,
+                  backgroundPosition: facePos,
                   WebkitMaskImage: "linear-gradient(180deg,#000 62%,rgba(0,0,0,0) 100%)",
                   maskImage: "linear-gradient(180deg,#000 62%,rgba(0,0,0,0) 100%)",
                 }}
@@ -275,7 +384,12 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, overall,
           <div className="grid items-start gap-5 sm:grid-cols-3">
             {/* Yield source */}
             <div className="min-w-0">
-              <div className="mb-3 text-[11px] font-bold uppercase tracking-[0.24em]" style={{ color: muted }}>{t("opp.yieldSource")}</div>
+              <div
+                className="mb-3 text-[11px] font-bold uppercase tracking-[0.24em]"
+                style={{ color: muted }}
+              >
+                {t("opp.yieldSource")}
+              </div>
               <div className="flex flex-col gap-2.5">
                 {OPPS.map((o) => {
                   const active = o.id === oppId;
@@ -296,7 +410,10 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, overall,
                       <img src={o.logo} alt="" className="h-6 w-6 flex-none rounded-full" />
                       <div className="min-w-0 flex-1">
                         <div className="text-sm font-bold">{t(o.labelKey)}</div>
-                        <div className="mt-0.5 text-[11.5px] font-semibold" style={{ color: muted }}>
+                        <div
+                          className="mt-0.5 text-[11.5px] font-semibold"
+                          style={{ color: muted }}
+                        >
                           {o.kind === "vault" ? t("opp.stableTag") : t("opp.morTag")} · {o.unit}
                         </div>
                       </div>
@@ -311,15 +428,25 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, overall,
 
             {/* Amount */}
             <div className="min-w-0">
-              <div className="mb-3 text-[11px] font-bold uppercase tracking-[0.24em]" style={{ color: muted }}>{t("amountLabel")}</div>
-              <div className="flex h-[58px] items-center gap-2.5 rounded-[14px] border border-white/[0.11] px-4" style={{ background: "rgba(255,255,255,.045)" }}>
+              <div
+                className="mb-3 text-[11px] font-bold uppercase tracking-[0.24em]"
+                style={{ color: muted }}
+              >
+                {t("amountLabel")}
+              </div>
+              <div
+                className="flex h-[58px] items-center gap-2.5 rounded-[14px] border border-white/[0.11] px-4"
+                style={{ background: "rgba(255,255,255,.045)" }}
+              >
                 <input
                   value={amount}
                   onChange={(e) => setAmount(e.target.value.replace(/[^0-9.]/g, ""))}
                   inputMode="decimal"
                   className="min-w-0 flex-1 border-none bg-transparent text-2xl font-extrabold tracking-tight text-white outline-none"
                 />
-                <span className="text-sm font-bold" style={{ color: "#8f8a83" }}>{opp.unit}</span>
+                <span className="text-sm font-bold" style={{ color: "#8f8a83" }}>
+                  {opp.unit}
+                </span>
               </div>
               <div className="mt-3 flex flex-wrap gap-2">
                 {opp.presets.map((v) => {
@@ -332,7 +459,9 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, overall,
                       className="cursor-pointer rounded-[10px] px-3 py-2 text-[12.5px] font-bold"
                       style={{
                         color: on ? "#1a1205" : "#c9c6c2",
-                        background: on ? "linear-gradient(90deg,#f7c948,#f5851f)" : "rgba(255,255,255,.05)",
+                        background: on
+                          ? "linear-gradient(90deg,#f7c948,#f5851f)"
+                          : "rgba(255,255,255,.05)",
                         border: on ? "1px solid transparent" : "1px solid rgba(255,255,255,.09)",
                       }}
                     >
@@ -347,15 +476,28 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, overall,
                 </div>
               )}
               {isMor && (
-                <div className="mt-2 text-[11.5px] font-semibold" style={{ color: "#b8741a" }}>{t("opp.mainnetWarn")}</div>
+                <div className="mt-2 text-[11.5px] font-semibold" style={{ color: "#b8741a" }}>
+                  {t("opp.mainnetWarn")}
+                </div>
               )}
             </div>
 
             {/* Your share */}
-            <div className="flex min-w-0 flex-col gap-3 rounded-[18px] border border-white/[0.07] p-[18px]" style={{ background: "rgba(255,255,255,.035)" }}>
-              <div className="text-[11px] font-bold uppercase tracking-[0.22em]" style={{ color: muted }}>{t("opp.yourShare")}</div>
+            <div
+              className="flex min-w-0 flex-col gap-3 rounded-[18px] border border-white/[0.07] p-[18px]"
+              style={{ background: "rgba(255,255,255,.035)" }}
+            >
+              <div
+                className="text-[11px] font-bold uppercase tracking-[0.22em]"
+                style={{ color: muted }}
+              >
+                {t("opp.yourShare")}
+              </div>
               <div className="flex items-baseline gap-2">
-                <span className="text-[34px] font-black leading-none tracking-tight" style={{ color: GOLD_HI }}>
+                <span
+                  className="text-[34px] font-black leading-none tracking-tight"
+                  style={{ color: GOLD_HI }}
+                >
                   {isMor ? `≈$${fmt2(totalUsd * 0.5)}` : fmt2(totalAsset * 0.5)}
                 </span>
                 <span className="text-[13px] font-bold" style={{ color: muted }}>
@@ -369,9 +511,14 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, overall,
                 { label: t("treasuryLabel"), color: "#5c4520", pct: REWARD_SPLIT.treasury },
               ].map((s) => (
                 <div key={s.label} className="flex items-center gap-2.5">
-                  <div className="h-2 w-2 flex-none rounded-[2px]" style={{ background: s.color }} />
+                  <div
+                    className="h-2 w-2 flex-none rounded-[2px]"
+                    style={{ background: s.color }}
+                  />
                   <span className="min-w-0 flex-1 truncate text-[13px] font-bold">{s.label}</span>
-                  <span className="text-[13px] font-extrabold" style={{ color: "#c9c6c2" }}>{share(s.pct)}</span>
+                  <span className="text-[13px] font-extrabold" style={{ color: "#c9c6c2" }}>
+                    {share(s.pct)}
+                  </span>
                 </div>
               ))}
               <button
@@ -379,7 +526,11 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, overall,
                 onClick={handleConfirm}
                 disabled={busy}
                 className="mt-auto cursor-pointer rounded-[13px] px-5 py-3.5 text-center text-[14.5px] font-extrabold disabled:opacity-70"
-                style={{ color: "#1a1205", background: "linear-gradient(90deg,#f7c948,#f5851f)", boxShadow: "0 8px 24px rgba(245,133,31,.28)" }}
+                style={{
+                  color: "#1a1205",
+                  background: "linear-gradient(90deg,#f7c948,#f5851f)",
+                  boxShadow: "0 8px 24px rgba(245,133,31,.28)",
+                }}
               >
                 {confirmLabel}
               </button>
@@ -388,20 +539,40 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, overall,
 
           {/* Vault position management — only when a live position exists */}
           {!isMor && position && position.shares > BigInt(0) && (
-            <div className="flex flex-wrap items-center gap-x-4 gap-y-2 rounded-xl border border-white/[0.07] px-4 py-3 text-xs" style={{ background: "rgba(255,255,255,.02)" }}>
+            <div
+              className="flex flex-wrap items-center gap-x-4 gap-y-2 rounded-xl border border-white/[0.07] px-4 py-3 text-xs"
+              style={{ background: "rgba(255,255,255,.02)" }}
+            >
               <span style={{ color: muted }}>
-                {t("opp.yourPosition")}: <strong className="font-mono text-white">${position.assets.toFixed(2)}</strong>
+                {t("opp.yourPosition")}:{" "}
+                <strong className="font-mono text-white">${position.assets.toFixed(2)}</strong>
                 {earned && earned.principal > 0 && (
-                  <span className="opacity-80"> ({t("opp.principal")} ${earned.principal.toFixed(2)} · {t("opp.yield")} <span style={{ color: "#4ade80" }}>${earned.earned.toFixed(2)}</span>)</span>
+                  <span className="opacity-80">
+                    {" "}
+                    ({t("opp.principal")} ${earned.principal.toFixed(2)} · {t("opp.yield")}{" "}
+                    <span style={{ color: "#4ade80" }}>${earned.earned.toFixed(2)}</span>)
+                  </span>
                 )}
               </span>
               <div className="ml-auto flex items-center gap-2">
                 {earned && earned.earned >= CLAIM_FLOOR_USD && (
-                  <button type="button" onClick={handleClaim} disabled={isStaking} className="cursor-pointer rounded-lg border border-white/15 px-3 py-1.5 font-semibold hover:bg-white/5 disabled:opacity-60">
-                    {stakePhase === "claim" ? t("dlg.claiming") : t("dlg.claim", { amount: `$${earned.earned.toFixed(2)}` })}
+                  <button
+                    type="button"
+                    onClick={handleClaim}
+                    disabled={isStaking}
+                    className="cursor-pointer rounded-lg border border-white/15 px-3 py-1.5 font-semibold hover:bg-white/5 disabled:opacity-60"
+                  >
+                    {stakePhase === "claim"
+                      ? t("dlg.claiming")
+                      : t("dlg.claim", { amount: `$${earned.earned.toFixed(2)}` })}
                   </button>
                 )}
-                <button type="button" onClick={handleWithdraw} disabled={isStaking} className="cursor-pointer rounded-lg border border-white/15 px-3 py-1.5 font-semibold hover:bg-white/5 disabled:opacity-60">
+                <button
+                  type="button"
+                  onClick={handleWithdraw}
+                  disabled={isStaking}
+                  className="cursor-pointer rounded-lg border border-white/15 px-3 py-1.5 font-semibold hover:bg-white/5 disabled:opacity-60"
+                >
                   {stakePhase === "withdraw" ? t("dlg.withdrawing") : t("dlg.withdrawAll")}
                 </button>
               </div>
@@ -409,7 +580,10 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, overall,
           )}
 
           {/* Footer */}
-          <div className="flex items-start gap-2 border-t border-white/[0.07] pt-3.5 text-xs leading-normal" style={{ color: "#7d7871" }}>
+          <div
+            className="flex items-start gap-2 border-t border-white/[0.07] pt-3.5 text-xs leading-normal"
+            style={{ color: "#7d7871" }}
+          >
             <span className="flex-none">ⓘ</span>
             <span>{t("disclaimer")}</span>
           </div>
@@ -421,10 +595,31 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, overall,
 
 /** The rewards-flow SVG (gold streams → You / rider / Gnars) with real avatars overlaid. */
 function RewardFlow({
-  riderName, riderImg, faceSize, facePos, youVal, ridVal, gnaVal, youLabel, youAvatar, gnarsLabel, srcLabel, yieldLabel,
+  riderName,
+  riderImg,
+  faceSize,
+  facePos,
+  youVal,
+  ridVal,
+  gnaVal,
+  youLabel,
+  youAvatar,
+  gnarsLabel,
+  srcLabel,
+  yieldLabel,
 }: {
-  riderName: string; riderImg: string; faceSize: string; facePos: string;
-  youVal: string; ridVal: string; gnaVal: string; youLabel: string; youAvatar?: string; gnarsLabel: string; srcLabel: string; yieldLabel: string;
+  riderName: string;
+  riderImg: string;
+  faceSize: string;
+  facePos: string;
+  youVal: string;
+  ridVal: string;
+  gnaVal: string;
+  youLabel: string;
+  youAvatar?: string;
+  gnarsLabel: string;
+  srcLabel: string;
+  yieldLabel: string;
 }) {
   const P = {
     you: "M126,130 C280,130 320,46 403,46",
@@ -434,22 +629,56 @@ function RewardFlow({
   const stream = (id: string, d: string, n: number) =>
     Array.from({ length: n }, (_, i) => (
       <circle key={id + i} r={4} fill={GOLD_HI}>
-        <animateMotion dur="2.8s" repeatCount="indefinite" begin={`${((i * 2.8) / n).toFixed(2)}s`} path={d} />
+        <animateMotion
+          dur="2.8s"
+          repeatCount="indefinite"
+          begin={`${((i * 2.8) / n).toFixed(2)}s`}
+          path={d}
+        />
       </circle>
     ));
-  const node = (key: string, cy: number, label: string, pct: string, val: string, inner?: ReactNode) => (
+  const node = (
+    key: string,
+    cy: number,
+    label: string,
+    pct: string,
+    val: string,
+    inner?: ReactNode,
+  ) => (
     <g key={key}>
       <circle cx={430} cy={cy} r={27} fill="#14110e" stroke={GOLD} strokeWidth={3} />
       {inner}
-      <text x={470} y={cy - 10} fill="#fff" fontSize={20} fontWeight={800}>{label}</text>
-      <text x={470} y={cy + 13} fill={GOLD} fontSize={17} fontWeight={800}>{pct}</text>
-      <text x={470} y={cy + 33} fill="#8a857e" fontSize={13} fontWeight={600}>{val}</text>
+      <text x={470} y={cy - 10} fill="#fff" fontSize={20} fontWeight={800}>
+        {label}
+      </text>
+      <text x={470} y={cy + 13} fill={GOLD} fontSize={17} fontWeight={800}>
+        {pct}
+      </text>
+      <text x={470} y={cy + 33} fill="#8a857e" fontSize={13} fontWeight={600}>
+        {val}
+      </text>
     </g>
   );
-  const overlay = (leftPct: number, topPct: number, width: number, size: string, pos: string, url: string): CSSProperties => ({
-    position: "absolute", left: `${leftPct}%`, top: `${topPct}%`, width: `${width}%`, aspectRatio: "1",
-    transform: "translate(-50%,-50%)", borderRadius: "50%", overflow: "hidden",
-    backgroundImage: `url(${url})`, backgroundRepeat: "no-repeat", backgroundSize: size, backgroundPosition: pos,
+  const overlay = (
+    leftPct: number,
+    topPct: number,
+    width: number,
+    size: string,
+    pos: string,
+    url: string,
+  ): CSSProperties => ({
+    position: "absolute",
+    left: `${leftPct}%`,
+    top: `${topPct}%`,
+    width: `${width}%`,
+    aspectRatio: "1",
+    transform: "translate(-50%,-50%)",
+    borderRadius: "50%",
+    overflow: "hidden",
+    backgroundImage: `url(${url})`,
+    backgroundRepeat: "no-repeat",
+    backgroundSize: size,
+    backgroundPosition: pos,
   });
 
   return (
@@ -469,17 +698,32 @@ function RewardFlow({
         {stream("g", P.gna, 2)}
 
         <circle cx={110} cy={138} r={15} fill={GOLD} />
-        <text x={110} y={100} fill="#fff" fontSize={17} fontWeight={700} textAnchor="middle">{srcLabel}</text>
-        <text x={110} y={176} fill="#8a857e" fontSize={13} fontWeight={600} textAnchor="middle">{yieldLabel}</text>
+        <text x={110} y={100} fill="#fff" fontSize={17} fontWeight={700} textAnchor="middle">
+          {srcLabel}
+        </text>
+        <text x={110} y={176} fill="#8a857e" fontSize={13} fontWeight={600} textAnchor="middle">
+          {yieldLabel}
+        </text>
 
-        {node("n1", 46, youLabel, "50%", youVal, youAvatar ? null : (
-          <text x={430} y={52} fill={GOLD_HI} fontSize={13} fontWeight={800} textAnchor="middle">{youLabel.slice(0, 3).toUpperCase()}</text>
-        ))}
+        {node(
+          "n1",
+          46,
+          youLabel,
+          "50%",
+          youVal,
+          youAvatar ? null : (
+            <text x={430} y={52} fill={GOLD_HI} fontSize={13} fontWeight={800} textAnchor="middle">
+              {youLabel.slice(0, 3).toUpperCase()}
+            </text>
+          ),
+        )}
         {node("n2", 138, riderName, "25%", ridVal)}
         {node("n3", 230, gnarsLabel, "25%", gnaVal)}
       </svg>
       {/* real avatars over the You (if connected) + rider + Gnars nodes */}
-      {youAvatar && <div aria-hidden style={overlay(61.43, 16.67, 7.71, "cover", "center", youAvatar)} />}
+      {youAvatar && (
+        <div aria-hidden style={overlay(61.43, 16.67, 7.71, "cover", "center", youAvatar)} />
+      )}
       <div aria-hidden style={overlay(61.43, 50, 7.71, faceSize, facePos, riderImg)} />
       <div aria-hidden style={overlay(61.43, 83.33, 7.71, "cover", "center", "/gnars.webp")} />
     </div>

--- a/src/components/treasury/TokenHoldings.tsx
+++ b/src/components/treasury/TokenHoldings.tsx
@@ -1,6 +1,7 @@
 import { cache } from "react";
 import { headers } from "next/headers";
 import { TREASURY_TOKEN_ADDRESSES } from "@/lib/config";
+import { getTokenPricesUsd } from "@/services/prices";
 import { EnrichedToken, TokenHoldingsClient } from "./TokenHoldingsClient";
 
 interface TokenBalance {
@@ -21,10 +22,6 @@ interface TokenMetadataResponse {
     name?: string;
     symbol?: string;
   };
-}
-
-interface PriceResponse {
-  prices?: Record<string, { usd?: number }>;
 }
 
 const loadTokenHoldings = cache(async (treasuryAddress: string): Promise<EnrichedToken[]> => {
@@ -89,7 +86,7 @@ const loadTokenHoldings = cache(async (treasuryAddress: string): Promise<Enriche
       symbol: metadata.symbol,
       name: metadata.name,
       logo: metadata.logo,
-      usdValue: 0,
+      usdValue: null,
     });
   }
 
@@ -97,31 +94,23 @@ const loadTokenHoldings = cache(async (treasuryAddress: string): Promise<Enriche
     return [];
   }
 
-  try {
-    const priceResponse = await fetchJson<PriceResponse>(`${baseUrl}/api/prices`, {
-      method: "POST",
-      body: JSON.stringify({
-        addresses: tokensWithMetadata.map((token) => token.contractAddress.toLowerCase()),
-      }),
-    });
+  // Server-side already — read the service directly instead of this module
+  // making an HTTP round trip to the app's own /api/prices.
+  const priceMap = await getTokenPricesUsd(
+    tokensWithMetadata.map((token) => token.contractAddress.toLowerCase()),
+    "base",
+  );
 
-    const priceMap = Object.fromEntries(
-      Object.entries(priceResponse.prices ?? {}).map(([address, value]) => [
-        address.toLowerCase(),
-        Number(value?.usd ?? 0) || 0,
-      ]),
-    );
-
-    for (const token of tokensWithMetadata) {
-      const price = priceMap[token.contractAddress.toLowerCase()] ?? 0;
-      token.usdValue = price * token.balance;
-    }
-  } catch {
-    // Ignore price errors; usdValue will remain 0.
+  for (const token of tokensWithMetadata) {
+    const price = priceMap[token.contractAddress.toLowerCase()];
+    // `null` = unpriceable. Leave usdValue null rather than claiming $0, which
+    // is a real balance the UI would otherwise show as worthless.
+    token.usdValue = price == null ? null : price * token.balance;
   }
 
   // Sort tokens by USD value descending for a friendlier presentation.
-  tokensWithMetadata.sort((a, b) => b.usdValue - a.usdValue);
+  // Unpriced tokens sort last rather than being treated as worth $0.
+  tokensWithMetadata.sort((a, b) => (b.usdValue ?? -1) - (a.usdValue ?? -1));
 
   return tokensWithMetadata;
 });

--- a/src/components/treasury/TokenHoldingsClient.tsx
+++ b/src/components/treasury/TokenHoldingsClient.tsx
@@ -20,7 +20,8 @@ export interface EnrichedToken {
   symbol: string;
   name: string;
   logo?: string;
-  usdValue: number;
+  /** `null` when the token could not be priced — render as unavailable, not $0. */
+  usdValue: number | null;
 }
 
 interface TokenHoldingsClientProps {
@@ -40,7 +41,9 @@ export function TokenHoldingsClient({ tokens, error }: TokenHoldingsClientProps)
     }).format(balance);
   };
 
-  const formatUsdValue = (value: number) => {
+  const formatUsdValue = (value: number | null) => {
+    // A real balance we couldn't price reads as a dash, never as $0.00.
+    if (value == null) return "—";
     return new Intl.NumberFormat(intlLocale, {
       style: "currency",
       currency: "USD",

--- a/src/components/treasury/TreasuryBalance.tsx
+++ b/src/components/treasury/TreasuryBalance.tsx
@@ -13,7 +13,10 @@ export async function TreasuryBalance({ treasuryAddress, metric = "total" }: Tre
     const snapshot = await loadTreasurySnapshot(treasuryAddress);
     value =
       metric === "total"
-        ? snapshot.usdTotal
+        ? // `null` means the price feed failed; `undefined` is this component's
+          // existing "no value" signal, which the client already renders as a
+          // dash rather than $0.
+          (snapshot.usdTotal ?? undefined)
         : metric === "eth"
           ? snapshot.ethBalance
           : snapshot.totalAuctionSales;

--- a/src/hooks/use-eth-price.ts
+++ b/src/hooks/use-eth-price.ts
@@ -3,13 +3,19 @@
 import { useQuery } from "@tanstack/react-query";
 
 interface EthPriceResponse {
-  usd: number;
+  /** `null` when the price feed is unavailable — never 0-as-unknown. */
+  usd: number | null;
   error?: string;
 }
 
 /**
- * Hook to fetch current ETH price in USD
- * Uses the /api/eth-price endpoint which fetches from Alchemy
+ * The single client-side ETH price. Every component that needs it must go
+ * through this hook rather than its own `useQuery` — one shared query key is
+ * what lets React Query dedupe them into one request per window.
+ *
+ * `/api/eth-price` is a thin wrapper over `services/prices` (Alchemy, 300s).
+ * `usd` is `null` when unknown; `?? 0` keeps that falsy so `formatEthToUsd`
+ * renders "—" rather than "$0.00".
  */
 export function useEthPrice() {
   const { data, isLoading, error } = useQuery<EthPriceResponse>({
@@ -21,8 +27,10 @@ export function useEthPrice() {
       }
       return res.json();
     },
-    staleTime: 60 * 1000, // 1 minute
-    refetchInterval: 60 * 1000, // Refetch every minute
+    // Matched to the route's CDN window. There is no `refetchInterval`: the old
+    // 60s poll re-fetched five times per cache window across every mounted
+    // consumer (bounties, member profiles) and got the same bytes each time.
+    staleTime: 5 * 60 * 1000,
   });
 
   return {

--- a/src/lib/cache-tags.ts
+++ b/src/lib/cache-tags.ts
@@ -16,6 +16,7 @@ export const CACHE_TAGS = {
   propdates: "propdates",
   rounds: "rounds",
   stake: "stake",
+  prices: "prices",
 } as const;
 
 export type StaticCacheTag = (typeof CACHE_TAGS)[keyof typeof CACHE_TAGS];

--- a/src/services/prices.ts
+++ b/src/services/prices.ts
@@ -1,0 +1,123 @@
+/**
+ * The single source of truth for USD prices.
+ *
+ * Before this module the app had four independent price paths: `/api/eth-price`
+ * (Alchemy, 60s), `/api/prices` (CoinGecko, 4h), `services/stake-graph.ts`
+ * (CoinGecko, 300s, unauthenticated) and `/api/wallet/tokens` (CoinGecko). Two
+ * of them ran inside `services/treasury.ts` at the same time, so the ETH price
+ * shown by one component could disagree with another's on the same page.
+ *
+ * Three rules hold here and nowhere else:
+ *
+ * 1. **One provider per asset class.** Alchemy for ETH (the key is already
+ *    mandatory and it is the fresher feed); CoinGecko for ERC-20s (that is
+ *    where its coverage is). Callers do not get to choose.
+ * 2. **An unknown price is `null`, never `0`.** A missing price that arrives as
+ *    `0` multiplies balances into a confident, well-formed "$0" — the treasury
+ *    page did exactly this whenever Alchemy hiccuped. `null` forces every
+ *    caller to decide what to render, and TypeScript makes them.
+ * 3. **One TTL.** 300s for everything, as a `prices` tagged data cache.
+ */
+import { unstable_cache } from "next/cache";
+import { CACHE_TAGS } from "@/lib/cache-tags";
+
+/** USD price, or `null` when it could not be determined. Never `0` for unknown. */
+export type UsdPrice = number | null;
+
+/** Shared by every price read. Freshness comes from the TTL — prices have no
+ * mutation to invalidate on — but the tag lets them be purged deliberately. */
+const PRICE_TTL_SECONDS = 300;
+
+/** CoinGecko platform slugs we actually query. */
+export type CoinGeckoPlatform = "base" | "arbitrum-one" | "ethereum";
+
+function coingeckoHeaders(apiKey: string): HeadersInit {
+  return { "user-agent": "gnars-website/prices", "x-cg-demo-api-key": apiKey };
+}
+
+/** Guards against `0`, negatives and NaN all being read as a real price. */
+function toPrice(value: unknown): UsdPrice {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+async function fetchEthUsd(): Promise<UsdPrice> {
+  const apiKey = process.env.ALCHEMY_API_KEY;
+  if (!apiKey) return null;
+  try {
+    const res = await fetch("https://api.g.alchemy.com/prices/v1/tokens/by-symbol?symbols=ETH", {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      next: { revalidate: PRICE_TTL_SECONDS },
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as {
+      data?: { symbol: string; prices?: { currency: string; value?: string }[] }[];
+    };
+    const eth = data?.data?.find((d) => d.symbol === "ETH");
+    const usd = eth?.prices?.find((p) => p.currency.toLowerCase() === "usd");
+    return toPrice(usd?.value);
+  } catch {
+    return null;
+  }
+}
+
+async function fetchTokenPricesUsd(
+  addresses: string[],
+  platform: CoinGeckoPlatform,
+): Promise<Record<string, UsdPrice>> {
+  const wanted = [...new Set(addresses.map((a) => a.toLowerCase()).filter(Boolean))];
+  // Every requested address gets a key, so a caller can always tell "asked and
+  // unknown" from "never asked".
+  const out: Record<string, UsdPrice> = Object.fromEntries(wanted.map((a) => [a, null]));
+  if (wanted.length === 0) return out;
+
+  const apiKey = process.env.COINGECKO_API_KEY;
+  if (!apiKey) return out;
+
+  try {
+    const params = new URLSearchParams({
+      contract_addresses: wanted.join(","),
+      vs_currencies: "usd",
+    });
+    const res = await fetch(
+      `https://api.coingecko.com/api/v3/simple/token_price/${platform}?${params}`,
+      { headers: coingeckoHeaders(apiKey), next: { revalidate: PRICE_TTL_SECONDS } },
+    );
+    if (!res.ok) return out;
+    const json = (await res.json()) as Record<string, { usd?: number }>;
+    for (const [addr, value] of Object.entries(json)) {
+      const key = addr.toLowerCase();
+      if (key in out) out[key] = toPrice(value?.usd);
+    }
+    return out;
+  } catch {
+    return out;
+  }
+}
+
+/**
+ * ETH/USD via Alchemy, or `null`. Callers that multiply a balance by this MUST
+ * branch on `null` rather than defaulting to `0` — see rule 2 above.
+ */
+export const getEthUsd = unstable_cache(fetchEthUsd, ["price-eth-usd"], {
+  tags: [CACHE_TAGS.prices],
+  revalidate: PRICE_TTL_SECONDS,
+});
+
+/**
+ * ERC-20 prices via CoinGecko, keyed by lowercased address. Every requested
+ * address is present in the result; unknown ones map to `null`.
+ */
+export const getTokenPricesUsd = unstable_cache(fetchTokenPricesUsd, ["price-tokens-usd"], {
+  tags: [CACHE_TAGS.prices],
+  revalidate: PRICE_TTL_SECONDS,
+});
+
+/** Convenience for the common "one token on one chain" read. */
+export async function getTokenPriceUsd(
+  address: string,
+  platform: CoinGeckoPlatform,
+): Promise<UsdPrice> {
+  const prices = await getTokenPricesUsd([address], platform);
+  return prices[address.toLowerCase()] ?? null;
+}

--- a/src/services/stake-graph.ts
+++ b/src/services/stake-graph.ts
@@ -44,6 +44,7 @@ import {
   MOR_TOKEN,
   MORPHEUS_POOLS,
 } from "@/lib/morpheus";
+import { getEthUsd, getTokenPriceUsd, type UsdPrice } from "@/services/prices";
 
 // Prefer Alchemy (reliable, handles large getLogs) when the key is set, since
 // the public RPCs frequently fail/timeout on the MOR log scan — and a swallowed
@@ -177,52 +178,20 @@ async function backerAddresses(vault: Address, feeRecipient?: Address): Promise<
 }
 
 /**
- * CoinGecko's demo key. `/api/prices` already treats it as mandatory; these
- * calls used to go out unauthenticated, i.e. on the shared-IP free tier that is
- * the most likely to 429 — and a 429 here silently deletes most of the TVL (see
- * `priceStEth` below), so the key matters more here than anywhere else.
- */
-const COINGECKO_KEY = process.env.COINGECKO_API_KEY;
-const coingeckoHeaders: HeadersInit = {
-  "user-agent": "gnars-website/stake-graph",
-  ...(COINGECKO_KEY ? { "x-cg-demo-api-key": COINGECKO_KEY } : {}),
-};
-
-/** ETH/USD, or 0 when the price could not be fetched. Callers that actually
- * need it to value something must treat 0 as a hard failure — never as $0. */
-async function getEthUsd(): Promise<number> {
-  try {
-    const res = await fetch(
-      "https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd",
-      {
-        headers: coingeckoHeaders,
-        next: { revalidate: 300 },
-      },
-    );
-    if (!res.ok) return 0;
-    const j = (await res.json()) as { ethereum?: { usd?: number } };
-    return j.ethereum?.usd ?? 0;
-  } catch {
-    return 0;
-  }
-}
-
-/**
  * Value a stETH position in USD, or throw.
  *
- * The whole graph used to be built from `tokens * ethUsd` with `ethUsd`
- * silently 0 on any CoinGecko hiccup. Every stETH row then evaluated to $0 and
- * was dropped by the `usd > 0` filter — erasing most of the TVL and several
- * backers while still returning a perfectly well-formed `StakeGraph`. Nothing
- * threw, so the route's error path never ran and the bad graph was cached like
- * a good one.
+ * The graph used to be built from `tokens * ethUsd` with `ethUsd` silently 0 on
+ * any price hiccup. Every stETH row then evaluated to $0 and was dropped by the
+ * `usd > 0` filter — erasing most of the TVL and several backers while still
+ * returning a perfectly well-formed `StakeGraph`. Nothing threw, so the route's
+ * error path never ran and the bad graph was cached like a good one.
  *
  * Throwing is what makes the caching safe: it reaches the route's `catch`,
  * which answers 500 with `no-store`, so a pricing outage degrades to "no data"
  * instead of "confidently wrong data pinned for the backstop TTL".
  */
-function priceStEth(tokens: number, ethUsd: number): number {
-  if (!(ethUsd > 0)) {
+function priceStEth(tokens: number, ethUsd: UsdPrice): number {
+  if (ethUsd == null) {
     throw new Error("stake-graph: ETH/USD unavailable — refusing to price stETH positions at $0");
   }
   return tokens * ethUsd;
@@ -282,7 +251,7 @@ async function etherscanReferred(
   return [];
 }
 
-async function morBackersByRider(ethUsd: number): Promise<Record<string, OrbitBacker[]>> {
+async function morBackersByRider(ethUsd: UsdPrice): Promise<Record<string, OrbitBacker[]>> {
   const walletToId = new Map<string, RiderId>();
   for (const r of RIDER_LIST) if (r.wallet) walletToId.set(r.wallet.toLowerCase(), r.id);
   const referrers = [...walletToId.keys()].map((a) => getAddress(a));
@@ -415,20 +384,6 @@ async function morBackersByRider(ethUsd: number): Promise<Record<string, OrbitBa
   return byRider;
 }
 
-async function getMorUsd(): Promise<number> {
-  try {
-    const res = await fetch(
-      `https://api.coingecko.com/api/v3/simple/token_price/arbitrum-one?contract_addresses=${MOR_TOKEN}&vs_currencies=usd`,
-      { headers: coingeckoHeaders, next: { revalidate: 300 } },
-    );
-    if (!res.ok) return 0;
-    const j = (await res.json()) as Record<string, { usd?: number }>;
-    return j?.[MOR_TOKEN.toLowerCase()]?.usd ?? 0;
-  } catch {
-    return 0;
-  }
-}
-
 /**
  * MOR earned for the Gnars treasury: what's already been distributed to the
  * Gnars Arbitrum multisig, plus Gnars' 25% share still sitting undistributed in
@@ -437,6 +392,22 @@ async function getMorUsd(): Promise<number> {
 async function gnarsMorEarned(
   morByRider: Record<string, OrbitBacker[]>,
 ): Promise<{ mor: number; usd: number }> {
+  // The pricing check deliberately lives OUTSIDE the try below: that catch is
+  // there to tolerate flaky Arbitrum reads, and it would happily swallow a
+  // "cannot price" throw, putting us right back to reporting $0 for real MOR.
+  const { mor, morUsd } = await readGnarsMor(morByRider);
+  // Same rule as `priceStEth`: only a balance we actually hold and cannot price
+  // is a failure. With no MOR accrued there is nothing to misreport.
+  if (mor > 0 && morUsd == null) {
+    throw new Error("stake-graph: MOR/USD unavailable — refusing to value accrued MOR at $0");
+  }
+  return { mor, usd: mor * (morUsd ?? 0) };
+}
+
+/** Raw read, tolerant of flaky RPCs. Pricing policy is applied by the caller. */
+async function readGnarsMor(
+  morByRider: Record<string, OrbitBacker[]>,
+): Promise<{ mor: number; morUsd: UsdPrice }> {
   const walletById = new Map<string, Address>();
   for (const r of RIDER_LIST) if (r.wallet) walletById.set(r.id, r.wallet);
 
@@ -460,13 +431,13 @@ async function gnarsMorEarned(
         })
         .then((b) => Number(formatUnits(b, MOR_DECIMALS)))
         .catch(() => 0),
-      getMorUsd(),
+      getTokenPriceUsd(MOR_TOKEN, "arbitrum-one"),
     ]);
     const pendingGnars = splitBals.reduce((s, v) => s + v, 0) * 0.25; // Gnars = 25% of each split
     const mor = pendingGnars + directRaw;
-    return { mor, usd: mor * morUsd };
+    return { mor, morUsd };
   } catch {
-    return { mor: 0, usd: 0 };
+    return { mor: 0, morUsd: null as UsdPrice };
   }
 }
 

--- a/src/services/treasury.ts
+++ b/src/services/treasury.ts
@@ -2,6 +2,7 @@ import { cache } from "react";
 import { formatEther } from "viem";
 import { BASE_URL, TREASURY_TOKEN_ADDRESSES, TREASURY_TOKEN_ALLOWLIST } from "@/lib/config";
 import { fetchTotalAuctionSalesWei } from "@/services/dao";
+import { getEthUsd, getTokenPricesUsd, type UsdPrice } from "@/services/prices";
 
 interface TokenBalance {
   contractAddress?: string;
@@ -15,17 +16,9 @@ interface AlchemyTokenResponse {
   };
 }
 
-interface PriceResponse {
-  prices?: Record<string, { usd?: number }>;
-}
-
-interface EthPriceResponse {
-  usd: number;
-  error?: string;
-}
-
 export interface TreasurySnapshot {
-  usdTotal: number;
+  /** `null` when a required price was unavailable — NOT the same as $0. */
+  usdTotal: number | null;
   ethBalance: number;
   totalAuctionSales: number;
 }
@@ -59,7 +52,7 @@ export const loadTreasurySnapshot = cache(
   async (treasuryAddress: string): Promise<TreasurySnapshot> => {
     const baseUrl = getBaseUrl();
 
-    const [ethRes, tokenRes, priceRes, ethPriceRes, auctionSalesWei] = await Promise.all([
+    const [ethRes, tokenRes, tokenPrices, ethUsd, auctionSalesWei] = await Promise.all([
       fetchJson<{ result?: string }>(`${baseUrl}/api/alchemy`, {
         method: "POST",
         body: JSON.stringify({
@@ -74,43 +67,40 @@ export const loadTreasurySnapshot = cache(
           params: [treasuryAddress, TREASURY_TOKEN_ADDRESSES.filter(Boolean)],
         }),
       }),
-      fetchJson<PriceResponse>(`${baseUrl}/api/prices`, {
-        method: "POST",
-        body: JSON.stringify({
-          addresses: TREASURY_TOKEN_ADDRESSES.map((a) => String(a).toLowerCase()),
-        }),
-      }).catch(() => ({ prices: {} })),
-      fetchJson<EthPriceResponse>(`${baseUrl}/api/eth-price`, {
-        method: "GET",
-      }).catch(() => ({ usd: 0 })),
+      // Straight to the service — this is already server-side, so the old
+      // `fetch(${baseUrl}/api/prices)` was the server making an HTTP round trip
+      // to its own API (two of them) purely to read a cached value.
+      getTokenPricesUsd(
+        TREASURY_TOKEN_ADDRESSES.map((a) => String(a).toLowerCase()),
+        "base",
+      ),
+      getEthUsd(),
       fetchTotalAuctionSalesWei().catch(() => BigInt(0)),
     ]);
 
     const ethBalanceWei = BigInt(ethRes.result ?? "0x0");
     const ethBalance = Number(formatEther(ethBalanceWei));
-    const ethPrice = ethPriceRes?.usd ?? 0;
 
     const tokenBalances = (tokenRes.result?.tokenBalances ?? []).filter((token) => {
       const balance = token.tokenBalance?.toLowerCase();
       return balance && balance !== "0" && balance !== "0x0";
     });
 
-    const prices: Record<string, { usd: number }> = priceRes.prices ?? {};
+    // WETH is 1:1 with ETH and takes the fresher Alchemy feed, as before.
     const wethAddress = String(TREASURY_TOKEN_ALLOWLIST.WETH).toLowerCase();
-
-    const priceLookup = Object.fromEntries(
-      Object.entries(prices).map(([address, value]) => [
-        address.toLowerCase(),
-        address.toLowerCase() === wethAddress ? ethPrice : Number(value?.usd ?? 0) || 0,
-      ]),
-    );
-    priceLookup[wethAddress] = ethPrice;
+    const priceLookup: Record<string, UsdPrice> = { ...tokenPrices, [wethAddress]: ethUsd };
 
     const DECIMALS: Record<string, number> = {
       [String(TREASURY_TOKEN_ALLOWLIST.USDC).toLowerCase()]: 6,
       [String(TREASURY_TOKEN_ALLOWLIST.WETH).toLowerCase()]: 18,
       [String(TREASURY_TOKEN_ALLOWLIST.SENDIT).toLowerCase()]: 18,
     };
+
+    // A price we could not fetch used to arrive as 0 and multiply straight into
+    // the total, so an Alchemy or CoinGecko hiccup rendered a confident, wrong
+    // dollar figure — usually far too low, since ETH dominates this treasury.
+    // Track it instead and report "unknown" rather than a number we don't have.
+    let priced = true;
 
     const tokensUsd = tokenBalances.reduce((sum, token) => {
       const address = token.contractAddress ? String(token.contractAddress).toLowerCase() : null;
@@ -119,12 +109,21 @@ export const loadTreasurySnapshot = cache(
       const raw = token.tokenBalance ?? "0x0";
       const parsed = Number.parseInt(raw, 16);
       const balance = Number.isFinite(parsed) ? parsed / Math.pow(10, decimals) : 0;
-      const price = priceLookup[address] ?? 0;
+      if (balance === 0) return sum;
+      const price = priceLookup[address];
+      if (price == null) {
+        priced = false;
+        return sum;
+      }
       return sum + balance * price;
     }, 0);
 
-    const nativeEthUsd = ethBalance * ethPrice;
-    const usdTotal = tokensUsd + nativeEthUsd;
+    if (ethBalance > 0 && ethUsd == null) priced = false;
+
+    const nativeEthUsd = ethBalance * (ethUsd ?? 0);
+    // `null` = "we could not price this", which every consumer must render as
+    // unavailable. It is never the same thing as a treasury worth $0.
+    const usdTotal: number | null = priced ? tokensUsd + nativeEthUsd : null;
     const totalAuctionSales = Number(formatEther(auctionSalesWei));
 
     return {


### PR DESCRIPTION
> Stacked on #222 — merge that first. The diff against `perf/stake-cache-standard` is this change only.

## Summary

- The app had **four** independent price paths: `/api/eth-price` (Alchemy, 60s), `/api/prices` (CoinGecko, 4h), `services/stake-graph.ts` (CoinGecko, 300s) and `/api/wallet/tokens`. Two of them ran inside `services/treasury.ts` **at the same time**, so the ETH price behind one component could disagree with another's on the same page — measured ~1% apart.
- New `src/services/prices.ts` owns all of it: **Alchemy for ETH, CoinGecko for ERC-20s, 300s, tagged `prices`**.
- **An unknown price is now `null`, never `0`** — this fixes a live bug, see below.

## The bug this fixes

`/api/eth-price` answered `{ usd: 0 }` on all three of its failure paths, and `services/treasury.ts:91` did `ethPrice = ethPriceRes?.usd ?? 0` then `ethBalance * ethPrice`. **Any Alchemy hiccup rendered a confident "$0.00"** for a treasury that is mostly ETH. `TokenHoldings` had the same shape, with a comment saying "Ignore price errors; usdValue will remain 0".

`UsdPrice = number | null` makes the compiler force every consumer to decide. Treasury, hero stats, token rows and the OG image now render "—".

## Changes

- `src/services/prices.ts` — new. `getEthUsd()`, `getTokenPricesUsd()`, `getTokenPriceUsd()`, all `unstable_cache` + `prices` tag.
- `/api/prices`, `/api/eth-price` — thin wrappers. `no-store` when nothing resolved, so an outage can't stick to the CDN.
- **Server consumers call the service directly** instead of the server fetching its own `/api/*` over HTTP: `treasury.ts` −2 self-requests per load, `TokenHoldings` −1, treasury OG image −4. The OG image also stopped re-implementing the entire balance+price computation: **−122 lines of duplicated financial logic** that could drift from the page it illustrates.
- `stake-graph.ts` — uses the service; its two ad-hoc CoinGecko calls are gone. The `priceStEth` / MOR throw-on-unpriceable guards from #222 are preserved, and the MOR one moved out of a `try/catch` that would have swallowed it.
- Client: `StakeDialog` had its own `["eth-price"]` query with a **different `staleTime` than `useEthPrice` on the same key** — two observers undercutting each other. Now uses the hook. `useEthPrice` drops `refetchInterval: 60s` (against a 300s cache it re-fetched identical bytes 5× per window, on every mounted bounty card and member profile). Same fix applied to the `["stake-yields"]` key.
- `caching-standard.md` — `prices` tag + new **Rule 3b** ("a missing value is `null`, never `0`"; server callers import the service, don't self-HTTP).

## Test plan

- [x] `pnpm lint` 0 errors (1 pre-existing warning in `BountiesView.tsx`)
- [x] `pnpm format:check` clean · `tsc --noEmit` clean (pre-existing `nodemailer` error only)
- [x] `pnpm test` 120 pass (pre-existing `nodemailer` suite fails on `main` too)
- [x] Runtime: `/api/eth-price` and `/api/prices` both `s-maxage=300`, and **ETH and WETH now report the same number** (1901.85) — previously 1901.85 from Alchemy vs 1924.17 from CoinGecko on the same page
- [x] Runtime: `/api/stake-graph` still resolves, stETH row intact
- [x] Runtime: `/treasury` renders **identically to production** (`$0,00` / `0,0000 ETH` — the configured treasury address genuinely holds zero of ETH/USDC/WETH/SENDIT on Base, verified against the prod API; not a regression from this PR)
- [ ] Post-deploy: confirm treasury + hero still show real values once balances are non-zero

## Note for the reviewer

The treasury showing `$0.00` in production is **pre-existing and unrelated to this PR** — `DAO_ADDRESSES.treasury` holds nothing on Base right now. Worth a separate look at whether that address is still correct.

Generated with [Claude Code](https://claude.com/claude-code)