### PR TITLE
fix(stake): reward box & positions read the EOA, not the Smart Account

### DIFF
--- a/src/components/stake/MorLootbox.tsx
+++ b/src/components/stake/MorLootbox.tsx
@@ -11,12 +11,12 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
-import { useActiveAccount } from "thirdweb/react";
 import { AnimatePresence, motion } from "framer-motion";
 import { Gift, Sparkles, X } from "lucide-react";
 import { toast } from "sonner";
 import { type Address } from "viem";
 import { Button } from "@/components/ui/button";
+import { useUserAddress } from "@/hooks/use-user-address";
 import { useMorpheusPosition } from "@/hooks/use-morpheus-position";
 import { useMorpheusStake } from "@/hooks/use-morpheus-stake";
 import { useMorDistribute } from "@/hooks/use-mor-distribute";
@@ -30,7 +30,12 @@ const fmt = (n: number) => n.toLocaleString("en-US", { maximumFractionDigits: 4 
 
 export function MorLootbox() {
   const t = useTranslations("stake");
-  const you = useActiveAccount()?.address;
+  // Read off the EFFECTIVE user address (EOA for external wallets), not the raw
+  // active account — with account-abstraction thirdweb's active account is the
+  // Smart Account wrap, but stakes/claims live on the user's EOA. Keying reads
+  // off the SA made the box find no position and never appear. Writes still sign
+  // through the active account inside the morpheus/distribute hooks.
+  const { address: you } = useUserAddress();
   const [nonce, setNonce] = useState(0);
   const position = useMorpheusPosition(you, nonce);
   const morpheus = useMorpheusStake();

--- a/src/components/stake/StakePositions.tsx
+++ b/src/components/stake/StakePositions.tsx
@@ -7,8 +7,8 @@
 
 import { useState } from "react";
 import { useTranslations } from "next-intl";
-import { useActiveAccount } from "thirdweb/react";
 import { cn } from "@/lib/utils";
+import { useUserAddress } from "@/hooks/use-user-address";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
 import { useMorpheusPosition, type MorpheusPoolPosition } from "@/hooks/use-morpheus-position";
 
@@ -87,7 +87,9 @@ function PositionRow({ p, now, t }: { p: MorpheusPoolPosition; now: number; t: T
 
 export function StakePositions() {
   const t = useTranslations("stake.positions");
-  const you = useActiveAccount()?.address;
+  // Effective user address (EOA for external wallets) — reads must key off the
+  // address the stake actually lives on, not the Smart Account wrap.
+  const { address: you } = useUserAddress();
   const pos = useMorpheusPosition(you);
   // Lazy initializer keeps render pure — the 7-day / power locks don't need a
   // live tick; a refresh re-reads the clock.


### PR DESCRIPTION
## The bug
The reward **lootbox never appeared** for external-wallet users (and the new positions panel showed "no positions").

**Root cause:** with account-abstraction, thirdweb's `useActiveAccount()` returns the **Smart Account** wrap address — but stakes/rewards live on the user's **EOA** (which is exactly why the app defaults external wallets to view-mode `"eoa"` and provides `useUserAddress()` as the single source of truth for read hooks). `MorLootbox` and `StakePositions` keyed their position reads off the SA (empty) → `hasAction` was false → the box never rendered.

## Fix
Both components now read from `useUserAddress().address` (the effective address — the EOA for external wallets, the SA for in-app wallets). **Writes are unchanged** — claim/distribute still sign through the active account inside the morpheus/distribute hooks, per `useUserAddress`'s documented contract ("reads key off this; writes use the active account directly").

## Verification
- `tsc --noEmit` clean · `eslint` clean.
- No behavior change for in-app-wallet users (there `useUserAddress().address === useActiveAccount().address`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)