### PR TITLE
fix(home): gate "Powered by Morpheus" strip behind the 100k MOR subnet goal

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -96,8 +96,10 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
         </div>
       </section>
 
-      {/* Community × community — Gnars is a Morpheus Builder */}
-      <PoweredByMorpheus />
+      {/* Community × community — Gnars is a Morpheus Builder (gated on the subnet goal) */}
+      <Suspense fallback={null}>
+        <PoweredByMorpheus />
+      </Suspense>
 
       {/* Dashboard Grid */}
       <div className="flex flex-1 flex-col gap-6 py-8">

--- a/src/components/home/PoweredByMorpheus.tsx
+++ b/src/components/home/PoweredByMorpheus.tsx
@@ -1,10 +1,24 @@
 import Image from "next/image";
 import { Link } from "@/i18n/navigation";
+import { getGnarsSubnetTotalStaked } from "@/lib/morpheus-builder";
+import { SUBNET_GOAL_MOR } from "@/lib/stake-milestones";
 
 // "Powered by Morpheus" homepage strip — signals the Gnars × Morpheus
 // community-to-community partnership, with the colored Morpheus mark, and links
 // to the subnet staking flow. Morpheus green (#2be58b / emerald) accents.
-export function PoweredByMorpheus() {
+//
+// Gated: only surfaces once the subnet actually clears its goal (SUBNET_GOAL_MOR).
+// Before that it's a spoiler, so we render nothing. Fails closed — if the
+// on-chain read errors we hide it rather than reveal it prematurely.
+export async function PoweredByMorpheus() {
+  let totalStaked = 0;
+  try {
+    totalStaked = await getGnarsSubnetTotalStaked();
+  } catch {
+    return null;
+  }
+  if (totalStaked < SUBNET_GOAL_MOR) return null;
+
   return (
     <section className="mx-auto w-full max-w-6xl px-4">
       <Link

--- a/src/lib/morpheus-builder.ts
+++ b/src/lib/morpheus-builder.ts
@@ -6,7 +6,8 @@
 // staker's principal is theirs, withdrawable after a 7-day lock. All values
 // below were read on-chain from BuildersV4 before hardcoding.
 
-import { getAddress, type Address } from "viem";
+import { createPublicClient, fallback, formatUnits, getAddress, http, type Address } from "viem";
+import { base } from "viem/chains";
 
 /** BuildersV4 (ERC1967 proxy) on Base. */
 export const BUILDERS = getAddress("0x42BB446eAE6dca7723a9eBdb81EA88aFe77eF4B9");
@@ -67,5 +68,21 @@ export type GnarsSubnetPosition = {
 };
 
 export const GNARS_SUBNET = { id: GNARS_SUBNET_ID, admin: getAddress("0x8Bf5941d27176242745B716251943Ae4892a3C26") } as const;
+
+/**
+ * Total MOR staked into the Gnars subnet, read on-chain (server-safe).
+ * Mirrors the `useGnarsSubnet` hook: `subnetsData(id).deposited`, 18 decimals.
+ * Used to gate the homepage "Powered by Morpheus" reveal behind the goal.
+ */
+export async function getGnarsSubnetTotalStaked(): Promise<number> {
+  const client = createPublicClient({ chain: base, transport: fallback(BASE_RPCS.map((u) => http(u))) });
+  const data = await client.readContract({
+    address: BUILDERS,
+    abi: buildersAbi,
+    functionName: "subnetsData",
+    args: [GNARS_SUBNET_ID],
+  });
+  return Number(formatUnits(data[1], MOR_DECIMALS));
+}
 
 export type { Address };


### PR DESCRIPTION
## Problem
The homepage **"Powered by Morpheus · community × community · Back Gnars →"** strip was rendering immediately. It's meant to be the reveal for when the Gnars Builder subnet clears its goal (`SUBNET_GOAL_MOR = 100_000`). Showing it now spoils that moment — the subnet is at **~7,329 MOR** today.

## Fix
- `PoweredByMorpheus` is now an **async server component** that reads the live subnet stake on-chain and renders `null` under the goal.
- Added `getGnarsSubnetTotalStaked()` to `lib/morpheus-builder.ts` — mirrors the `useGnarsSubnet` hook exactly (`subnetsData(id).deposited`, 18 decimals, `fallback(BASE_RPCS)`).
- **Fail-closed:** if the on-chain read errors, the strip is hidden (never revealed prematurely).
- Wrapped in `<Suspense fallback={null}>` in `page.tsx` so the read never blocks the home shell (page is ISR, `revalidate = 300`, so it re-checks ~every 5 min and appears automatically once the subnet hits 100k).

## Verification
- `npx tsc --noEmit` → clean
- `npx eslint` on changed files → clean
- On-chain read confirmed: `subnetsData().deposited = 7,329.2 MOR` → `< 100k` → strip hidden ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)