### PR TITLE
feat(stake): stake MOR directly into the Gnars Builder subnet (Base)

### DIFF
--- a/src/app/[locale]/stake/page.tsx
+++ b/src/app/[locale]/stake/page.tsx
@@ -5,6 +5,7 @@ import { StakeAdminPanel } from "@/components/stake/StakeAdminPanel";
 import { StakeOrbit } from "@/components/stake/StakeOrbit";
 import { MorLootbox } from "@/components/stake/MorLootbox";
 import { MorpheusStakeWidget } from "@/components/stake/MorpheusStakeWidget";
+import { GnarsSubnetPanel } from "@/components/stake/GnarsSubnetPanel";
 import { STAKE_MINIAPP_EMBED_CONFIG } from "@/lib/miniapp-config";
 
 export async function generateMetadata({
@@ -67,6 +68,7 @@ export default async function StakePage({ params }: { params: Promise<{ locale: 
           <CharacterSelector />
         </div>
         <StakeOrbit />
+        <GnarsSubnetPanel />
         <StakeAdminPanel />
       </div>
       <MorLootbox />

--- a/src/components/stake/GnarsSubnetPanel.tsx
+++ b/src/components/stake/GnarsSubnetPanel.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+// Back Gnars on Morpheus: lock MOR into the Gnars Builder subnet (Base). The
+// campaign's actual "stake on the Gnars subnet" flow. Principal stays yours,
+// withdrawable after a 7-day lock; the subnet accrues MOR emissions for the
+// builder. Kept violet ("Morpheus"), distinct from the rider Capital flow.
+
+import Image from "next/image";
+import { useState } from "react";
+import { useActiveAccount } from "thirdweb/react";
+import { toast } from "sonner";
+import { AlertTriangle, Lock } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { SUBNET_MIN_DEPOSIT_MOR } from "@/lib/morpheus-builder";
+import { useGnarsSubnet } from "@/hooks/use-gnars-subnet";
+import { useGnarsSubnetStake } from "@/hooks/use-gnars-subnet-stake";
+
+const fmt = (n: number, d = 4) => n.toLocaleString("en-US", { maximumFractionDigits: d });
+
+export function GnarsSubnetPanel() {
+  const you = useActiveAccount()?.address;
+  const { stake, withdraw, phase, error, isBusy } = useGnarsSubnetStake();
+  const [nonce, setNonce] = useState(0);
+  const { position, totalStaked } = useGnarsSubnet(you, nonce);
+  const [amount, setAmount] = useState("");
+
+  const nowSec = Math.floor(Date.now() / 1000);
+  const locked = !!position && position.unlockAt > nowSec;
+  const daysLeft = position ? Math.max(0, Math.ceil((position.unlockAt - nowSec) / 86400)) : 0;
+
+  const onStake = async () => {
+    if (!amount || Number(amount) <= 0) return;
+    const ok = await stake(amount);
+    if (ok) { toast.success("Staked on the Gnars subnet", { description: `${amount} MOR backing Gnars on Morpheus.` }); setAmount(""); setNonce((n) => n + 1); }
+    else toast.error("Stake failed", { description: error ?? undefined });
+  };
+
+  const onWithdraw = async () => {
+    if (!position || position.staked <= 0) return;
+    const ok = await withdraw(String(position.staked));
+    if (ok) { toast.success("Withdrawn"); setNonce((n) => n + 1); }
+    else toast.error("Withdraw failed", { description: error ?? undefined });
+  };
+
+  const phaseLabel =
+    phase === "approve" ? "approving MOR…"
+    : phase === "stake" ? "staking on Base…"
+    : "Stake MOR";
+
+  return (
+    <div id="gnars-subnet-stake" className="scroll-mt-24 rounded-2xl border border-violet-500/30 bg-violet-500/[0.03] p-5">
+      <div className="mb-3 flex flex-wrap items-center gap-2">
+        <Image src="/logos/morpheus.webp" alt="Morpheus" width={22} height={22} className="rounded" />
+        <h2 className="text-lg font-black tracking-tight">Back Gnars on the Morpheus subnet</h2>
+        <span className="rounded-full border border-violet-500/50 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-violet-400">MOR · Base</span>
+      </div>
+      <p className="mb-4 text-sm text-muted-foreground">
+        Lock <b>MOR</b> into the Gnars Builder subnet to back the builder. Your principal stays yours
+        (withdrawable after a 7-day lock); the subnet accrues MOR emissions for Gnars. Self-custody on Base.
+      </p>
+
+      <div className="mb-4 grid grid-cols-2 gap-3">
+        <div className="rounded-xl border border-border/60 bg-background/40 p-3">
+          <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">Total staked</div>
+          <div className="text-lg font-black tabular-nums">{fmt(totalStaked, 0)} <span className="text-xs font-medium text-muted-foreground">MOR</span></div>
+        </div>
+        <div className="rounded-xl border border-border/60 bg-background/40 p-3">
+          <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">Your stake</div>
+          <div className="text-lg font-black tabular-nums">{fmt(position?.staked ?? 0, 4)} <span className="text-xs font-medium text-muted-foreground">MOR</span></div>
+        </div>
+      </div>
+
+      <div className="flex gap-2">
+        <Input
+          type="number"
+          inputMode="decimal"
+          placeholder={`min ${SUBNET_MIN_DEPOSIT_MOR} MOR${position ? ` · you have ${fmt(position.walletMor, 4)}` : ""}`}
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+        />
+        <Button onClick={onStake} disabled={isBusy || !you} className="shrink-0 bg-violet-500 text-white hover:bg-violet-600">
+          {phaseLabel}
+        </Button>
+      </div>
+
+      <p className="mt-3 flex items-start gap-1.5 text-xs text-muted-foreground">
+        <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-violet-400" />
+        You back the builder — rewards accrue to the subnet, not to individual stakers. Every action is a Base tx.
+      </p>
+
+      {position && position.staked > 0 && (
+        <div className="mt-4 flex items-center justify-between gap-3 border-t border-border/40 pt-3">
+          <div className="text-sm">
+            <span className="font-mono">{fmt(position.staked, 4)} MOR</span>{" "}
+            <span className="text-xs text-muted-foreground">
+              {locked ? <><Lock className="mb-0.5 inline h-3 w-3" /> unlocks in {daysLeft}d</> : "unlocked"}
+            </span>
+          </div>
+          <Button size="sm" variant="outline" disabled={isBusy || locked} onClick={onWithdraw}>
+            Withdraw
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/stake/GnarsSubnetPanel.tsx
+++ b/src/components/stake/GnarsSubnetPanel.tsx
@@ -25,7 +25,9 @@ export function GnarsSubnetPanel() {
   const { position, totalStaked } = useGnarsSubnet(you, nonce);
   const [amount, setAmount] = useState("");
 
-  const nowSec = Math.floor(Date.now() / 1000);
+  // Read the clock once at mount (lazy initializer is pure-in-render safe); the
+  // 7-day unlock doesn't need a live tick — a refresh/refetch re-reads it.
+  const [nowSec] = useState(() => Math.floor(Date.now() / 1000));
   const locked = !!position && position.unlockAt > nowSec;
   const daysLeft = position ? Math.max(0, Math.ceil((position.unlockAt - nowSec) / 86400)) : 0;
 

--- a/src/components/stake/MorpheusStakeWidget.tsx
+++ b/src/components/stake/MorpheusStakeWidget.tsx
@@ -28,7 +28,8 @@ export function MorpheusStakeWidget() {
   const [view, setView] = useState<View>("closed");
 
   const goStake = () => {
-    document.getElementById("stake-start")?.scrollIntoView({ behavior: "smooth", block: "start" });
+    // Jump to the real Gnars subnet stake panel (MOR → the Builder subnet).
+    document.getElementById("gnars-subnet-stake")?.scrollIntoView({ behavior: "smooth", block: "start" });
     setView("closed");
   };
 

--- a/src/hooks/use-gnars-subnet-stake.ts
+++ b/src/hooks/use-gnars-subnet-stake.ts
@@ -1,0 +1,123 @@
+"use client";
+
+// Stake / withdraw MOR on the Gnars Builder subnet (Base). deposit() locks MOR
+// into the subnet (7-day withdraw lock); withdraw() pulls principal back after
+// the lock. Rewards accrue at the subnet level (builder-claimed), so there's no
+// per-staker claim here. Mirrors use-morpheus-stake.ts but on Base.
+
+import { useCallback, useRef, useState } from "react";
+import { prepareTransaction, sendTransaction, waitForReceipt } from "thirdweb";
+import { base as thirdwebBase } from "thirdweb/chains";
+import { createPublicClient, http, fallback, encodeFunctionData, parseUnits, type Address } from "viem";
+import { base } from "viem/chains";
+import { useWriteAccount } from "@/hooks/use-write-account";
+import { ensureOnChain } from "@/lib/thirdweb-tx";
+import { getThirdwebClient } from "@/lib/thirdweb";
+import {
+  BUILDERS, GNARS_SUBNET_ID, MOR_BASE, MOR_DECIMALS, BASE_RPCS, buildersAbi, erc20AbiMin,
+} from "@/lib/morpheus-builder";
+
+const rpc = createPublicClient({ chain: base, transport: fallback(BASE_RPCS.map((u) => http(u))) });
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function waitForAllowance(owner: Address, needed: bigint, tries = 12): Promise<void> {
+  for (let i = 0; i < tries; i++) {
+    try {
+      const a = await rpc.readContract({ address: MOR_BASE, abi: erc20AbiMin, functionName: "allowance", args: [owner, BUILDERS] });
+      if (a >= needed) return;
+    } catch { /* keep polling */ }
+    await sleep(1500);
+  }
+}
+
+export type SubnetPhase = "idle" | "approve" | "stake" | "withdraw" | "done" | "error";
+
+export function useGnarsSubnetStake() {
+  const writer = useWriteAccount();
+  const [phase, setPhase] = useState<SubnetPhase>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const pending = useRef(false);
+
+  /** Lock `amount` MOR into the Gnars subnet (approve first if needed). */
+  const stake = useCallback(
+    async (amount: string): Promise<boolean> => {
+      if (pending.current) return false;
+      const client = getThirdwebClient();
+      if (!client) { setError("Thirdweb not configured."); setPhase("error"); return false; }
+      if (!writer) { setError("Connect your wallet."); setPhase("error"); return false; }
+
+      let amt: bigint;
+      try { amt = parseUnits(amount, MOR_DECIMALS); } catch { setError("Invalid amount."); setPhase("error"); return false; }
+      if (amt <= BigInt(0)) { setError("Invalid amount."); setPhase("error"); return false; }
+
+      const account = writer.account;
+      setError(null);
+      pending.current = true;
+      try {
+        await ensureOnChain(writer.wallet, thirdwebBase);
+
+        const allowance = await rpc.readContract({ address: MOR_BASE, abi: erc20AbiMin, functionName: "allowance", args: [account.address as Address, BUILDERS] });
+        if (allowance < amt) {
+          setPhase("approve");
+          const approveData = encodeFunctionData({ abi: erc20AbiMin, functionName: "approve", args: [BUILDERS, amt] });
+          const approveTx = prepareTransaction({ client, chain: thirdwebBase, to: MOR_BASE, data: approveData });
+          const hash = (await sendTransaction({ account, transaction: approveTx })).transactionHash;
+          await waitForReceipt({ client, chain: thirdwebBase, transactionHash: hash });
+          await waitForAllowance(account.address as Address, amt);
+        }
+
+        setPhase("stake");
+        const depositData = encodeFunctionData({ abi: buildersAbi, functionName: "deposit", args: [GNARS_SUBNET_ID, amt] });
+        const tx = prepareTransaction({ client, chain: thirdwebBase, to: BUILDERS, data: depositData });
+        const stakeHash = (await sendTransaction({ account, transaction: tx })).transactionHash;
+        await waitForReceipt({ client, chain: thirdwebBase, transactionHash: stakeHash });
+
+        setPhase("done");
+        return true;
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Stake failed.");
+        setPhase("error");
+        return false;
+      } finally {
+        pending.current = false;
+      }
+    },
+    [writer],
+  );
+
+  /** Withdraw `amount` MOR principal (reverts before the 7-day lock lifts). */
+  const withdraw = useCallback(
+    async (amount: string): Promise<boolean> => {
+      if (pending.current) return false;
+      const client = getThirdwebClient();
+      if (!client) { setError("Thirdweb not configured."); setPhase("error"); return false; }
+      if (!writer) { setError("Connect your wallet."); setPhase("error"); return false; }
+
+      let amt: bigint;
+      try { amt = parseUnits(amount, MOR_DECIMALS); } catch { setError("Invalid amount."); setPhase("error"); return false; }
+
+      const account = writer.account;
+      setError(null);
+      pending.current = true;
+      try {
+        await ensureOnChain(writer.wallet, thirdwebBase);
+        setPhase("withdraw");
+        const data = encodeFunctionData({ abi: buildersAbi, functionName: "withdraw", args: [GNARS_SUBNET_ID, amt] });
+        const tx = prepareTransaction({ client, chain: thirdwebBase, to: BUILDERS, data });
+        const hash = (await sendTransaction({ account, transaction: tx })).transactionHash;
+        await waitForReceipt({ client, chain: thirdwebBase, transactionHash: hash });
+        setPhase("done");
+        return true;
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Withdrawal failed.");
+        setPhase("error");
+        return false;
+      } finally {
+        pending.current = false;
+      }
+    },
+    [writer],
+  );
+
+  return { stake, withdraw, phase, error, isBusy: phase === "approve" || phase === "stake" || phase === "withdraw" };
+}

--- a/src/hooks/use-gnars-subnet.ts
+++ b/src/hooks/use-gnars-subnet.ts
@@ -1,0 +1,60 @@
+"use client";
+
+// Read-only view of the Gnars Builder subnet on Base: the wallet's staked MOR +
+// unlock time + spendable MOR balance, and the subnet's total staked. Nothing
+// here moves money.
+
+import { useEffect, useState } from "react";
+import { createPublicClient, http, fallback, formatUnits, type Address } from "viem";
+import { base } from "viem/chains";
+import {
+  BUILDERS, GNARS_SUBNET_ID, MOR_BASE, MOR_DECIMALS, SUBNET_WITHDRAW_LOCK_SECONDS,
+  BASE_RPCS, buildersAbi, erc20AbiMin, type GnarsSubnetPosition,
+} from "@/lib/morpheus-builder";
+
+const client = createPublicClient({ chain: base, transport: fallback(BASE_RPCS.map((u) => http(u))) });
+
+export type GnarsSubnetState = {
+  position: GnarsSubnetPosition | null;
+  /** Total MOR staked across all backers of the subnet. */
+  totalStaked: number;
+};
+
+export function useGnarsSubnet(wallet?: string, nonce = 0): GnarsSubnetState {
+  const [state, setState] = useState<GnarsSubnetState>({ position: null, totalStaked: 0 });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const subnetData = await client.readContract({
+          address: BUILDERS, abi: buildersAbi, functionName: "subnetsData", args: [GNARS_SUBNET_ID],
+        });
+        const totalStaked = Number(formatUnits(subnetData[1], MOR_DECIMALS));
+        if (!cancelled) setState((s) => ({ ...s, totalStaked }));
+
+        if (!wallet) { if (!cancelled) setState((s) => ({ ...s, position: null })); return; }
+
+        const [user, bal] = await Promise.all([
+          client.readContract({ address: BUILDERS, abi: buildersAbi, functionName: "usersData", args: [wallet as Address, GNARS_SUBNET_ID] }),
+          client.readContract({ address: MOR_BASE, abi: erc20AbiMin, functionName: "balanceOf", args: [wallet as Address] }),
+        ]);
+        const lastDeposit = Number(user[0]);
+        const deposited = user[2];
+        const position: GnarsSubnetPosition = {
+          staked: Number(formatUnits(deposited, MOR_DECIMALS)),
+          unlockAt: deposited > BigInt(0) ? lastDeposit + SUBNET_WITHDRAW_LOCK_SECONDS : 0,
+          walletMor: Number(formatUnits(bal, MOR_DECIMALS)),
+        };
+        if (!cancelled) setState((s) => ({ ...s, position }));
+      } catch {
+        if (!cancelled) setState((s) => ({ ...s, position: null }));
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [wallet, nonce]);
+
+  return state;
+}

--- a/src/lib/morpheus-builder.ts
+++ b/src/lib/morpheus-builder.ts
@@ -1,0 +1,71 @@
+// Morpheus Builders subnet staking — the "back Gnars on Morpheus" flow.
+//
+// Distinct from the Capital pools in `morpheus.ts` (stake stETH/USDC on mainnet
+// to earn MOR). Here a supporter LOCKS **MOR** directly into the Gnars Builder
+// subnet on **Base**. The subnet accrues MOR emissions for the builder; the
+// staker's principal is theirs, withdrawable after a 7-day lock. All values
+// below were read on-chain from BuildersV4 before hardcoding.
+
+import { getAddress, type Address } from "viem";
+
+/** BuildersV4 (ERC1967 proxy) on Base. */
+export const BUILDERS = getAddress("0x42BB446eAE6dca7723a9eBdb81EA88aFe77eF4B9");
+
+/** The Gnars Builder subnet id (bytes32, NOT an address). */
+export const GNARS_SUBNET_ID = "0xf129111951997d1c386be9b7de27d4c74490c42ad0ffbcb65e380d17f8a8ea3d" as const;
+
+/** MOR on Base — the deposit token (verified = depositToken()). */
+export const MOR_BASE = getAddress("0x7431aDa8a591C955a994a21710752EF9b882b8e3");
+export const MOR_DECIMALS = 18;
+
+/** subnets(id).withdrawLockPeriodAfterDeposit — 7 days (read on-chain). */
+export const SUBNET_WITHDRAW_LOCK_SECONDS = 604800;
+/** subnets(id).minimalDeposit — 0.001 MOR (read on-chain). */
+export const SUBNET_MIN_DEPOSIT_MOR = "0.001";
+
+// Only the members this UI needs. Types verified against the on-chain ABI.
+export const buildersAbi = [
+  { type: "function", name: "deposit", stateMutability: "nonpayable", inputs: [
+    { name: "subnetId_", type: "bytes32" }, { name: "amount_", type: "uint256" },
+  ], outputs: [] },
+  { type: "function", name: "withdraw", stateMutability: "nonpayable", inputs: [
+    { name: "subnetId_", type: "bytes32" }, { name: "amount_", type: "uint256" },
+  ], outputs: [] },
+  { type: "function", name: "usersData", stateMutability: "view", inputs: [
+    { name: "user", type: "address" }, { name: "subnetId", type: "bytes32" },
+  ], outputs: [
+    { name: "lastDeposit", type: "uint128" }, { name: "_1", type: "uint128" },
+    { name: "deposited", type: "uint256" }, { name: "_2", type: "uint256" },
+  ] },
+  { type: "function", name: "subnetsData", stateMutability: "view", inputs: [{ name: "subnetId", type: "bytes32" }], outputs: [
+    { name: "_0", type: "uint128" }, { name: "deposited", type: "uint256" },
+    { name: "_2", type: "uint256" }, { name: "rate", type: "uint256" }, { name: "pendingRewards", type: "uint256" },
+  ] },
+  { type: "function", name: "getCurrentSubnetRewards", stateMutability: "view", inputs: [{ name: "subnetId", type: "bytes32" }], outputs: [{ type: "uint256" }] },
+] as const;
+
+export const erc20AbiMin = [
+  { type: "function", name: "allowance", stateMutability: "view", inputs: [{ name: "owner", type: "address" }, { name: "spender", type: "address" }], outputs: [{ type: "uint256" }] },
+  { type: "function", name: "approve", stateMutability: "nonpayable", inputs: [{ name: "spender", type: "address" }, { name: "amount", type: "uint256" }], outputs: [{ type: "bool" }] },
+  { type: "function", name: "balanceOf", stateMutability: "view", inputs: [{ name: "owner", type: "address" }], outputs: [{ type: "uint256" }] },
+] as const;
+
+/** Public Base RPCs, healthy-first (mainnet.base.org rate-limits under bursts). */
+export const BASE_RPCS: readonly string[] = [
+  "https://base-rpc.publicnode.com",
+  "https://base.drpc.org",
+  "https://mainnet.base.org",
+];
+
+export type GnarsSubnetPosition = {
+  /** Staked MOR principal. */
+  staked: number;
+  /** Unix seconds when withdraw unlocks (0 if nothing staked). */
+  unlockAt: number;
+  /** MOR balance in the wallet, available to stake. */
+  walletMor: number;
+};
+
+export const GNARS_SUBNET = { id: GNARS_SUBNET_ID, admin: getAddress("0x8Bf5941d27176242745B716251943Ae4892a3C26") } as const;
+
+export type { Address };


### PR DESCRIPTION
The real **"stake on the Gnars subnet"** flow (campaign + floating widget). Lock **MOR** into the Gnars Builder subnet on **Base** via `BuildersV4.deposit(subnetId, amount)`; principal stays yours, withdrawable after the **7-day** lock; the subnet accrues MOR emissions for the builder (no per-staker claim — consistent with the "back the builder, no guaranteed yield" framing).

- New: `src/lib/morpheus-builder.ts` (verified addresses/ABI), `use-gnars-subnet` (read), `use-gnars-subnet-stake` (approve + deposit + withdraw), `GnarsSubnetPanel`.
- Widget "Stake now" now scrolls to this panel.
- On-chain params verified live: MOR `0x7431…`, subnet id `0xf129…`, lock 7d, min 0.001 MOR, ~7.3k MOR already staked.

⚠️ **Preview-only — do not merge until tested with a small real MOR stake on the preview** (I can't run the app locally; CI verifies the build, not the on-chain flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)