### PR TITLE
feat(stake): reward panel surfaces Morpho vault yield too (not just MOR)

### DIFF
--- a/messages/en/stake.json
+++ b/messages/en/stake.json
@@ -185,7 +185,10 @@
     "collect": "Collect",
     "collecting": "Collecting…",
     "collectedTitle": "Collected to your wallet",
-    "inWarehouse": "in the Warehouse"
+    "inWarehouse": "in the Warehouse",
+    "morphoTitle": "Morpho yield",
+    "claimYield": "Harvest",
+    "vaultClaimed": "Yield harvested to your wallet"
   },
   "admin": {
     "title": "Sponsorship vaults",

--- a/messages/pt-br/stake.json
+++ b/messages/pt-br/stake.json
@@ -185,7 +185,10 @@
     "collect": "Coletar",
     "collecting": "Coletando…",
     "collectedTitle": "Coletado na sua carteira",
-    "inWarehouse": "no Warehouse"
+    "inWarehouse": "no Warehouse",
+    "morphoTitle": "Yield Morpho",
+    "claimYield": "Colher",
+    "vaultClaimed": "Yield colhido na carteira"
   },
   "admin": {
     "title": "Cofres de patrocínio",

--- a/src/components/stake/MorLootbox.tsx
+++ b/src/components/stake/MorLootbox.tsx
@@ -23,6 +23,8 @@ import { useMorDistribute } from "@/hooks/use-mor-distribute";
 import { predictSplitAddress, splitMorBalance, warehouseMorBalance } from "@/lib/mor-split";
 import { MOR_GNARS_RECIPIENT, type MorpheusAsset } from "@/lib/morpheus";
 import { RewardClaimModal } from "@/components/stake/RewardClaimModal";
+import { useStakeDeposit } from "@/hooks/use-stake-deposit";
+import { useVaultRewards } from "@/hooks/use-vault-rewards";
 
 const ZERO = "0x0000000000000000000000000000000000000000";
 const LOOT_MIN_MOR = 0.0001; // ignore dust
@@ -40,11 +42,15 @@ export function MorLootbox() {
   const position = useMorpheusPosition(you, nonce);
   const morpheus = useMorpheusStake();
   const { distribute, collect, isBusy: distributing, collecting } = useMorDistribute();
+  // Morpho (USDC vault) yield — the OTHER reward type, claimable per rider vault.
+  const { claimRewards, isStaking: claimingVault } = useStakeDeposit();
+  const vaultRewards = useVaultRewards(you, nonce);
 
   const [open, setOpen] = useState(false);
   const [splitBalances, setSplitBalances] = useState<Partial<Record<MorpheusAsset, number>>>({});
   const [collectItems, setCollectItems] = useState<{ owner: Address; amount: number }[]>([]);
   const [busyAsset, setBusyAsset] = useState<MorpheusAsset | null>(null);
+  const [busyVault, setBusyVault] = useState<string | null>(null);
   // Read the clock once at mount (a lazy initializer is pure-in-render safe) —
   // the 7-day unlock doesn't need a live tick; a refresh re-reads it.
   const [nowSec] = useState(() => Math.floor(Date.now() / 1000));
@@ -89,9 +95,12 @@ export function MorLootbox() {
   const claimable = pools.filter((p) => p.pendingMor > LOOT_MIN_MOR && p.referrer && p.referrer.toLowerCase() !== ZERO);
   const distributable = pools.filter((p) => (splitBalances[p.asset] ?? 0) > LOOT_MIN_MOR);
   const stakedPools = pools.filter((p) => p.staked > 0);
-  // The box surfaces whenever there's any MOR to act on — rewards to claim,
-  // distribute or collect, OR a principal position to manage (7-day lock).
-  const hasAction = claimable.length > 0 || distributable.length > 0 || collectable > LOOT_MIN_MOR || stakedPools.length > 0;
+  // The box surfaces whenever there's anything to act on — MOR rewards (claim,
+  // distribute, collect), Morpho vault yield to harvest, OR a principal position
+  // to manage (7-day lock).
+  const hasAction =
+    claimable.length > 0 || distributable.length > 0 || collectable > LOOT_MIN_MOR ||
+    vaultRewards.length > 0 || stakedPools.length > 0;
 
   const refresh = () => setNonce((n) => n + 1);
 
@@ -143,6 +152,22 @@ export function MorLootbox() {
     [collectItems, collect, t],
   );
 
+  // Harvest a rider vault's Morpho yield — withdraws only the earned amount,
+  // leaving the principal. USDC on Base; one click, no stepper.
+  const onClaimVault = useCallback(
+    async (vault: Address, earnedRaw: bigint) => {
+      setBusyVault(vault);
+      try {
+        const ok = await claimRewards(vault, earnedRaw);
+        if (ok) { toast.success(t("lootbox.vaultClaimed")); refresh(); }
+        else toast.error(t("lootbox.failed"));
+      } finally {
+        setBusyVault(null);
+      }
+    },
+    [claimRewards, t],
+  );
+
   const onWithdraw = useCallback(
     async (asset: MorpheusAsset, staked: number) => {
       setBusyAsset(asset);
@@ -170,9 +195,12 @@ export function MorLootbox() {
           claimable={claimable}
           distributable={distributable}
           collectable={collectable}
+          vaultRewards={vaultRewards}
           stakedPools={stakedPools}
           splitBalances={splitBalances}
           busyAsset={busyAsset}
+          busyVault={busyVault}
+          claimingVault={claimingVault}
           morpheusBusy={morpheus.isBusy}
           morpheusPhase={morpheus.phase}
           distributing={distributing}
@@ -181,6 +209,7 @@ export function MorLootbox() {
           onClaim={onClaim}
           onDistribute={onDistribute}
           onCollect={onCollect}
+          onClaimVault={onClaimVault}
           onWithdraw={onWithdraw}
           onClose={() => setOpen(false)}
         />

--- a/src/components/stake/RewardClaimModal.tsx
+++ b/src/components/stake/RewardClaimModal.tsx
@@ -12,6 +12,7 @@ import { type Address } from "viem";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import type { MorpheusPoolPosition } from "@/hooks/use-morpheus-position";
+import type { VaultReward } from "@/hooks/use-vault-rewards";
 import type { MorpheusAsset } from "@/lib/morpheus";
 
 // The r3f Canvas is client-only and heavy — load it only when the modal mounts.
@@ -37,9 +38,12 @@ interface Props {
   claimable: MorpheusPoolPosition[];
   distributable: MorpheusPoolPosition[];
   collectable: number;
+  vaultRewards: VaultReward[];
   stakedPools: MorpheusPoolPosition[];
   splitBalances: Partial<Record<MorpheusAsset, number>>;
   busyAsset: MorpheusAsset | null;
+  busyVault: string | null;
+  claimingVault: boolean;
   morpheusBusy: boolean;
   morpheusPhase: string;
   distributing: boolean;
@@ -48,14 +52,15 @@ interface Props {
   onClaim: (asset: MorpheusAsset, referrer: Address) => void;
   onDistribute: (asset: MorpheusAsset, referrer: Address) => void;
   onCollect: () => void;
+  onClaimVault: (vault: Address, earnedRaw: bigint) => void;
   onWithdraw: (asset: MorpheusAsset, staked: number) => void;
   onClose: () => void;
 }
 
 export function RewardClaimModal({
-  claimable, distributable, collectable, stakedPools, splitBalances,
-  busyAsset, morpheusBusy, morpheusPhase, distributing, collecting, nowSec,
-  onClaim, onDistribute, onCollect, onWithdraw, onClose,
+  claimable, distributable, collectable, vaultRewards, stakedPools, splitBalances,
+  busyAsset, busyVault, claimingVault, morpheusBusy, morpheusPhase, distributing, collecting, nowSec,
+  onClaim, onDistribute, onCollect, onClaimVault, onWithdraw, onClose,
 }: Props) {
   const t = useTranslations("stake");
 
@@ -193,10 +198,29 @@ export function RewardClaimModal({
               </div>
             )}
 
-            {claimable.length === 0 && distributable.length === 0 && collectable === 0 && (
+            {claimable.length === 0 && distributable.length === 0 && collectable === 0 && vaultRewards.length === 0 && (
               <p className="rounded-lg border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">{t("lootbox.allCollected")}</p>
             )}
           </div>
+
+          {/* Morpho vault yield — the other reward type: one-click harvest per rider vault (USDC on Base) */}
+          {vaultRewards.length > 0 && (
+            <div className="border-t pt-3">
+              <p className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">{t("lootbox.morphoTitle")}</p>
+              <div className="space-y-2">
+                {vaultRewards.map((v) => (
+                  <div key={`v-${v.vault}`} className="flex items-center justify-between gap-2 rounded-lg border bg-muted/40 px-3 py-2">
+                    <span className="text-xs text-muted-foreground">
+                      <b className="font-mono text-foreground">{v.earned.toLocaleString(undefined, { maximumFractionDigits: 4 })}</b> USDC · {v.riderId}
+                    </span>
+                    <Button size="sm" disabled={busyVault === v.vault && claimingVault} onClick={() => onClaimVault(v.vault, v.earnedRaw)} className="h-7">
+                      {busyVault === v.vault && claimingVault ? t("lootbox.claiming") : t("lootbox.claimYield")}
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
 
           {/* Principal positions (withdraw after 7-day lock) */}
           {stakedPools.length > 0 && (

--- a/src/hooks/use-vault-rewards.ts
+++ b/src/hooks/use-vault-rewards.ts
@@ -1,0 +1,110 @@
+"use client";
+
+// Claimable Morpho yield across every rider sponsorship vault, so the reward
+// panel can surface a "claim yield" per vault alongside the MOR rewards.
+// earned = convertToAssets(shares) − principal, where principal is rebuilt from
+// the account's Deposit/Withdraw events (same as the stake dialog).
+//
+// Guarded: if the principal read fails (Blockscout hiccup) it returns 0, which
+// would make the whole position look like yield — so we SKIP any vault whose
+// principal we couldn't confirm, rather than offer to withdraw the principal.
+
+import { useEffect, useState } from "react";
+import { createPublicClient, http, fallback, formatUnits, type Address } from "viem";
+import { base } from "viem/chains";
+import { RIDERS, type RiderId } from "@/lib/gnars-vaults";
+
+const client = createPublicClient({
+  chain: base,
+  transport: fallback([
+    http("https://mainnet.base.org"),
+    http("https://base-rpc.publicnode.com"),
+    http("https://base.drpc.org"),
+  ]),
+});
+
+const abi = [
+  { type: "function", name: "balanceOf", stateMutability: "view", inputs: [{ type: "address" }], outputs: [{ type: "uint256" }] },
+  { type: "function", name: "convertToAssets", stateMutability: "view", inputs: [{ type: "uint256" }], outputs: [{ type: "uint256" }] },
+] as const;
+
+type DecodedParam = { name?: string; value?: unknown };
+type LogItem = { decoded?: { method_call?: string; parameters?: DecodedParam[] } | null };
+
+/** Net principal an account put in: sum of its Deposit assets minus Withdraw assets. */
+async function principalFromLogs(vault: Address, account: string): Promise<bigint> {
+  try {
+    const res = await fetch(`https://base.blockscout.com/api/v2/addresses/${vault}/logs`, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(9000),
+    });
+    if (!res.ok) return BigInt(0);
+    const json = (await res.json()) as { items?: LogItem[] };
+    const me = account.toLowerCase();
+    let principal = BigInt(0);
+    for (const log of json.items ?? []) {
+      const call = log.decoded?.method_call ?? "";
+      const params = log.decoded?.parameters ?? [];
+      const owner = params.find((p) => p.name === "owner")?.value;
+      if (typeof owner !== "string" || owner.toLowerCase() !== me) continue;
+      const assets = params.find((p) => p.name === "assets")?.value;
+      if (typeof assets !== "string" && typeof assets !== "number") continue;
+      const amt = BigInt(assets);
+      if (call.startsWith("Deposit(")) principal += amt;
+      else if (call.startsWith("Withdraw(")) principal -= amt;
+    }
+    return principal > BigInt(0) ? principal : BigInt(0);
+  } catch {
+    return BigInt(0);
+  }
+}
+
+export type VaultReward = {
+  riderId: RiderId;
+  vault: Address;
+  /** USDC micro-units, for the claim (withdraw) call. */
+  earnedRaw: bigint;
+  /** USDC. */
+  earned: number;
+};
+
+const DUST = BigInt(100); // 0.0001 USDC in 6-dec units
+
+export function useVaultRewards(account?: string, nonce = 0): VaultReward[] {
+  const [items, setItems] = useState<VaultReward[]>([]);
+
+  useEffect(() => {
+    if (!account) { setItems([]); return; }
+    let cancelled = false;
+    (async () => {
+      const riders = Object.values(RIDERS).filter((r): r is Rider & { vault: Address } => Boolean(r.vault));
+      // Cheap first pass — only the vaults where the wallet actually holds shares
+      // are worth the (costlier) earned computation.
+      const shares = await Promise.all(
+        riders.map((r) =>
+          client.readContract({ address: r.vault, abi, functionName: "balanceOf", args: [account as Address] }).catch(() => BigInt(0)),
+        ),
+      );
+      const held = riders.map((r, i) => ({ r, shares: shares[i] })).filter((x) => x.shares > BigInt(0));
+
+      const out: VaultReward[] = [];
+      for (const { r, shares: sh } of held) {
+        const [current, principal] = await Promise.all([
+          client.readContract({ address: r.vault, abi, functionName: "convertToAssets", args: [sh] }).catch(() => BigInt(0)),
+          principalFromLogs(r.vault, account),
+        ]);
+        if (principal > BigInt(0) && current > principal) {
+          const earnedRaw = current - principal;
+          if (earnedRaw > DUST) out.push({ riderId: r.id, vault: r.vault, earnedRaw, earned: Number(formatUnits(earnedRaw, 6)) });
+        }
+      }
+      if (!cancelled) setItems(out);
+    })();
+    return () => { cancelled = true; };
+  }, [account, nonce]);
+
+  return items;
+}
+
+// Local alias so the type-guard predicate reads cleanly.
+type Rider = (typeof RIDERS)[RiderId];


### PR DESCRIPTION
## What
The reward panel (lootbox) now shows **both** reward types: the MOR flow (claim → bridge → distribute → collect) **and** the Morpho USDC vault yield (one-click harvest per rider vault).

## How
- **use-vault-rewards** (new hook): reads the wallet's claimable yield in each rider vault (`balanceOf → convertToAssets − principal`, principal rebuilt from Deposit/Withdraw events — same math as the stake dialog). **Guard:** if the principal read fails (Blockscout hiccup) it returns 0, which would make the whole position look like yield — so we **skip** any vault whose principal we couldn't confirm rather than offer to withdraw the principal.
- **MorLootbox:** folds `vaultRewards` + `claimRewards` (from `useStakeDeposit`) into the panel; `onClaimVault` withdraws only the earned amount, leaving principal. Reads key off the EOA (`useUserAddress`), matching where deposits live.
- **RewardClaimModal:** new "Morpho yield" section with a Harvest button per vault.

`tsc` + `eslint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)