### PR TITLE
feat(newhome): hero headline rewrite, PT-BR voice, tighter mobile

### DIFF
--- a/messages/en/newhome.json
+++ b/messages/en/newhome.json
@@ -1,15 +1,13 @@
 {
   "hero": {
     "onAir": "On air · Gnars TV",
-    "title": "Open action sports brand.",
-    "leadPrefix": "Gnars is a headless brand run by the people who skate it.",
+    "title": "Gnars is a headless brand run by its shredders",
     "ctaStake": "Back a rider",
     "ctaBounties": "See open bounties",
     "stats": {
-      "totalGnars": "Total Gnars",
       "members": "Members",
       "treasury": "Treasury",
-      "rails": "NogglesRails"
+      "rails": "Sculptures"
     }
   },
   "ticker": {

--- a/messages/pt-br/newhome.json
+++ b/messages/pt-br/newhome.json
@@ -1,15 +1,13 @@
 {
   "hero": {
     "onAir": "No ar · Gnars TV",
-    "title": "Esportes de ação, dos próprios riders.",
-    "leadPrefix": "Gnars é uma marca headless tocada por quem anda de skate.",
+    "title": "Na Gnars, quem manda é quem anda",
     "ctaStake": "Apoie um rider",
     "ctaBounties": "Ver bounties abertas",
     "stats": {
-      "totalGnars": "Total de Gnars",
       "members": "Membros",
       "treasury": "Tesouro",
-      "rails": "NogglesRails"
+      "rails": "Esculturas"
     }
   },
   "ticker": {

--- a/src/app/[locale]/newhome/page.tsx
+++ b/src/app/[locale]/newhome/page.tsx
@@ -58,8 +58,10 @@ export default async function NewHome({ params }: { params: Promise<{ locale: st
     treasury.usdTotal == null ? "—" : `$${formatLargeNumber(treasury.usdTotal)}`;
   const railCount = NOGGLES_RAILS.length;
 
+  // No total-supply tile: `ownerCount` is the subgraph's distinct-owner count,
+  // so Members already answers "how many people are in this" — the supply number
+  // beside it just read as a second, larger membership figure.
   const heroStats: HeroStat[] = [
-    { value: String(daoStats.totalSupply), label: t("hero.stats.totalGnars"), icon: "gnars" },
     { value: String(daoStats.ownerCount), label: t("hero.stats.members"), icon: "members" },
     { value: treasuryLabel, label: t("hero.stats.treasury"), icon: "treasury" },
     { value: String(railCount), label: t("hero.stats.rails"), icon: "rails" },
@@ -72,9 +74,8 @@ export default async function NewHome({ params }: { params: Promise<{ locale: st
           would add a horizontal scrollbar on every platform that reserves one. */}
       <div aria-hidden className="fixed inset-0 -z-10 bg-[#0a0a0a]" />
 
-      <TVHeroSection />
-
       <HeroSection stats={heroStats} />
+      <TVHeroSection />
 
       <StakeSection />
       <Interlude eyebrow={t("stake.whyEyebrow")}>{t("stake.whyBody")}</Interlude>

--- a/src/components/newhome/BountiesSection.tsx
+++ b/src/components/newhome/BountiesSection.tsx
@@ -167,7 +167,7 @@ export function BountiesSection({
   };
 
   return (
-    <section id="bounties" className="px-6 py-18">
+    <section id="bounties" className="px-4 py-10 sm:px-6 sm:py-18">
       <div className={`${SHELL} flex flex-col gap-6 px-0`}>
         <SectionHeading
           eyebrow={

--- a/src/components/newhome/GovSection.tsx
+++ b/src/components/newhome/GovSection.tsx
@@ -46,7 +46,7 @@ export async function GovSection() {
   const t = await getTranslations("newhome.gov");
 
   return (
-    <section id="gov" className="px-6 pb-22 pt-18">
+    <section id="gov" className="px-4 pb-12 pt-10 sm:px-6 sm:pb-22 sm:pt-18">
       <div className={`${SHELL} flex flex-col gap-6 px-0`}>
         <div className="flex flex-col gap-2.5">
           <Eyebrow>{t("eyebrow")}</Eyebrow>

--- a/src/components/newhome/HeroSection.tsx
+++ b/src/components/newhome/HeroSection.tsx
@@ -1,5 +1,5 @@
 import { getTranslations } from "next-intl/server";
-import { Map, TrendingUp, Trophy, Users } from "lucide-react";
+import { Map, TrendingUp, Users } from "lucide-react";
 import { Link } from "@/i18n/navigation";
 import { HeroTagline } from "./HeroTagline";
 import { SHELL } from "./primitives";
@@ -7,11 +7,10 @@ import { SHELL } from "./primitives";
 export interface HeroStat {
   value: string;
   label: string;
-  icon: "gnars" | "members" | "treasury" | "rails";
+  icon: "members" | "treasury" | "rails";
 }
 
 const ICONS = {
-  gnars: { Icon: Trophy, bg: "bg-purple-900/30", fg: "text-purple-400" },
   members: { Icon: Users, bg: "bg-blue-900/30", fg: "text-blue-400" },
   treasury: { Icon: TrendingUp, bg: "bg-green-900/30", fg: "text-green-400" },
   rails: { Icon: Map, bg: "bg-red-900/30", fg: "text-red-400" },
@@ -25,13 +24,19 @@ export async function HeroSection({ stats }: { stats: HeroStat[] }) {
       id="top"
       className="relative bg-[radial-gradient(90%_55%_at_50%_10%,rgba(217,70,239,.1)_0%,rgba(217,70,239,0)_60%)]"
     >
-      <div className={`${SHELL} flex flex-col items-center gap-3.5 pb-18 pt-12 text-center`}>
-        <h1 className="bg-[linear-gradient(90deg,#fafafa,rgba(250,250,250,.8))] bg-clip-text text-[clamp(2.75rem,7vw,6.75rem)] font-extrabold leading-[0.94] tracking-[-0.03em] text-transparent">
+      <div
+        className={`${SHELL} flex flex-col items-center gap-3.5 pb-10 pt-7 text-center sm:pb-18 sm:pt-12`}
+      >
+        {/* Sized down from the display setting the shorter headline used: this
+            sentence is twice the length, and at the old clamp it ran to five
+            lines before the fold. `text-balance` keeps the wrap even. */}
+        <h1 className="text-balance bg-[linear-gradient(90deg,#fafafa,rgba(250,250,250,.8))] bg-clip-text text-[clamp(2.25rem,5.5vw,4.75rem)] font-extrabold leading-[1] tracking-[-0.03em] text-transparent">
           {t("title")}
         </h1>
 
-        <p className="max-w-[32em] text-pretty text-lg leading-[1.55] text-neutral-400">
-          {t("leadPrefix")} <HeroTagline />
+        {/* HeroTagline reserves its own height against layout shift. */}
+        <p className="max-w-[32em] text-pretty text-[clamp(1.0625rem,2.2vw,1.5rem)] leading-[1.45] text-neutral-400">
+          <HeroTagline />
         </p>
 
         <div className="mt-1.5 flex flex-wrap justify-center gap-2.5">

--- a/src/components/newhome/HeroTagline.tsx
+++ b/src/components/newhome/HeroTagline.tsx
@@ -10,19 +10,31 @@ import TextType from "@/components/TextType";
 export function HeroTagline() {
   const t = useTranslations("home.hero");
   const descriptions = t.raw("descriptions") as readonly string[];
+  const longest = descriptions.reduce((a, b) => (b.length > a.length ? b : a), "");
 
   return (
-    <TextType
-      text={[...descriptions]}
-      as="span"
-      className="font-medium text-neutral-50"
-      typingSpeed={75}
-      deletingSpeed={50}
-      pauseDuration={1800}
-      showCursor
-      cursorCharacter="_"
-      cursorBlinkDuration={0.5}
-      loop
-    />
+    // The tagline types and deletes itself, so its box would grow and shrink and
+    // shove the buttons and stats down the page on every rotation. A hidden copy
+    // of the longest line shares the single grid cell and holds the height open.
+    // Stacking rather than a fixed min-height means the reservation is exactly
+    // right at any width — one line on desktop, two once the copy wraps — with
+    // no dead space at either end.
+    <span className="grid">
+      <span aria-hidden className="invisible col-start-1 row-start-1">
+        {longest}
+      </span>
+      <TextType
+        text={[...descriptions]}
+        as="span"
+        className="col-start-1 row-start-1 font-medium text-neutral-50"
+        typingSpeed={75}
+        deletingSpeed={50}
+        pauseDuration={1800}
+        showCursor
+        cursorCharacter="_"
+        cursorBlinkDuration={0.5}
+        loop
+      />
+    </span>
   );
 }

--- a/src/components/newhome/RailsSection.tsx
+++ b/src/components/newhome/RailsSection.tsx
@@ -33,7 +33,7 @@ export function RailsSection() {
   }, []);
 
   return (
-    <section id="rails" className="px-6 py-18">
+    <section id="rails" className="px-4 py-10 sm:px-6 sm:py-18">
       <div className={`${SHELL} flex flex-col gap-6 px-0`}>
         <SectionHeading
           eyebrow={t("eyebrow")}

--- a/src/components/newhome/StakeSection.tsx
+++ b/src/components/newhome/StakeSection.tsx
@@ -15,7 +15,7 @@ export async function StakeSection() {
   const t = await getTranslations("newhome.stake");
 
   return (
-    <section id="stake" className="px-6 pb-18 pt-22">
+    <section id="stake" className="px-4 pb-10 pt-12 sm:px-6 sm:pb-18 sm:pt-22">
       <div className={`${SHELL} flex flex-col gap-7 px-0`}>
         <SectionHeading
           eyebrow={t("eyebrow")}

--- a/src/components/newhome/SwapSection.tsx
+++ b/src/components/newhome/SwapSection.tsx
@@ -18,7 +18,7 @@ export async function SwapSection() {
   ];
 
   return (
-    <section id="swap" className="px-6 py-18">
+    <section id="swap" className="px-4 py-10 sm:px-6 sm:py-18">
       <div
         className={`${SHELL} grid grid-cols-1 items-center gap-11 px-0 lg:grid-cols-[1fr_440px]`}
       >

--- a/src/components/newhome/primitives.tsx
+++ b/src/components/newhome/primitives.tsx
@@ -11,7 +11,7 @@ import { cn } from "@/lib/utils";
  */
 
 /** Page ground + max width used by every section. */
-export const SHELL = "mx-auto w-full max-w-6xl px-6";
+export const SHELL = "mx-auto w-full max-w-6xl px-4 sm:px-6";
 
 /** Small caps eyebrow above a section title. */
 export function Eyebrow({ children, className }: { children: ReactNode; className?: string }) {
@@ -102,7 +102,7 @@ export function Interlude({
   children: ReactNode;
 }) {
   return (
-    <section className="bg-[#0a0a0a] px-6 py-9">
+    <section className="bg-[#0a0a0a] px-4 py-6 sm:px-6 sm:py-9">
       <div className="mx-auto flex max-w-[640px] flex-col gap-1.5 text-center">
         <span
           className={cn(

--- a/src/components/tv/GnarsTVSet.tsx
+++ b/src/components/tv/GnarsTVSet.tsx
@@ -1122,8 +1122,10 @@ export function GnarsTVSet({ channels, ticker }: GnarsTVSetProps) {
               ))}
             </span>
 
-            {/* Right cluster */}
-            <span className="flex flex-wrap items-end gap-3 sm:ml-auto sm:gap-4">
+            {/* Right cluster. Below `sm` the deck wraps and this takes a row of
+                its own, so it claims the full width and centres — left-aligned
+                it sat under the nameplate with a ragged gap down the right. */}
+            <span className="flex w-full flex-wrap items-end justify-center gap-3 sm:ml-auto sm:w-auto sm:justify-start sm:gap-4">
               <span className="flex flex-col items-center gap-[7px]">
                 <span
                   className="flex gap-2"


### PR DESCRIPTION
## Summary

- Hero headline is now the brand sentence, with the typing tagline standing alone beneath it.
- PT-BR gets its own line rather than a translation — `Na Gnars, quem manda é quem anda`, written for the BR audience.
- Mobile padding scaled down across every `/newhome` section; TV control deck centres when it wraps.

## Changes

- `messages/{en,pt-br}/newhome.json` — new `hero.title` per locale, `stats.rails` → Sculptures/Esculturas, `stats.totalGnars` removed
- `HeroSection.tsx` — display clamp 6.75rem → 4.75rem (the sentence is twice as long as the copy the old size was tuned for), `text-balance`, mobile padding
- `HeroTagline.tsx` — reserves its own height with a hidden copy of the longest string, so the type/delete cycle no longer shifts the page
- `newhome/page.tsx` — total-supply tile dropped; `ownerCount` is the subgraph's distinct-owner count, so Members already answers it
- `primitives.tsx`, `Bounties/Gov/Rails/Stake/Swap` sections — mobile padding 72–88px → 40–48px vertical, 24px → 16px horizontal, desktop rhythm restored at `sm`
- `GnarsTVSet.tsx` — control cluster takes a full row and centres below `sm`

## Test plan

- [x] `pnpm build` exits 0
- [x] `pnpm lint` — 0 errors (1 pre-existing warning in `BountiesView.tsx`)
- [x] Headline wraps 2 lines desktop / 2–3 mobile, EN + PT-BR, no horizontal overflow at 360/390/768/1440
- [x] Tagline box measured stable across a full type/delete cycle (35px desktop, 49px mobile, both locales)
- [x] TV control rows measured `left=29 / right=29` at 390px — centred

Generated with [Claude Code](https://claude.com/claude-code)