### PR TITLE
feat(stake): "Your positions" panel below the orbit

### DIFF
--- a/messages/en/stake.json
+++ b/messages/en/stake.json
@@ -192,5 +192,20 @@
     "deployedToast": "{id} vault deployed",
     "deployedToastDesc": "Approve the batch in the SOPA Safe to activate.",
     "deployFail": "{id} deploy failed"
+  },
+  "positions": {
+    "title": "Your positions",
+    "subtitle": "Your Morpheus Capital stakes — deposit, MOR earned, and when each lock lifts.",
+    "connect": "Connect your wallet to see your positions.",
+    "loading": "Reading your positions…",
+    "none": "No Morpheus stake yet. Back a rider above to start earning MOR.",
+    "earned": "MOR earned",
+    "morLock": "MOR unlock",
+    "principalLock": "Deposit unlock",
+    "claimable": "claimable now",
+    "lockedUntil": "locked until {date}",
+    "unlocked": "unlocked",
+    "claimHint": "To claim, open the reward box (bottom-right) once the MOR unlock date has passed — it bridges your MOR to Arbitrum and splits it to your wallet.",
+    "powerLockNote": "A far-off MOR unlock means a longer power-lock was chosen at deposit (higher APR / power factor) — the MOR stays locked until that date."
   }
 }

--- a/messages/pt-br/stake.json
+++ b/messages/pt-br/stake.json
@@ -192,5 +192,20 @@
     "deployedToast": "Vault de {id} deployado",
     "deployedToastDesc": "Aprove o batch no Safe da SOPA pra ativar.",
     "deployFail": "Falha no deploy de {id}"
+  },
+  "positions": {
+    "title": "Suas posições",
+    "subtitle": "Seus stakes na Morpheus Capital — depósito, MOR rendido e quando cada lock abre.",
+    "connect": "Conecte a carteira pra ver suas posições.",
+    "loading": "Lendo suas posições…",
+    "none": "Nenhum stake na Morpheus ainda. Apoie um rider acima pra começar a render MOR.",
+    "earned": "MOR rendido",
+    "morLock": "Unlock do MOR",
+    "principalLock": "Unlock do depósito",
+    "claimable": "dá pra sacar",
+    "lockedUntil": "travado até {date}",
+    "unlocked": "liberado",
+    "claimHint": "Pra sacar, abra a caixa de recompensa (canto inferior direito) depois que a data de unlock do MOR passar — ela leva o MOR pra Arbitrum e divide na sua carteira.",
+    "powerLockNote": "Um unlock do MOR distante significa que um power-lock maior foi escolhido no depósito (APR / power factor mais alto) — o MOR fica travado até essa data."
   }
 }

--- a/src/app/[locale]/stake/page.tsx
+++ b/src/app/[locale]/stake/page.tsx
@@ -3,6 +3,7 @@ import { getTranslations, setRequestLocale } from "next-intl/server";
 import { CharacterSelector } from "@/components/stake/CharacterSelector";
 import { StakeAdminPanel } from "@/components/stake/StakeAdminPanel";
 import { StakeOrbit } from "@/components/stake/StakeOrbit";
+import { StakePositions } from "@/components/stake/StakePositions";
 import { MorLootbox } from "@/components/stake/MorLootbox";
 import { MorpheusStakeWidget } from "@/components/stake/MorpheusStakeWidget";
 import { STAKE_MINIAPP_EMBED_CONFIG } from "@/lib/miniapp-config";
