### PR TITLE
feat(stake): Collect withdraws ALL recipients in one batched tx (Multicall3)

### DIFF
--- a/messages/en/stake.json
+++ b/messages/en/stake.json
@@ -181,7 +181,7 @@
     "step3sub": "Split 50/25/25",
     "allCollected": "Nothing to collect right now — all your MOR has been claimed and distributed.",
     "step4": "Collect",
-    "step4sub": "Warehouse → your wallet",
+    "step4sub": "Warehouse → every wallet (you + Gnars)",
     "collect": "Collect",
     "collecting": "Collecting…",
     "collectedTitle": "Collected to your wallet",

--- a/messages/pt-br/stake.json
+++ b/messages/pt-br/stake.json
@@ -181,7 +181,7 @@
     "step3sub": "Divide 50/25/25",
     "allCollected": "Nada pra coletar agora — todo o seu MOR já foi reivindicado e distribuído.",
     "step4": "Coletar",
-    "step4sub": "Warehouse → sua carteira",
+    "step4sub": "Warehouse → todas as carteiras (você + Gnars)",
     "collect": "Coletar",
     "collecting": "Coletando…",
     "collectedTitle": "Coletado na sua carteira",

--- a/src/components/stake/MorLootbox.tsx
+++ b/src/components/stake/MorLootbox.tsx
@@ -15,13 +15,13 @@ import { useTranslations } from "next-intl";
 import { motion } from "framer-motion";
 import { Gift } from "lucide-react";
 import { toast } from "sonner";
-import { type Address } from "viem";
+import { getAddress, type Address } from "viem";
 import { useUserAddress } from "@/hooks/use-user-address";
 import { useMorpheusPosition } from "@/hooks/use-morpheus-position";
 import { useMorpheusStake } from "@/hooks/use-morpheus-stake";
 import { useMorDistribute } from "@/hooks/use-mor-distribute";
 import { predictSplitAddress, splitMorBalance, warehouseMorBalance } from "@/lib/mor-split";
-import type { MorpheusAsset } from "@/lib/morpheus";
+import { MOR_GNARS_RECIPIENT, type MorpheusAsset } from "@/lib/morpheus";
 import { RewardClaimModal } from "@/components/stake/RewardClaimModal";
 
 const ZERO = "0x0000000000000000000000000000000000000000";
@@ -43,7 +43,7 @@ export function MorLootbox() {
 
   const [open, setOpen] = useState(false);
   const [splitBalances, setSplitBalances] = useState<Partial<Record<MorpheusAsset, number>>>({});
-  const [collectable, setCollectable] = useState(0);
+  const [collectItems, setCollectItems] = useState<{ owner: Address; amount: number }[]>([]);
   const [busyAsset, setBusyAsset] = useState<MorpheusAsset | null>(null);
   // Read the clock once at mount (a lazy initializer is pure-in-render safe) —
   // the 7-day unlock doesn't need a live tick; a refresh re-reads it.
@@ -63,14 +63,27 @@ export function MorLootbox() {
     return () => { cancelled = true; };
   }, [you, position, nonce]);
 
-  // MOR the user was credited in the SplitsWarehouse (after a distribute), still
-  // to be collected into the wallet — the last hop of the reward flow.
+  // Every recipient's MOR credited in the SplitsWarehouse (staker + Gnars +
+  // athletes) still to be collected — the last hop. One Collect click withdraws
+  // them all in a single batched tx (Multicall3).
   useEffect(() => {
-    if (!you) { setCollectable(0); return; }
+    if (!you) { setCollectItems([]); return; }
     let cancelled = false;
-    warehouseMorBalance(you as Address).then((v) => { if (!cancelled) setCollectable(v); });
+    (async () => {
+      const referrers = (position?.pools ?? [])
+        .filter((p) => p.staked > 0 && p.referrer && p.referrer.toLowerCase() !== ZERO)
+        .map((p) => getAddress(p.referrer));
+      const owners = [...new Set([getAddress(you as Address), MOR_GNARS_RECIPIENT, ...referrers])];
+      const amounts = await Promise.all(owners.map((o) => warehouseMorBalance(o)));
+      const items = owners
+        .map((owner, i) => ({ owner, amount: amounts[i] }))
+        .filter((x) => x.amount > LOOT_MIN_MOR);
+      if (!cancelled) setCollectItems(items);
+    })();
     return () => { cancelled = true; };
-  }, [you, nonce]);
+  }, [you, position, nonce]);
+
+  const collectable = collectItems.reduce((s, x) => s + x.amount, 0);
 
   const pools = position?.pools ?? [];
   const claimable = pools.filter((p) => p.pendingMor > LOOT_MIN_MOR && p.referrer && p.referrer.toLowerCase() !== ZERO);
