### PR TITLE
feat(stake): step de lock com APR/multiplicador reais (power factor)

### DIFF
--- a/messages/en/stake.json
+++ b/messages/en/stake.json
@@ -139,6 +139,22 @@
     "lineStable": "Steady wins. {you} {asset} a year back to you — I'll take my cut in grip tape.",
     "lineVar": "~{rate}% APR is a big air. Could land clean, could slam. You in?"
   },
+  "lock": {
+    "step": "Step 2 · boost (optional)",
+    "title": "Lock your MOR claim to earn more",
+    "explain": "Your stETH stays liquid — withdraw after the 7-day window, whenever you want. You only defer WHEN you can claim the MOR you earn; in exchange your reward multiplier goes up.",
+    "continue": "Next: lock →",
+    "none": "No lock",
+    "noneNote": "Claim your MOR anytime",
+    "years": "{n, plural, one {# year} other {# years}}",
+    "mult": "{mult}× more MOR",
+    "oneway": "A lock can only be extended later, never shortened.",
+    "back": "Back",
+    "summaryTitle": "What you're choosing",
+    "summaryNone": "No lock — base rate, and you can claim your MOR whenever you like.",
+    "summaryLocked": "Locking {label} → {mult}× the MOR share, in exchange for not claiming it until then.",
+    "stethNote": "Either way your stETH principal is never locked by this — only the 7-day withdraw rule applies."
+  },
   "lootbox": {
     "title": "Rewards ready",
     "claim": "Claim",

--- a/messages/pt-br/stake.json
+++ b/messages/pt-br/stake.json
@@ -139,6 +139,22 @@
     "lineStable": "Devagar e sempre. {you} {asset} por ano de volta pra você — meu corte eu pego em fita.",
     "lineVar": "~{rate}% APR é um baita air. Pode cair limpo ou levar tombo. Tá dentro?"
   },
+  "lock": {
+    "step": "Passo 2 · turbinar (opcional)",
+    "title": "Trave o claim do MOR pra render mais",
+    "explain": "Seu stETH continua líquido — saca depois dos 7 dias, quando quiser. Você só adia QUANDO pode sacar o MOR que acumula; em troca, seu multiplicador de recompensa sobe.",
+    "continue": "Próximo: lock →",
+    "none": "Sem lock",
+    "noneNote": "Saca seu MOR quando quiser",
+    "years": "{n, plural, one {# ano} other {# anos}}",
+    "mult": "{mult}× mais MOR",
+    "oneway": "O lock só pode ser estendido depois, nunca encurtado.",
+    "back": "Voltar",
+    "summaryTitle": "O que você está escolhendo",
+    "summaryNone": "Sem lock — taxa base, e você saca seu MOR quando quiser.",
+    "summaryLocked": "Travar {label} → {mult}× a fatia de MOR, em troca de não poder sacar até lá.",
+    "stethNote": "De qualquer forma seu stETH nunca fica preso por isso — vale só a regra de saque de 7 dias."
+  },
   "lootbox": {
     "title": "Recompensas prontas",
     "claim": "Sacar",

--- a/src/components/stake/StakeDialog.tsx
+++ b/src/components/stake/StakeDialog.tsx
@@ -14,6 +14,7 @@ import { useEnsNameAndAvatar } from "@/hooks/use-ens";
 import type { StakeYields } from "@/services/yields";
 import { REWARD_SPLIT } from "./CharacterSelector";
 import { riderCustomLine } from "@/lib/rider-lines";
+import { LOCK_OPTIONS, multiplierForYears, claimLockEndFor } from "@/lib/lock-multiplier";
 
 // Adapted from the Claude-designed "Stake Dialog v2" — arcade-gold, three
 // columns (yield source / amount / your share) over a rewards-flow hero with the
@@ -86,9 +87,18 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, overall,
   const [refresh, setRefresh] = useState(0);
   const [oppId, setOppId] = useState<OppId>("vault-usdc");
   const [amount, setAmount] = useState(OPPS[0].default);
+  // MOR stakes get a 2nd step to tune the optional power-factor lock, so the
+  // first screen stays lean for newcomers. `nowSec` is captured once (lazy init)
+  // to keep the multiplier math out of render-time Date.now().
+  const [step, setStep] = useState<"config" | "lock">("config");
+  const [lockYears, setLockYears] = useState(0);
+  const [nowSec] = useState(() => Math.floor(Date.now() / 1000));
 
   const { data: yields } = useQuery({ queryKey: ["stake-yields"], queryFn: fetchYields, staleTime: 60_000 });
   const { data: ethUsd = 0 } = useQuery({ queryKey: ["eth-price"], queryFn: fetchEthPrice, staleTime: 60_000 });
+
+  // Reopen always lands on the lean first step with no lock preselected.
+  useEffect(() => { if (open) { setStep("config"); setLockYears(0); } }, [open]);
 
   const opp = OPPS.find((o) => o.id === oppId)!;
   const isMor = opp.kind === "mor";
@@ -100,7 +110,9 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, overall,
 
   const assetUsd = opp.asset === "steth" ? ethUsd : 1;
   const amountNum = Math.max(0, parseFloat(amount) || 0);
-  const totalAsset = (amountNum * rate) / 100; // yield in the deposit asset
+  // The power-factor lock scales the MOR projection (1× when no lock / vault).
+  const lockMult = isMor ? multiplierForYears(lockYears, nowSec) : 1;
+  const totalAsset = ((amountNum * rate) / 100) * lockMult; // yield in the deposit asset
   const totalUsd = totalAsset * assetUsd;
   const busy = isMor ? morpheus.isBusy : isStaking;
 
@@ -108,6 +120,8 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, overall,
     const o = OPPS.find((x) => x.id === next)!;
     setOppId(next);
     setAmount(o.default);
+    setStep("config");
+    setLockYears(0);
   };
 
   // Shares of the yield — the 3-way split (mirrors the vault and the MOR split).
