### PR TITLE
feat(stake): add "Collect" step — withdraw MOR from the SplitsWarehouse

### DIFF
--- a/messages/en/stake.json
+++ b/messages/en/stake.json
@@ -178,8 +178,14 @@
     "step2": "Bridge",
     "step2sub": "LayerZero to Arbitrum (~1–2 min)",
     "step3": "Distribute",
-    "step3sub": "Split 50/25/25 to wallets",
-    "allCollected": "Nothing to collect right now — all your MOR has been claimed and distributed."
+    "step3sub": "Split 50/25/25",
+    "allCollected": "Nothing to collect right now — all your MOR has been claimed and distributed.",
+    "step4": "Collect",
+    "step4sub": "Warehouse → your wallet",
+    "collect": "Collect",
+    "collecting": "Collecting…",
+    "collectedTitle": "Collected to your wallet",
+    "inWarehouse": "in the Warehouse"
   },
   "admin": {
     "title": "Sponsorship vaults",

--- a/messages/pt-br/stake.json
+++ b/messages/pt-br/stake.json
@@ -178,8 +178,14 @@
     "step2": "Bridge",
     "step2sub": "LayerZero pra Arbitrum (~1–2 min)",
     "step3": "Distribuir",
-    "step3sub": "Divide 50/25/25 nas carteiras",
-    "allCollected": "Nada pra coletar agora — todo o seu MOR já foi reivindicado e distribuído."
+    "step3sub": "Divide 50/25/25",
+    "allCollected": "Nada pra coletar agora — todo o seu MOR já foi reivindicado e distribuído.",
+    "step4": "Coletar",
+    "step4sub": "Warehouse → sua carteira",
+    "collect": "Coletar",
+    "collecting": "Coletando…",
+    "collectedTitle": "Coletado na sua carteira",
+    "inWarehouse": "no Warehouse"
   },
   "admin": {
     "title": "Cofres de patrocínio",

--- a/src/components/stake/MorLootbox.tsx
+++ b/src/components/stake/MorLootbox.tsx
@@ -20,7 +20,7 @@ import { useUserAddress } from "@/hooks/use-user-address";
 import { useMorpheusPosition } from "@/hooks/use-morpheus-position";
 import { useMorpheusStake } from "@/hooks/use-morpheus-stake";
 import { useMorDistribute } from "@/hooks/use-mor-distribute";
-import { predictSplitAddress, splitMorBalance } from "@/lib/mor-split";
+import { predictSplitAddress, splitMorBalance, warehouseMorBalance } from "@/lib/mor-split";
 import type { MorpheusAsset } from "@/lib/morpheus";
 import { RewardClaimModal } from "@/components/stake/RewardClaimModal";
 
@@ -39,10 +39,11 @@ export function MorLootbox() {
   const [nonce, setNonce] = useState(0);
   const position = useMorpheusPosition(you, nonce);
   const morpheus = useMorpheusStake();
-  const { distribute, isBusy: distributing } = useMorDistribute();
+  const { distribute, collect, isBusy: distributing, collecting } = useMorDistribute();
 
   const [open, setOpen] = useState(false);
   const [splitBalances, setSplitBalances] = useState<Partial<Record<MorpheusAsset, number>>>({});
+  const [collectable, setCollectable] = useState(0);
   const [busyAsset, setBusyAsset] = useState<MorpheusAsset | null>(null);
   // Read the clock once at mount (a lazy initializer is pure-in-render safe) —
   // the 7-day unlock doesn't need a live tick; a refresh re-reads it.
@@ -62,13 +63,22 @@ export function MorLootbox() {
     return () => { cancelled = true; };
   }, [you, position, nonce]);
 
+  // MOR the user was credited in the SplitsWarehouse (after a distribute), still
+  // to be collected into the wallet — the last hop of the reward flow.
+  useEffect(() => {
+    if (!you) { setCollectable(0); return; }
+    let cancelled = false;
+    warehouseMorBalance(you as Address).then((v) => { if (!cancelled) setCollectable(v); });
+    return () => { cancelled = true; };
+  }, [you, nonce]);
+
   const pools = position?.pools ?? [];
   const claimable = pools.filter((p) => p.pendingMor > LOOT_MIN_MOR && p.referrer && p.referrer.toLowerCase() !== ZERO);
   const distributable = pools.filter((p) => (splitBalances[p.asset] ?? 0) > LOOT_MIN_MOR);
   const stakedPools = pools.filter((p) => p.staked > 0);
-  // The box surfaces whenever there's any MOR to act on — rewards to collect OR
-  // a principal position to manage (withdraw after the 7-day lock).
-  const hasAction = claimable.length > 0 || distributable.length > 0 || stakedPools.length > 0;
+  // The box surfaces whenever there's any MOR to act on — rewards to claim,
+  // distribute or collect, OR a principal position to manage (7-day lock).
+  const hasAction = claimable.length > 0 || distributable.length > 0 || collectable > LOOT_MIN_MOR || stakedPools.length > 0;
 
   const refresh = () => setNonce((n) => n + 1);
 
@@ -110,6 +120,16 @@ export function MorLootbox() {
     [distribute, t],
   );
 
+  const onCollect = useCallback(
+    async () => {
+      if (!you) return;
+      const ok = await collect(you as Address);
+      if (ok) { toast.success(t("lootbox.collectedTitle")); refresh(); }
+      else toast.error(t("lootbox.failed"));
+    },
+    [you, collect, t],
+  );
+
   const onWithdraw = useCallback(
     async (asset: MorpheusAsset, staked: number) => {
       setBusyAsset(asset);
@@ -128,7 +148,7 @@ export function MorLootbox() {
 
   const totalClaimable = claimable.reduce((s, p) => s + p.pendingMor, 0);
   const totalDistributable = distributable.reduce((s, p) => s + (splitBalances[p.asset] ?? 0), 0);
-  const badge = totalClaimable + totalDistributable;
+  const badge = totalClaimable + totalDistributable + collectable;
 
   return (
     <>
@@ -136,15 +156,18 @@ export function MorLootbox() {
         <RewardClaimModal
           claimable={claimable}
           distributable={distributable}
+          collectable={collectable}
           stakedPools={stakedPools}
           splitBalances={splitBalances}
           busyAsset={busyAsset}
           morpheusBusy={morpheus.isBusy}
           morpheusPhase={morpheus.phase}
           distributing={distributing}
+          collecting={collecting}
           nowSec={nowSec}
           onClaim={onClaim}
           onDistribute={onDistribute}
+          onCollect={onCollect}
           onWithdraw={onWithdraw}
           onClose={() => setOpen(false)}
         />

--- a/src/components/stake/RewardClaimModal.tsx
+++ b/src/components/stake/RewardClaimModal.tsx
@@ -36,54 +36,63 @@ function tierFor(total: number): "bronze" | "silver" | "gold" | "black" {
 interface Props {
   claimable: MorpheusPoolPosition[];
   distributable: MorpheusPoolPosition[];
+  collectable: number;
   stakedPools: MorpheusPoolPosition[];
   splitBalances: Partial<Record<MorpheusAsset, number>>;
   busyAsset: MorpheusAsset | null;
   morpheusBusy: boolean;
   morpheusPhase: string;
   distributing: boolean;
+  collecting: boolean;
   nowSec: number;
   onClaim: (asset: MorpheusAsset, referrer: Address) => void;
   onDistribute: (asset: MorpheusAsset, referrer: Address) => void;
+  onCollect: () => void;
   onWithdraw: (asset: MorpheusAsset, staked: number) => void;
   onClose: () => void;
 }
 
 export function RewardClaimModal({
-  claimable, distributable, stakedPools, splitBalances,
-  busyAsset, morpheusBusy, morpheusPhase, distributing, nowSec,
-  onClaim, onDistribute, onWithdraw, onClose,
+  claimable, distributable, collectable, stakedPools, splitBalances,
+  busyAsset, morpheusBusy, morpheusPhase, distributing, collecting, nowSec,
+  onClaim, onDistribute, onCollect, onWithdraw, onClose,
 }: Props) {
   const t = useTranslations("stake");
 
   const totalClaimable = claimable.reduce((s, p) => s + p.pendingMor, 0);
   const totalDistributable = distributable.reduce((s, p) => s + (splitBalances[p.asset] ?? 0), 0);
-  const total = totalClaimable + totalDistributable;
+  const total = totalClaimable + totalDistributable + collectable;
 
-  const stage: "claim" | "distribute" | "done" =
-    claimable.length > 0 ? "claim" : distributable.length > 0 ? "distribute" : "done";
+  const stage: "claim" | "distribute" | "collect" | "done" =
+    claimable.length > 0 ? "claim"
+      : distributable.length > 0 ? "distribute"
+      : collectable > 0 ? "collect"
+      : "done";
 
-  const isPending = busyAsset != null;
-  // Reward has landed at the split → let the chest reveal it (idle otherwise).
-  const isOpening = distributable.length > 0 && busyAsset == null;
+  const isPending = busyAsset != null || collecting;
+  // Reward is out of the pool (at the split, or credited in the warehouse) → let
+  // the chest reveal it; idle while a tx runs or nothing's waiting.
+  const isOpening = (distributable.length > 0 || collectable > 0) && !isPending;
 
   // Clicking the chest runs the primary next action.
   const runPrimary = () => {
     if (claimable.length > 0) { const p = claimable[0]; onClaim(p.asset, p.referrer); return; }
-    if (distributable.length > 0) { const p = distributable[0]; onDistribute(p.asset, p.referrer); }
+    if (distributable.length > 0) { const p = distributable[0]; onDistribute(p.asset, p.referrer); return; }
+    if (collectable > 0) onCollect();
   };
 
   const steps = [
     { key: "claim", label: t("lootbox.step1"), sub: t("lootbox.step1sub") },
     { key: "bridge", label: t("lootbox.step2"), sub: t("lootbox.step2sub") },
     { key: "distribute", label: t("lootbox.step3"), sub: t("lootbox.step3sub") },
+    { key: "collect", label: t("lootbox.step4"), sub: t("lootbox.step4sub") },
   ] as const;
 
+  const order = ["claim", "bridge", "distribute", "collect"];
+  const currentIdx = stage === "claim" ? 0 : stage === "distribute" ? 2 : stage === "collect" ? 3 : order.length;
   const stepState = (key: string): "done" | "current" | "idle" => {
-    if (stage === "done") return "done";
-    if (stage === "claim") return key === "claim" ? "current" : "idle";
-    // distribute stage: claim + bridge behind us, distribute is the live step.
-    return key === "distribute" ? "current" : "done";
+    const i = order.indexOf(key);
+    return i < currentIdx ? "done" : i === currentIdx ? "current" : "idle";
   };
 
   return (
@@ -173,7 +182,18 @@ export function RewardClaimModal({
               </div>
             ))}
 
-            {claimable.length === 0 && distributable.length === 0 && (
+            {collectable > 0 && (
+              <div className="flex items-center justify-between gap-2 rounded-lg border bg-muted/40 px-3 py-2">
+                <span className="text-xs text-muted-foreground">
+                  <b className="font-mono text-foreground">{fmt(collectable)}</b> MOR · {t("lootbox.inWarehouse")}
+                </span>
+                <Button size="sm" disabled={collecting} onClick={onCollect} className="h-7">
+                  {collecting ? t("lootbox.collecting") : t("lootbox.collect")}
+                </Button>
+              </div>
+            )}
+
+            {claimable.length === 0 && distributable.length === 0 && collectable === 0 && (
               <p className="rounded-lg border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">{t("lootbox.allCollected")}</p>
             )}
           </div>

--- a/src/hooks/use-mor-distribute.ts
+++ b/src/hooks/use-mor-distribute.ts
@@ -20,9 +20,10 @@ import { ARBITRUM_PUSH_SPLIT_FACTORY, MOR_TOKEN } from "@/lib/morpheus";
 import {
   splitParamsFor, predictSplitAddress, isSplitDeployed,
   pushSplitFactoryAbi, splitWalletAbi, SPLIT_OWNER, SPLIT_SALT,
+  SPLITS_WAREHOUSE, splitsWarehouseAbi,
 } from "@/lib/mor-split";
 
-export type DistributePhase = "idle" | "deploy" | "distribute" | "done" | "error";
+export type DistributePhase = "idle" | "deploy" | "distribute" | "collect" | "done" | "error";
 
 export function useMorDistribute() {
   const writer = useWriteAccount();
@@ -85,10 +86,47 @@ export function useMorDistribute() {
     [writer],
   );
 
+  /**
+   * Collect `owner`'s MOR out of the SplitsWarehouse into their wallet — the cut
+   * `distribute` credited there. `withdraw(owner, token)` is permissionless; the
+   * caller pays gas and the MOR still only goes to `owner`.
+   */
+  const collect = useCallback(
+    async (owner: Address): Promise<boolean> => {
+      if (pending.current) return false;
+      const client = getThirdwebClient();
+      if (!client) { setError("Thirdweb not configured."); setPhase("error"); return false; }
+      if (!writer) { setError("Connect your wallet."); setPhase("error"); return false; }
+      setError(null);
+      pending.current = true;
+      try {
+        await ensureOnChain(writer.wallet, arbitrum);
+        setPhase("collect");
+        const data = encodeFunctionData({
+          abi: splitsWarehouseAbi, functionName: "withdraw", args: [owner, MOR_TOKEN],
+        });
+        const tx = prepareTransaction({ client, chain: arbitrum, to: SPLITS_WAREHOUSE, data });
+        const hash = (await sendTransaction({ account: writer.account, transaction: tx })).transactionHash;
+        await waitForReceipt({ client, chain: arbitrum, transactionHash: hash });
+        setPhase("done");
+        return true;
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Collect failed.");
+        setPhase("error");
+        return false;
+      } finally {
+        pending.current = false;
+      }
+    },
+    [writer],
+  );
+
   return {
     distribute,
+    collect,
     phase,
     error,
-    isBusy: phase === "deploy" || phase === "distribute",
+    isBusy: phase === "deploy" || phase === "distribute" || phase === "collect",
+    collecting: phase === "collect",
   };
 }

--- a/src/lib/mor-split.ts
+++ b/src/lib/mor-split.ts
@@ -120,3 +120,32 @@ export async function splitMorBalance(staker: Address, athlete: Address): Promis
     return 0;
   }
 }
+
+/**
+ * The 0xSplits SplitsWarehouse (ERC-6909) — same canonical address on every
+ * chain. `distribute` doesn't push straight to wallets: it CREDITS each
+ * recipient's balance in the Warehouse, and a separate `withdraw(owner, token)`
+ * pushes it out. Warehouse token id = uint256(uint160(token)).
+ */
+export const SPLITS_WAREHOUSE = getAddress("0x8fb66F38cF86A3d5e8768f8F1754A24A6c661Fb8");
+
+export const splitsWarehouseAbi = [
+  { type: "function", name: "balanceOf", stateMutability: "view", inputs: [{ name: "owner", type: "address" }, { name: "id", type: "uint256" }], outputs: [{ type: "uint256" }] },
+  { type: "function", name: "withdraw", stateMutability: "nonpayable", inputs: [{ name: "owner", type: "address" }, { name: "token", type: "address" }], outputs: [] },
+] as const;
+
+/**
+ * MOR credited to `owner` in the SplitsWarehouse after a distribute, waiting to
+ * be collected into the wallet. The Warehouse leaves 1 wei — treat <= 1 as empty.
+ */
+export async function warehouseMorBalance(owner: Address): Promise<number> {
+  try {
+    const bal = await arbitrumClient.readContract({
+      address: SPLITS_WAREHOUSE, abi: splitsWarehouseAbi, functionName: "balanceOf",
+      args: [getAddress(owner), BigInt(MOR_TOKEN)],
+    });
+    return Number(formatUnits(bal <= BigInt(1) ? BigInt(0) : bal, MOR_DECIMALS));
+  } catch {
+    return 0;
+  }
+}


### PR DESCRIPTION
## Problem
SplitV2's `distribute` doesn't push straight to wallets — it **credits the SplitsWarehouse (ERC-6909)** and needs a separate `withdraw`. So after distributing, the MOR appeared to vanish (a staker's cut sat stuck in the Warehouse). The flow was missing its last hop.

## Fix — a 4th step: Claim → Bridge → Distribute → **Collect**
- **mor-split**: `SPLITS_WAREHOUSE` + `splitsWarehouseAbi` + `warehouseMorBalance(owner)` (id = `uint256(uint160(MOR))`, treats ≤1 wei as empty).
- **use-mor-distribute**: `collect(owner)` → `SplitsWarehouse.withdraw(owner, MOR)` on Arbitrum; exposes `collecting`.
- **MorLootbox**: reads the warehouse credit (`collectable`), `onCollect` handler, folded into `hasAction`/badge — all on-chain logic unchanged.
- **RewardClaimModal**: 4th "Collect" step + action row; the chest opens when there's reward at the split **or** in the warehouse.

## Note
This immediately surfaces MOR already stuck in the Warehouse from earlier distributes (so it can finally be collected). `tsc` + `eslint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)