@@ -67,6 +68,7 @@ export default async function StakePage({ params }: { params: Promise<{ locale: 
           <CharacterSelector />
         </div>
         <StakeOrbit />
+        <StakePositions />
         <StakeAdminPanel />
       </div>
       <MorLootbox />

--- a/src/components/stake/StakePositions.tsx
+++ b/src/components/stake/StakePositions.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+// "Your positions" panel on /stake — reads the connected wallet's Morpheus
+// Capital stakes (stETH + USDC) and shows, per asset: deposit, MOR earned, when
+// the MOR claim-lock lifts (the power lock chosen at deposit) and when the 7-day
+// principal lock lifts. Read-only; the actual claim happens in the reward box.
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { useActiveAccount } from "thirdweb/react";
+import { cn } from "@/lib/utils";
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
+import { useMorpheusPosition, type MorpheusPoolPosition } from "@/hooks/use-morpheus-position";
+
+const fmt = (n: number, d = 4) => n.toLocaleString(undefined, { maximumFractionDigits: d });
+const fmtDate = (ts: number) =>
+  new Date(ts * 1000).toLocaleDateString(undefined, { day: "2-digit", month: "short", year: "numeric" });
+
+type T = ReturnType<typeof useTranslations>;
+
+function Badge({ tone, children }: { tone: "ok" | "warn"; children: React.ReactNode }) {
+  return (
+    <span
+      className={cn(
+        "inline-block rounded-full px-2 py-0.5 text-[11px] font-semibold",
+        tone === "ok"
+          ? "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400"
+          : "bg-amber-500/15 text-amber-600 dark:text-amber-400",
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+function Metric({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">{label}</span>
+      <span className="text-sm tabular-nums">{children}</span>
+    </div>
+  );
+}
+
+function PositionRow({ p, now, t }: { p: MorpheusPoolPosition; now: number; t: T }) {
+  const morUnlocked = p.morUnlockAt > 0 && p.morUnlockAt <= now;
+  const depUnlocked = p.unlockAt > 0 && p.unlockAt <= now;
+  return (
+    <div className="rounded-xl border p-3">
+      <div className="flex items-center justify-between gap-2">
+        <span className="flex items-center gap-2 font-semibold">
+          <span className={cn("size-2 shrink-0 rounded-full", p.asset === "usdc" ? "bg-sky-500" : "bg-emerald-500")} />
+          {p.symbol}
+        </span>
+        <span className="font-mono text-sm tabular-nums">
+          {fmt(p.staked)} <span className="text-xs font-normal text-muted-foreground">{p.symbol}</span>
+        </span>
+      </div>
+
+      <div className="mt-3 grid grid-cols-2 gap-x-4 gap-y-2.5 sm:grid-cols-3">
+        <Metric label={t("earned")}>
+          <span className="font-mono font-semibold">{fmt(p.pendingMor)}</span>{" "}
+          <span className="text-xs text-muted-foreground">MOR</span>
+        </Metric>
+        <Metric label={t("morLock")}>
+          {p.morUnlockAt <= 0 ? (
+            <span className="text-muted-foreground">—</span>
+          ) : morUnlocked ? (
+            <Badge tone="ok">{t("claimable")}</Badge>
+          ) : (
+            <Badge tone="warn">{t("lockedUntil", { date: fmtDate(p.morUnlockAt) })}</Badge>
+          )}
+        </Metric>
+        <Metric label={t("principalLock")}>
+          {p.unlockAt <= 0 ? (
+            <span className="text-muted-foreground">—</span>
+          ) : depUnlocked ? (
+            <span className="text-emerald-600 dark:text-emerald-400">{t("unlocked")}</span>
+          ) : (
+            <span>{fmtDate(p.unlockAt)}</span>
+          )}
+        </Metric>
+      </div>
+    </div>
+  );
+}
+
+export function StakePositions() {
+  const t = useTranslations("stake.positions");
+  const you = useActiveAccount()?.address;
+  const pos = useMorpheusPosition(you);
+  // Lazy initializer keeps render pure — the 7-day / power locks don't need a
+  // live tick; a refresh re-reads the clock.
+  const [now] = useState(() => Math.floor(Date.now() / 1000));
+
+  const staked = pos?.pools.filter((p) => p.staked > 0) ?? [];
+  const anyLocked = staked.some((p) => p.morUnlockAt > now);
+
+  let body: React.ReactNode;
+  if (!you) body = <p className="text-sm text-muted-foreground">{t("connect")}</p>;
+  else if (!pos) body = <p className="text-sm text-muted-foreground">{t("loading")}</p>;
+  else if (staked.length === 0) body = <p className="text-sm text-muted-foreground">{t("none")}</p>;
+  else
+    body = (
+      <div className="space-y-3">
+        {staked.map((p) => (
+          <PositionRow key={p.asset} p={p} now={now} t={t} />
+        ))}
+        <p className="pt-1 text-xs leading-relaxed text-muted-foreground">{t("claimHint")}</p>
+        {anyLocked && <p className="text-xs leading-relaxed text-muted-foreground">{t("powerLockNote")}</p>}
+      </div>
+    );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("title")}</CardTitle>
+        <CardDescription>{t("subtitle")}</CardDescription>
+      </CardHeader>
+      <CardContent>{body}</CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/use-morpheus-position.ts
+++ b/src/hooks/use-morpheus-position.ts
@@ -31,6 +31,10 @@ export type MorpheusPoolPosition = {
   pendingMor: number;
   /** Unix seconds when the withdraw lock lifts (0 if nothing staked). */
   unlockAt: number;
+  /** Unix seconds when the MOR reward claim-lock lifts (claimLockEnd) — until
+   * then the accrued MOR can't be claimed. 0 if none. This is the "power lock"
+   * chosen at deposit: a longer lock buys a higher power factor / APR. */
+  morUnlockAt: number;
   /** The athlete credited as referrer for this position (drives the 3-way split). */
   referrer: Address;
 };
@@ -62,12 +66,14 @@ export function useMorpheusPosition(wallet?: string, nonce = 0): MorpheusPositio
             ]);
             const lastStake = Number(data[0]); // uint128 lastStake
             const deposited = data[1]; // uint256 deposited
+            const claimLockEnd = Number(data[5]); // uint128 claimLockEnd (MOR power lock)
             const referrer = data[8] as Address; // stored referrer (athlete)
             return {
               asset, symbol,
               staked: Number(formatUnits(deposited, decimals)),
               pendingMor: Number(formatUnits(reward, MOR_DECIMALS)),
               unlockAt: deposited > BigInt(0) ? lastStake + WITHDRAW_LOCK_SECONDS : 0,
+              morUnlockAt: deposited > BigInt(0) ? claimLockEnd : 0,
               referrer,
             } satisfies MorpheusPoolPosition;
           }),


### PR DESCRIPTION
## What
Adds a read-only **"Your positions"** card on `/stake`, right below the `StakeOrbit`, so a staker can see their Morpheus Capital positions without leaving to the Morpheus dashboard.

Per asset (stETH + USDC): **deposit**, **MOR earned**, when the **MOR claim-lock** lifts, and when the **7-day principal lock** lifts.

## Why
A staker asked "how do I claim my rewards?" — the answer is subtle: MOR is subject to the **power-lock** (`claimLockEnd`) chosen at deposit. A far-off MOR-unlock date (e.g. a 2-year lock for a higher power factor / APR) means the reward is *earned but not claimable yet*. Surfacing this on-page prevents confused "why can't I claim?" moments and failed claim txs.

## Changes
- `use-morpheus-position`: now also returns `morUnlockAt` (the `claimLockEnd` from `usersData`, index 5), alongside the principal unlock.
- `StakePositions.tsx`: new component — shadcn `Card`, full i18n (en + pt-br), badges **"claimable now"** / **"locked until <date>"** for the MOR, and a note explaining the power-lock trade-off.
- Wired below `<StakeOrbit />` in the stake page.

## Verification
- `tsc --noEmit` clean · `eslint` clean (fixed the render-purity rule with a lazy `useState` clock, matching `MorLootbox`).
- Reads are the same on-chain `usersData` the rest of the stake UI uses; nothing here moves funds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)