@@ -146,7 +160,8 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, overall,
   const handleConfirm = async () => {
     if (isMor) {
       if (!rider?.wallet) return;
-      const ok = await morpheus.stake(opp.asset === "steth" ? "stEth" : "usdc", amount, rider.wallet);
+      const lockEnd = claimLockEndFor(lockYears);
+      const ok = await morpheus.stake(opp.asset === "steth" ? "stEth" : "usdc", amount, rider.wallet, lockEnd);
       if (ok) { toast.success(t("opp.stakedMorTitle", { name }), { description: t("opp.stakedMorDesc") }); setRefresh((n) => n + 1); onOpenChange(false); }
       else toast.error(t("dlg.failTitle"), { description: morpheus.error ?? undefined });
       return;
@@ -271,7 +286,9 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, overall,
             </div>
           </div>
 
-          {/* Three columns */}
+          {/* Step 1 (config): source · amount · your share. Step 2 (lock, MOR only)
+              tunes the optional power-factor multiplier — kept off the first screen. */}
+          {step === "config" ? (
           <div className="grid items-start gap-5 sm:grid-cols-3">
             {/* Yield source */}
             <div className="min-w-0">
@@ -376,15 +393,28 @@ export function StakeDialog({ open, onOpenChange, riderId, name, image, overall,
               ))}
               <button
                 type="button"
-                onClick={handleConfirm}
+                onClick={isMor ? () => setStep("lock") : handleConfirm}
                 disabled={busy}
                 className="mt-auto cursor-pointer rounded-[13px] px-5 py-3.5 text-center text-[14.5px] font-extrabold disabled:opacity-70"
                 style={{ color: "#1a1205", background: "linear-gradient(90deg,#f7c948,#f5851f)", boxShadow: "0 8px 24px rgba(245,133,31,.28)" }}
               >
-                {confirmLabel}
+                {isMor ? t("lock.continue") : confirmLabel}
               </button>
             </div>
           </div>
+          ) : (
+            <LockStep
+              t={t}
+              rate={rate}
+              nowSec={nowSec}
+              lockYears={lockYears}
+              setLockYears={setLockYears}
+              onBack={() => setStep("config")}
+              onStake={handleConfirm}
+              stakeLabel={confirmLabel}
+              busy={busy}
+            />
+          )}
 
           {/* Vault position management — only when a live position exists */}
           {!isMor && position && position.shares > BigInt(0) && (
@@ -482,6 +512,94 @@ function RewardFlow({
       {youAvatar && <div aria-hidden style={overlay(61.43, 16.67, 7.71, "cover", "center", youAvatar)} />}
       <div aria-hidden style={overlay(61.43, 50, 7.71, faceSize, facePos, riderImg)} />
       <div aria-hidden style={overlay(61.43, 83.33, 7.71, "cover", "center", "/gnars.webp")} />
+    </div>
+  );
+}
+
+/** Step 2 (MOR only): pick the optional power-factor lock. The multiplier is
+ * exact (on-chain LockMultiplierMath replica); the APR it scales is the same
+ * live estimate shown on step 1, so the RELATIVE boost is honest. */
+function LockStep({
+  t, rate, nowSec, lockYears, setLockYears, onBack, onStake, stakeLabel, busy,
+}: {
+  t: ReturnType<typeof useTranslations>;
+  rate: number; nowSec: number; lockYears: number;
+  setLockYears: (y: number) => void; onBack: () => void; onStake: () => void; stakeLabel: string; busy: boolean;
+}) {
+  const muted = "#8a857e";
+  const optLabel = (y: number) => (y === 0 ? t("lock.none") : t("lock.years", { n: y }));
+  return (
+    <div className="grid items-start gap-5 sm:grid-cols-[minmax(0,1fr)_300px]">
+      {/* Explainer + lock options */}
+      <div className="min-w-0">
+        <div className="mb-1 text-[11px] font-bold uppercase tracking-[0.24em]" style={{ color: muted }}>{t("lock.step")}</div>
+        <h3 className="m-0 text-lg font-black">{t("lock.title")}</h3>
+        <p className="mt-1.5 text-[13px] leading-relaxed" style={{ color: muted }}>{t("lock.explain")}</p>
+        <div className="mt-4 grid gap-2.5">
+          {LOCK_OPTIONS.map(({ years }) => {
+            const m = multiplierForYears(years, nowSec);
+            const active = years === lockYears;
+            return (
+              <button
+                key={years}
+                type="button"
+                onClick={() => setLockYears(years)}
+                aria-pressed={active}
+                className="flex cursor-pointer items-center gap-3 rounded-[13px] px-4 py-3 text-left transition"
+                style={{
+                  border: active ? `2px solid ${GOLD}` : "1px solid rgba(255,255,255,.09)",
+                  background: active ? "rgba(245,166,35,.09)" : "rgba(255,255,255,.035)",
+                }}
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm font-bold">{optLabel(years)}</div>
+                  <div className="mt-0.5 text-[11.5px] font-semibold" style={{ color: muted }}>
+                    {years === 0 ? t("lock.noneNote") : t("lock.mult", { mult: m.toFixed(2) })}
+                  </div>
+                </div>
+                <div className="flex-none text-right">
+                  <div className="text-[17px] font-black" style={{ color: GREEN }}>~{(rate * m).toFixed(0)}%</div>
+                  <div className="text-[10px] font-bold uppercase tracking-wider" style={{ color: muted }}>APR</div>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+        <div className="mt-3 flex items-start gap-2 text-[11.5px] font-semibold" style={{ color: "#b8741a" }}>
+          <span className="flex-none">⚠</span><span>{t("lock.oneway")}</span>
+        </div>
+      </div>
+
+      {/* Summary + actions */}
+      <div className="flex min-h-[240px] flex-col gap-3 rounded-[18px] border border-white/[0.07] p-[18px]" style={{ background: "rgba(255,255,255,.035)" }}>
+        <div className="text-[11px] font-bold uppercase tracking-[0.22em]" style={{ color: muted }}>{t("lock.summaryTitle")}</div>
+        <p className="text-[13px] leading-relaxed" style={{ color: "#c9c6c2" }}>
+          {lockYears === 0
+            ? t("lock.summaryNone")
+            : t("lock.summaryLocked", { label: optLabel(lockYears), mult: multiplierForYears(lockYears, nowSec).toFixed(2) })}
+        </p>
+        <p className="text-[12px] leading-relaxed" style={{ color: muted }}>{t("lock.stethNote")}</p>
+        <div className="mt-auto flex flex-col gap-2">
+          <button
+            type="button"
+            onClick={onStake}
+            disabled={busy}
+            className="cursor-pointer rounded-[13px] px-5 py-3.5 text-center text-[14.5px] font-extrabold disabled:opacity-70"
+            style={{ color: "#1a1205", background: "linear-gradient(90deg,#f7c948,#f5851f)", boxShadow: "0 8px 24px rgba(245,133,31,.28)" }}
+          >
+            {stakeLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onBack}
+            disabled={busy}
+            className="cursor-pointer rounded-[13px] border border-white/15 px-5 py-2.5 text-center text-[13px] font-bold disabled:opacity-60"
+            style={{ color: "#c9c6c2" }}
+          >
+            {t("lock.back")}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/hooks/use-morpheus-stake.ts
+++ b/src/hooks/use-morpheus-stake.ts
@@ -101,9 +101,12 @@ export function useMorpheusStake() {
   const [error, setError] = useState<string | null>(null);
   const pending = useRef(false);
 
-  /** Stake `amount` of the asset, crediting the athlete as referrer. */
+  /** Stake `amount` of the asset, crediting the athlete as referrer. `claimLockEnd`
+   * (unix seconds, 0 = none) is the optional power-factor lock: it defers when the
+   * MOR can be CLAIMED, boosting the reward multiplier — it does NOT lock the
+   * deposit (that follows the 7-day withdraw rule). */
   const stake = useCallback(
-    async (asset: MorpheusAsset, amount: string, athlete: Address): Promise<boolean> => {
+    async (asset: MorpheusAsset, amount: string, athlete: Address, claimLockEnd = 0): Promise<boolean> => {
       if (pending.current) return false;
       const client = getThirdwebClient();
       if (!client) { setError("Thirdweb not configured."); setPhase("error"); return false; }
@@ -143,10 +146,11 @@ export function useMorpheusStake() {
         }
 
         setPhase("stake");
-        // claimLockEnd = 0 → no extra lock beyond the protocol's 7-day default.
+        // claimLockEnd > 0 → defer MOR claims until then for a bigger reward
+        // multiplier (power factor); 0 keeps only the protocol's 7-day default.
         const stakeData = encodeFunctionData({
           abi: depositPoolAbi, functionName: "stake",
-          args: [MOR_REWARD_POOL_INDEX, assets, BigInt(0), athlete],
+          args: [MOR_REWARD_POOL_INDEX, assets, BigInt(Math.max(0, Math.floor(claimLockEnd))), athlete],
         });
         const sendStake = async () => {
           const tx = prepareTransaction({ client, chain: ethereum, to: pool, data: stakeData });

--- a/src/lib/lock-multiplier.ts
+++ b/src/lib/lock-multiplier.ts
@@ -1,0 +1,55 @@
+// Morpheus power-factor lock multiplier — a faithful float replica of the
+// on-chain LockMultiplierMath.getLockPeriodMultiplier (contracts/libs). The
+// curve is tanh-based, capped at 10.7×, and anchored to ABSOLUTE dates (the MOR
+// distribution window, ending Jan 2040) — so the same lock *duration* is worth
+// slightly less the later you lock.
+//
+// What locking actually does (verified against DepositPool.sol): it commits you
+// to not CLAIMING your accrued MOR until the end date, in exchange for a bigger
+// share of emissions. It does NOT lock your deposit — the stETH/USDC principal
+// follows the protocol's 7-day withdraw rule regardless. The lock is one-way:
+// _stake requires the new claimLockEnd ≥ the current one (extend only).
+
+const POWER_MAX = 16.61327546;
+const MAX_MULT = 10.7;
+const MIN_MULT = 1;
+const PERIOD_START = 1721908800; // Thu, 25 Jul 2024 12:00:00 UTC
+const PERIOD_END = 2211192000; // Thu, 26 Jan 2040 12:00:00 UTC
+const DISTRIBUTION = PERIOD_END - PERIOD_START;
+const YEAR = 365.25 * 86400;
+
+/** Reward multiplier for a claim lock spanning [startSec, endSec] (both unix seconds). */
+export function lockMultiplier(startSec: number, endSec: number): number {
+  const end = Math.min(endSec, PERIOD_END);
+  const start = Math.max(startSec, PERIOD_START);
+  if (start >= end) return 1;
+  const endP = Math.tanh(2 * ((end - PERIOD_START) / DISTRIBUTION));
+  const startP = Math.tanh(2 * ((start - PERIOD_START) / DISTRIBUTION));
+  const m = POWER_MAX * (endP - startP);
+  return Math.min(Math.max(m, MIN_MULT), MAX_MULT);
+}
+
+/** The `claimLockEnd` timestamp (unix seconds) for locking `years` from `nowSec`; 0 = no lock. */
+export function claimLockEndFor(years: number, nowSec: number = Math.floor(Date.now() / 1000)): number {
+  return years <= 0 ? 0 : Math.round(nowSec + years * YEAR);
+}
+
+/** The multiplier you'd get by locking `years` from `nowSec` (1 = no boost). */
+export function multiplierForYears(years: number, nowSec: number = Math.floor(Date.now() / 1000)): number {
+  if (years <= 0) return 1;
+  return lockMultiplier(nowSec, nowSec + years * YEAR);
+}
+
+export interface LockOption {
+  /** Lock length in years; 0 = no lock. */
+  years: number;
+}
+// Sub-1-year locks barely move the tanh curve (still ~1×), so we skip them: the
+// meaningful choices start at 1 year. Kept short so first-timers aren't drowned.
+export const LOCK_OPTIONS: LockOption[] = [
+  { years: 0 },
+  { years: 1 },
+  { years: 2 },
+  { years: 3 },
+  { years: 5 },
+];


### PR DESCRIPTION
## O que
Adiciona um **2º passo opcional** no fluxo de stake da Morpheus pra escolher o **lock do claim** (power factor) — a peça que faltava pra mostrar o APR **real** em vez do número de vitrine solto. A 1ª tela continua enxuta (a pedido: não sobrecarregar quem chega agora); o lock só aparece num step separado, e o vault segue em 1 passo.

## Multiplicador é exato, não chutado
`src/lib/lock-multiplier.ts` é uma réplica fiel em TS do `LockMultiplierMath.getLockPeriodMultiplier` **on-chain** (curva tanh, teto 10.7×, ancorada nas datas de distribuição do MOR até jan/2040). Ele **escala a mesma estimativa de APR já exibida** no step 1 — então o boost **relativo** de cada lock é honesto, mesmo a base sendo uma estimativa (`estimate:true`).

Valores reais hoje: sem lock ~1×, 1 ano **1.93×**, 2 anos **3.69×**, 3 anos **5.24×**, 5 anos **7.73×** (a "vitrine 16.78%" ≈ 1 ano de lock).

## Deixa claro o que trava
Verificado no `DepositPool.sol` (`_withdraw` só checa o lock de 7 dias; `_claim` checa `claimLockEnd`): **o lock trava só QUANDO o MOR pode ser sacado — o stETH nunca fica preso.** O step escreve isso com todas as letras, e avisa que o lock é **via única** (`_stake` exige `claimLockEnd_ >= atual`).

## Mudanças
- `lib/lock-multiplier.ts` (novo): fórmula + opções (0/1/2/3/5 anos) + helpers.
- `use-morpheus-stake`: `stake()` aceita `claimLockEnd` e passa no `args` (antes `0` fixo).
- `StakeDialog`: estado `step`/`lockYears`, botão "Próximo: lock →" (só MOR), componente `LockStep` (opções com multiplicador + APR projetado, resumo, back/stake). `nowSec` via lazy init (sem `Date.now()` em render).
- i18n en + pt-br (`lock.*`).

## Verificação
`tsc --noEmit` ✓ · `eslint` ✓ · `next build` ✓ · JSON válido (en+pt-br).

🤖 Generated with [Claude Code](https://claude.com/claude-code)