@@ -122,12 +135,12 @@ export function MorLootbox() {
 
   const onCollect = useCallback(
     async () => {
-      if (!you) return;
-      const ok = await collect(you as Address);
+      if (collectItems.length === 0) return;
+      const ok = await collect(collectItems.map((x) => x.owner));
       if (ok) { toast.success(t("lootbox.collectedTitle")); refresh(); }
       else toast.error(t("lootbox.failed"));
     },
-    [you, collect, t],
+    [collectItems, collect, t],
   );
 
   const onWithdraw = useCallback(

--- a/src/hooks/use-mor-distribute.ts
+++ b/src/hooks/use-mor-distribute.ts
@@ -20,7 +20,7 @@ import { ARBITRUM_PUSH_SPLIT_FACTORY, MOR_TOKEN } from "@/lib/morpheus";
 import {
   splitParamsFor, predictSplitAddress, isSplitDeployed,
   pushSplitFactoryAbi, splitWalletAbi, SPLIT_OWNER, SPLIT_SALT,
-  SPLITS_WAREHOUSE, splitsWarehouseAbi,
+  SPLITS_WAREHOUSE, splitsWarehouseAbi, MULTICALL3, multicall3Abi,
 } from "@/lib/mor-split";
 
 export type DistributePhase = "idle" | "deploy" | "distribute" | "collect" | "done" | "error";
@@ -87,13 +87,15 @@ export function useMorDistribute() {
   );
 
   /**
-   * Collect `owner`'s MOR out of the SplitsWarehouse into their wallet — the cut
-   * `distribute` credited there. `withdraw(owner, token)` is permissionless; the
-   * caller pays gas and the MOR still only goes to `owner`.
+   * Collect EVERY recipient's MOR out of the SplitsWarehouse in one tx — staker
+   * + Gnars + athlete — by batching their `withdraw(owner, MOR)` calls through
+   * Multicall3. `withdraw` pays out to `owner` no matter who calls, so a single
+   * Collect click delivers all cuts. `allowFailure` so a zero/dust owner can
+   * never revert the batch.
    */
   const collect = useCallback(
-    async (owner: Address): Promise<boolean> => {
-      if (pending.current) return false;
+    async (owners: Address[]): Promise<boolean> => {
+      if (pending.current || owners.length === 0) return false;
       const client = getThirdwebClient();
       if (!client) { setError("Thirdweb not configured."); setPhase("error"); return false; }
       if (!writer) { setError("Connect your wallet."); setPhase("error"); return false; }
@@ -102,10 +104,13 @@ export function useMorDistribute() {
       try {
         await ensureOnChain(writer.wallet, arbitrum);
         setPhase("collect");
-        const data = encodeFunctionData({
-          abi: splitsWarehouseAbi, functionName: "withdraw", args: [owner, MOR_TOKEN],
-        });
-        const tx = prepareTransaction({ client, chain: arbitrum, to: SPLITS_WAREHOUSE, data });
+        const calls = owners.map((owner) => ({
+          target: SPLITS_WAREHOUSE,
+          allowFailure: true,
+          callData: encodeFunctionData({ abi: splitsWarehouseAbi, functionName: "withdraw", args: [owner, MOR_TOKEN] }),
+        }));
+        const data = encodeFunctionData({ abi: multicall3Abi, functionName: "aggregate3", args: [calls] });
+        const tx = prepareTransaction({ client, chain: arbitrum, to: MULTICALL3, data });
         const hash = (await sendTransaction({ account: writer.account, transaction: tx })).transactionHash;
         await waitForReceipt({ client, chain: arbitrum, transactionHash: hash });
         setPhase("done");

--- a/src/lib/mor-split.ts
+++ b/src/lib/mor-split.ts
@@ -149,3 +149,32 @@ export async function warehouseMorBalance(owner: Address): Promise<number> {
     return 0;
   }
 }
+
+/**
+ * Multicall3 — same canonical address on every chain. Used to batch every
+ * recipient's warehouse `withdraw` (staker + Gnars + athlete) into one tx, so a
+ * single Collect click delivers all cuts. `withdraw(owner, token)` pays out to
+ * `owner` regardless of caller, so Multicall3 as msg.sender is fine.
+ */
+export const MULTICALL3 = getAddress("0xcA11bde05977b3631167028862bE2a173976CA11");
+
+export const multicall3Abi = [
+  {
+    type: "function", name: "aggregate3", stateMutability: "payable",
+    inputs: [{
+      name: "calls", type: "tuple[]",
+      components: [
+        { name: "target", type: "address" },
+        { name: "allowFailure", type: "bool" },
+        { name: "callData", type: "bytes" },
+      ],
+    }],
+    outputs: [{
+      name: "returnData", type: "tuple[]",
+      components: [
+        { name: "success", type: "bool" },
+        { name: "returnData", type: "bytes" },
+      ],
+    }],
+  },
+] as const;


### PR DESCRIPTION
## What
The **Collect** button now delivers **every** recipient's cut (staker + Gnars + athlete) in **one batched tx**, instead of only the staker's. Fixes the Gnars 25% getting stranded in the SplitsWarehouse.

## How
- `mor-split`: `MULTICALL3` + `multicall3Abi` (`aggregate3`).
- `use-mor-distribute`: `collect(owners[])` builds one `withdraw(owner, MOR)` per recipient and sends them through Multicall3 `aggregate3` with `allowFailure` (a zero/dust owner never reverts the batch). `withdraw` pays out to `owner` regardless of caller, so batching from Multicall3 is safe.
- `MorLootbox`: reads warehouse credits for `[staker, Gnars, athletes]`, folds them into `collectItems`; Collect withdraws them all at once. `collectable` is now the total across recipients.

## Effect
One click → the staker's cut lands in their wallet **and** the Gnars 25% lands in the Gnars Arbitrum multisig. `tsc` + `eslint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)