### PR TITLE
feat(rails): NogglesRail globe module + site-wide rewards lootbox

### DIFF
--- a/messages/en/newhome.json
+++ b/messages/en/newhome.json
@@ -118,7 +118,27 @@
     },
     "readProposal": "Read the proposal →",
     "whyEyebrow": "Why the map matters",
-    "whyBody": "Every pin is a proposal that passed and a crew that showed up. CC0 means anyone can build the next one — no license, no permission needed."
+    "whyBody": "Every pin is a proposal that passed and a crew that showed up. CC0 means anyone can build the next one — no license, no permission needed.",
+    "filters": {
+      "all": "All",
+      "americas": "Americas",
+      "europe": "Europe",
+      "africa": "Africa",
+      "asia": "Asia",
+      "oceania": "Oceania"
+    },
+    "mono": {
+      "installed": "INSTALLED",
+      "countries": "COUNTRIES",
+      "continents": "CONTINENTS"
+    },
+    "selected": "SELECTED",
+    "photoTag": "Photo · on site",
+    "renderTag": "3D render",
+    "prevPhoto": "Previous photo",
+    "nextPhoto": "Next photo",
+    "goToPhoto": "Go to photo {n}",
+    "viewInstallation": "View full installation ↗"
   },
   "swap": {
     "eyebrow": "Money · Swap",

--- a/messages/en/stake.json
+++ b/messages/en/stake.json
@@ -187,7 +187,8 @@
     "inWarehouse": "in the Warehouse",
     "morphoTitle": "Morpho yield",
     "claimYield": "Harvest",
-    "vaultClaimed": "Yield harvested to your wallet"
+    "vaultClaimed": "Yield harvested to your wallet",
+    "enableRewards": "Enable rewards"
   },
   "admin": {
     "title": "Sponsorship vaults",

--- a/messages/pt-br/newhome.json
+++ b/messages/pt-br/newhome.json
@@ -118,7 +118,27 @@
     },
     "readProposal": "Ler a proposta →",
     "whyEyebrow": "Por que o mapa importa",
-    "whyBody": "Cada pin é uma proposta que passou e uma galera que apareceu. CC0 significa que qualquer pessoa pode construir a próxima — sem licença, sem pedir permissão."
+    "whyBody": "Cada pin é uma proposta que passou e uma galera que apareceu. CC0 significa que qualquer pessoa pode construir a próxima — sem licença, sem pedir permissão.",
+    "filters": {
+      "all": "Todos",
+      "americas": "Américas",
+      "europe": "Europa",
+      "africa": "África",
+      "asia": "Ásia",
+      "oceania": "Oceania"
+    },
+    "mono": {
+      "installed": "INSTALADOS",
+      "countries": "PAÍSES",
+      "continents": "CONTINENTES"
+    },
+    "selected": "SELECIONADO",
+    "photoTag": "Foto · no local",
+    "renderTag": "Render 3D",
+    "prevPhoto": "Foto anterior",
+    "nextPhoto": "Próxima foto",
+    "goToPhoto": "Ir para a foto {n}",
+    "viewInstallation": "Ver instalação completa ↗"
   },
   "swap": {
     "eyebrow": "Dinheiro · Swap",

--- a/messages/pt-br/stake.json
+++ b/messages/pt-br/stake.json
@@ -187,7 +187,8 @@
     "inWarehouse": "no Warehouse",
     "morphoTitle": "Yield Morpho",
     "claimYield": "Colher",
-    "vaultClaimed": "Yield colhido na carteira"
+    "vaultClaimed": "Yield colhido na carteira",
+    "enableRewards": "Ativar recompensas"
   },
   "admin": {
     "title": "Cofres de patrocínio",

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -12,6 +12,7 @@ import { FooterBar } from "@/components/layout/FooterBar";
 import Providers from "@/components/layout/Providers";
 import { ScrollToTop } from "@/components/layout/ScrollToTop";
 import { MiniAppReady } from "@/components/miniapp/MiniAppReady";
+import { GlobalRewardsLootbox } from "@/components/stake/GlobalRewardsLootbox";
 import { MiniTV } from "@/components/tv/MiniTV";
 import { MiniTVVisibilityProvider } from "@/components/tv/MiniTVVisibilityContext";
 import { Toaster } from "@/components/ui/sonner";
@@ -123,6 +124,7 @@ export default async function LocaleLayout({
                   <FooterBar />
                   <Toaster />
                   <MiniTV />
+                  <GlobalRewardsLootbox />
                 </MiniTVVisibilityProvider>
               </TooltipProvider>
             </Providers>

--- a/src/app/[locale]/newhome/page.tsx
+++ b/src/app/[locale]/newhome/page.tsx
@@ -90,10 +90,10 @@ export default async function NewHome({ params }: { params: Promise<{ locale: st
         {t("rails.whyBody")}
       </Interlude>
 
+      <GovSection />
+
       <SwapSection />
       <Interlude eyebrow={t("swap.whyEyebrow")}>{t("swap.whyBody")}</Interlude>
-
-      <GovSection />
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -256,6 +256,20 @@
   }
 }
 
+/* NogglesRail globe — the selected pin's halo. Declared here so the
+   reduced-motion block at the foot of this file neutralises it. */
+@keyframes rail-pin-pulse {
+  0%,
+  100% {
+    transform: translate(-50%, -50%) scale(1.25);
+    opacity: 0.75;
+  }
+  50% {
+    transform: translate(-50%, -50%) scale(1.75);
+    opacity: 0.25;
+  }
+}
+
 /* Bounty trading cards — foil shine, sparkle twinkle and the poidh seal's
    holographic hue cycle. Separate names from the `gnars-*` set above because the
    sweep travels further and skews rather than rotating. The reduced-motion block

--- a/src/components/newhome/AuctionPanel.tsx
+++ b/src/components/newhome/AuctionPanel.tsx
@@ -119,7 +119,7 @@ export function AuctionPanel() {
   const noop = useCallback(() => {}, []);
 
   return (
-    <div className="flex flex-col gap-4 rounded-2xl border border-[#f7c948]/25 bg-[linear-gradient(180deg,#181410,#0f0d0b)] p-5 shadow-[0_0_0_1px_rgba(0,0,0,.4),0_20px_50px_rgba(0,0,0,.35)]">
+    <div className="flex h-full flex-col gap-4 rounded-2xl border border-[#f7c948]/25 bg-[linear-gradient(180deg,#181410,#0f0d0b)] p-5 shadow-[0_0_0_1px_rgba(0,0,0,.4),0_20px_50px_rgba(0,0,0,.35)]">
       {/* Badge + countdown */}
       <div className="flex items-center justify-between gap-3">
         {/* The badge tracks the clock. Between an auction ending and someone

--- a/src/components/newhome/GovSection.tsx
+++ b/src/components/newhome/GovSection.tsx
@@ -55,10 +55,10 @@ export async function GovSection() {
           </h2>
         </div>
 
-        <div className="grid grid-cols-1 items-start gap-5 lg:grid-cols-2">
+        <div className="grid grid-cols-1 items-stretch gap-5 lg:grid-cols-2">
           <AuctionPanel />
 
-          <div className="flex min-w-0 flex-col gap-4 rounded-2xl border border-white/10 bg-neutral-900 p-5">
+          <div className="flex h-full min-w-0 flex-col gap-4 rounded-2xl border border-white/10 bg-neutral-900 p-5">
             <Suspense fallback={<RecentProposalsSkeleton />}>
               <Proposals />
             </Suspense>

--- a/src/components/newhome/RailsSection.tsx
+++ b/src/components/newhome/RailsSection.tsx
@@ -1,22 +1,13 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useTranslations } from "next-intl";
-import { NogglesRailsGlobe } from "@/components/nogglesrails/NogglesRailsGlobe";
-import { NOGGLES_RAILS, type NogglesRailLocation } from "@/content/nogglesrails";
-import { Link } from "@/i18n/navigation";
-import { cn } from "@/lib/utils";
+import { RailGlobeSection } from "@/components/nogglesrails/RailGlobeSection";
+import { NOGGLES_RAILS } from "@/content/nogglesrails";
 import { SectionHeading, SHELL, StatTile } from "./primitives";
-
-/** First paragraph only — the full description belongs on the rail's own page. */
-function lede(rail: NogglesRailLocation): string {
-  return rail.description.split("\n\n")[0];
-}
 
 export function RailsSection() {
   const t = useTranslations("newhome.rails");
-  const [index, setIndex] = useState(0);
-  const active = NOGGLES_RAILS[index];
 
   const stats = useMemo(
     () => ({
@@ -26,11 +17,6 @@ export function RailsSection() {
     }),
     [],
   );
-
-  const handleSelect = useCallback((rail: NogglesRailLocation) => {
-    const i = NOGGLES_RAILS.findIndex((r) => r.slug === rail.slug);
-    if (i >= 0) setIndex(i);
-  }, []);
 
   return (
     <section id="rails" className="px-4 py-10 sm:px-6 sm:py-18">
@@ -48,79 +34,7 @@ export function RailsSection() {
           }
         />
 
-        <div className="grid grid-cols-1 items-stretch gap-5 lg:grid-cols-[1.35fr_1fr]">
-          <div className="relative min-h-[420px] overflow-hidden rounded-xl border border-white/10 bg-[#0f1114] bg-[radial-gradient(70%_60%_at_50%_45%,rgba(102,153,204,.12),rgba(10,10,10,0)_70%)] lg:min-h-[540px]">
-            <NogglesRailsGlobe
-              focusSlug={active.slug}
-              onSelectRail={handleSelect}
-              className="h-full min-h-[420px] w-full lg:min-h-[540px]"
-            />
-            <span className="pointer-events-none absolute left-4.5 top-4 text-[11px] font-medium uppercase tracking-[0.08em] text-neutral-400">
-              {t("hint")}
-            </span>
-          </div>
-
-          <div className="flex flex-col gap-3.5 rounded-xl border border-white/10 bg-neutral-900 p-5.5">
-            <div>
-              <span className="text-[11.5px] font-semibold uppercase tracking-[0.1em] text-[#6699cc]">
-                {active.type} · {active.continent}
-              </span>
-              <h3 className="mt-1.5 text-[28px] font-extrabold leading-[1.05] text-neutral-50">
-                {active.label}
-              </h3>
-              <p className="mt-1 text-sm text-neutral-400">
-                {active.city}, {active.country}
-              </p>
-            </div>
-
-            <p className="line-clamp-4 text-pretty text-[13.5px] leading-[1.6] text-neutral-400">
-              {lede(active)}
-            </p>
-
-            <div className="flex flex-wrap gap-1.5">
-              <a
-                href={active.proposal.link}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="rounded-md border border-white/10 bg-neutral-800/60 px-2.5 py-1 text-xs font-medium text-neutral-400 hover:text-neutral-50"
-              >
-                {active.proposal.name}
-              </a>
-              <span className="rounded-md border border-white/10 bg-neutral-800/60 px-2.5 py-1 font-mono text-[11.5px] text-neutral-400">
-                {active.position[0].toFixed(2)}, {active.position[1].toFixed(2)}
-              </span>
-              <Link
-                href={`/nogglesrails/${active.slug}`}
-                className="rounded-md border border-white/10 bg-neutral-800/60 px-2.5 py-1 text-xs font-medium text-neutral-400 hover:text-neutral-50"
-              >
-                {t("readProposal")}
-              </Link>
-            </div>
-
-            <div className="grid flex-1 auto-rows-min grid-cols-2 gap-1.5 overflow-hidden">
-              {NOGGLES_RAILS.map((rail, i) => (
-                <button
-                  key={rail.slug}
-                  type="button"
-                  onClick={() => setIndex(i)}
-                  className={cn(
-                    "rounded-lg border px-2.5 py-2 text-left",
-                    i === index
-                      ? "border-neutral-50/40 bg-neutral-800"
-                      : "border-white/[0.08] bg-neutral-800/35 hover:border-white/20",
-                  )}
-                >
-                  <span className="block truncate text-[13px] font-semibold text-neutral-100">
-                    {rail.label}
-                  </span>
-                  <span className="block truncate text-[11px] text-neutral-400">
-                    {rail.country}
-                  </span>
-                </button>
-              ))}
-            </div>
-          </div>
-        </div>
+        <RailGlobeSection />
       </div>
     </section>
   );

--- a/src/components/nogglesrails/NogglesRailsGlobe.tsx
+++ b/src/components/nogglesrails/NogglesRailsGlobe.tsx
@@ -15,6 +15,7 @@ interface GlobePoint {
   type: string;
   iconUrl: string;
   iconSize: [number, number];
+  selected: boolean;
   rail: NogglesRailLocation;
 }
 
@@ -31,18 +32,28 @@ interface NogglesRailsGlobeProps {
   onSelectRail?: (rail: NogglesRailLocation) => void;
   /** Overrides the default `h-[60vh] min-h-[350px]` frame. */
   className?: string;
+  /** Idle spin. Forced off while a rail is in focus, and under reduced motion. */
+  autoRotate?: boolean;
+  /** Multiplier on the idle spin rate. */
+  spinSpeed?: number;
 }
 
 export function NogglesRailsGlobe({
   focusSlug,
   onSelectRail,
   className,
+  autoRotate = true,
+  spinSpeed = 1,
 }: NogglesRailsGlobeProps = {}) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const globeRef = useRef<any>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
   const [drawerOpen, setDrawerOpen] = useState(false);
+  // three.js reports readiness separately from the container measuring: on a
+  // cold load the ref can still be null when dimensions first arrive, and the
+  // opening fly-to was silently skipped.
+  const [ready, setReady] = useState(false);
   const [selected, setSelected] = useState<LocationData | null>(null);
   // The marker DOM is built once per mount, so its click handler reads the
   // latest callback through a ref instead of closing over the mount-time one.
@@ -51,6 +62,9 @@ export function NogglesRailsGlobe({
     onSelectRef.current = onSelectRail;
   }, [onSelectRail]);
 
+  // Keyed on the focused slug: react-globe.gl only rebuilds marker elements when
+  // the data array's identity changes, and the selected pin needs a different
+  // element than the rest.
   const points: GlobePoint[] = useMemo(
     () =>
       NOGGLES_RAILS.map((r) => ({
@@ -60,9 +74,10 @@ export function NogglesRailsGlobe({
         type: r.type,
         iconUrl: r.iconUrl,
         iconSize: r.iconSize,
+        selected: r.slug === focusSlug,
         rail: r,
       })),
-    [],
+    [focusSlug],
   );
 
   const markerHtmlElement = useCallback((point: object) => {
@@ -71,7 +86,15 @@ export function NogglesRailsGlobe({
     el.style.cursor = "pointer";
     el.style.pointerEvents = "auto";
     el.title = p.label;
-    el.innerHTML = `<img src="${p.iconUrl}" width="${p.iconSize[0]}" height="${p.iconSize[1]}" style="filter: drop-shadow(0 0 3px rgba(0,0,0,0.6));" />`;
+    // The pin stays the NogglesRail render rather than becoming a generic dot —
+    // it is the brand mark, and at this size it still reads as a point. The
+    // selected state is a pulsing green halo behind it, so "which one is open"
+    // is legible without giving up the icon.
+    el.innerHTML = `<span style="position:relative;display:block;width:${p.iconSize[0]}px;height:${p.iconSize[1]}px">${
+      p.selected
+        ? `<span aria-hidden style="position:absolute;left:50%;top:50%;width:${p.iconSize[0] + 16}px;height:${p.iconSize[1] + 16}px;transform:translate(-50%,-50%);border-radius:999px;border:2px solid #22c55e;background:radial-gradient(circle,rgba(34,197,94,.45),rgba(34,197,94,0) 70%);animation:rail-pin-pulse 1.8s ease-in-out infinite"></span>`
+        : ""
+    }<img src="${p.iconUrl}" width="${p.iconSize[0]}" height="${p.iconSize[1]}" style="position:relative;filter: drop-shadow(0 0 3px rgba(0,0,0,0.6));" /></span>`;
     el.addEventListener("click", (e) => {
       e.stopPropagation();
       if (onSelectRef.current) {
@@ -103,22 +126,28 @@ export function NogglesRailsGlobe({
     if (!globeRef.current) return;
     globeRef.current.pointOfView({ altitude: 1.5 }, 0);
     const controls = globeRef.current.controls();
-    controls.autoRotate = !focusSlug;
-    controls.autoRotateSpeed = 0.3;
+    const reduced =
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    controls.autoRotate = autoRotate && !focusSlug && !reduced;
+    controls.autoRotateSpeed = 0.3 * spinSpeed;
     controls.minDistance = 200;
     controls.maxDistance = 350;
-  }, [dimensions, focusSlug]);
+  }, [dimensions, focusSlug, autoRotate, spinSpeed, ready]);
 
   // Fly to whichever rail the parent has in focus.
   useEffect(() => {
-    if (!focusSlug || !globeRef.current || dimensions.width === 0) return;
+    if (!focusSlug || !ready || !globeRef.current || dimensions.width === 0) return;
     const rail = NOGGLES_RAILS.find((r) => r.slug === focusSlug);
     if (!rail) return;
+    const reduced =
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     globeRef.current.pointOfView(
       { lat: rail.position[0], lng: rail.position[1], altitude: 1.5 },
-      900,
+      reduced ? 0 : 900,
     );
-  }, [focusSlug, dimensions.width]);
+  }, [focusSlug, dimensions.width, ready]);
 
   return (
     <>
@@ -131,8 +160,9 @@ export function NogglesRailsGlobe({
             ref={globeRef}
             width={dimensions.width}
             height={dimensions.height}
-            globeImageUrl="//unpkg.com/three-globe/example/img/earth-blue-marble.jpg"
-            bumpImageUrl="//unpkg.com/three-globe/example/img/earth-topology.png"
+            globeImageUrl="https://unpkg.com/three-globe/example/img/earth-blue-marble.jpg"
+            bumpImageUrl="https://unpkg.com/three-globe/example/img/earth-topology.png"
+            onGlobeReady={() => setReady(true)}
             backgroundColor="rgba(0,0,0,0)"
             atmosphereColor="#6699cc"
             atmosphereAltitude={0.15}

--- a/src/components/nogglesrails/RailGlobeSection.tsx
+++ b/src/components/nogglesrails/RailGlobeSection.tsx
@@ -1,0 +1,298 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { NogglesRailsGlobe } from "@/components/nogglesrails/NogglesRailsGlobe";
+import { NOGGLES_RAILS, type Continent, type NogglesRailLocation } from "@/content/nogglesrails";
+import { Link } from "@/i18n/navigation";
+import { cn } from "@/lib/utils";
+
+/** The render that stands in for a rail with no site photography yet. */
+const RENDER_FALLBACK = "/nogglesRail3D.png";
+
+/**
+ * Site photography only.
+ *
+ * `images` is a mixed bag — the rails dataset stores YouTube watch links in it
+ * alongside stills, and a watch URL in an <img> is an empty frame. Rails left
+ * with nothing fall through to the 3D render rather than a blank panel.
+ */
+function railPhotos(rail: NogglesRailLocation): string[] {
+  return rail.images.filter((url) => !/youtube\.com|youtu\.be/i.test(url));
+}
+
+/** First paragraph only — the rest belongs on the rail's own page. */
+function lede(rail: NogglesRailLocation): string {
+  return rail.description.split("\n\n")[0];
+}
+
+/** Continents actually present in the data, in the order they first appear. */
+const CONTINENTS: Continent[] = Array.from(new Set(NOGGLES_RAILS.map((r) => r.continent)));
+
+const FILTER_KEY: Record<Continent, string> = {
+  Americas: "americas",
+  Europe: "europe",
+  Asia: "asia",
+  Africa: "africa",
+  Oceania: "oceania",
+};
+
+export function RailGlobeSection({
+  autoRotate = true,
+  spinSpeed = 1,
+}: {
+  autoRotate?: boolean;
+  spinSpeed?: number;
+} = {}) {
+  const t = useTranslations("newhome.rails");
+  const [index, setIndex] = useState(0);
+  const [filter, setFilter] = useState<Continent | null>(null);
+  const [photo, setPhoto] = useState(0);
+
+  const active = NOGGLES_RAILS[index];
+  const photos = useMemo(() => railPhotos(active), [active]);
+  const hasPhotos = photos.length > 0;
+  const frames = hasPhotos ? photos : [RENDER_FALLBACK];
+
+  // A new rail starts at its first frame; without this the carousel keeps an
+  // index the next rail may not have.
+  useEffect(() => {
+    setPhoto(0);
+  }, [index]);
+
+  const stats = useMemo(
+    () => ({
+      installations: NOGGLES_RAILS.length,
+      countries: new Set(NOGGLES_RAILS.map((r) => r.country)).size,
+      continents: new Set(NOGGLES_RAILS.map((r) => r.continent)).size,
+    }),
+    [],
+  );
+
+  const selectRail = useCallback((rail: NogglesRailLocation) => {
+    const i = NOGGLES_RAILS.findIndex((r) => r.slug === rail.slug);
+    if (i >= 0) setIndex(i);
+  }, []);
+
+  const step = useCallback(
+    (delta: number) => setPhoto((p) => (p + delta + frames.length) % frames.length),
+    [frames.length],
+  );
+
+  return (
+    <div className="flex flex-col gap-5">
+      {/* Continent filter. Non-matching entries in the grid below dim rather
+          than disappear: the list is the page's index of every rail, and one
+          that vanishes on a filter reads as missing data. */}
+      <div className="flex flex-wrap items-center gap-1.5">
+        <FilterPill active={filter === null} onClick={() => setFilter(null)}>
+          {t("filters.all")}
+        </FilterPill>
+        {CONTINENTS.map((c) => (
+          <FilterPill key={c} active={filter === c} onClick={() => setFilter(c)}>
+            {t(`filters.${FILTER_KEY[c]}`)}
+          </FilterPill>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 items-stretch gap-5 lg:grid-cols-[1.08fr_1fr]">
+        {/* ── Globe ─────────────────────────────────────────── */}
+        <div className="relative min-h-[420px] overflow-hidden rounded-2xl border border-white/[0.09] bg-[#0f1114] bg-[radial-gradient(70%_60%_at_50%_45%,rgba(30,58,138,.28),rgba(10,10,10,0)_70%)] lg:min-h-[560px]">
+          <NogglesRailsGlobe
+            focusSlug={active.slug}
+            onSelectRail={selectRail}
+            autoRotate={autoRotate}
+            spinSpeed={spinSpeed}
+            className="h-full min-h-[420px] w-full lg:min-h-[560px]"
+          />
+
+          <span className="pointer-events-none absolute left-4 top-4 font-mono text-[11px] uppercase tracking-[0.08em] text-white/45">
+            {t("hint")}
+          </span>
+
+          <span className="pointer-events-none absolute bottom-4 left-4 font-mono text-[11px] tracking-[0.08em] text-white/45">
+            <span className="text-white">{stats.installations}</span> {t("mono.installed")} ·{" "}
+            <span className="text-white">{stats.countries}</span> {t("mono.countries")} ·{" "}
+            <span className="text-white">{stats.continents}</span> {t("mono.continents")}
+          </span>
+
+          <span className="pointer-events-none absolute bottom-4 right-4 flex items-center gap-1.5 font-mono text-[11px] tracking-[0.08em] text-white/45">
+            <span className="size-[7px] rounded-full bg-[#22c55e] shadow-[0_0_6px_#22c55e]" />
+            {t("selected")}
+          </span>
+        </div>
+
+        {/* ── Detail ────────────────────────────────────────── */}
+        <div className="flex flex-col gap-3.5 rounded-2xl border border-white/[0.09] bg-[#131316] p-6">
+          <div>
+            <span className="text-[11.5px] font-semibold uppercase tracking-[0.1em] text-[#6699cc]">
+              {active.type} · {active.continent}
+            </span>
+            <h3 className="mt-1.5 text-[clamp(1.75rem,3vw,2.125rem)] font-extrabold leading-[1.05] text-neutral-50">
+              {active.label}
+            </h3>
+            <p className="mt-1 text-sm text-neutral-400">
+              {active.city}, {active.country}
+            </p>
+          </div>
+
+          {/* Carousel */}
+          <div className="relative h-[220px] overflow-hidden rounded-xl border border-white/10 bg-[#0d0d10]">
+            {hasPhotos ? (
+              // eslint-disable-next-line @next/next/no-img-element -- rail photography is hosted across hive/ipfs/gnars.center; the optimizer would need every host allow-listed
+              <img
+                key={frames[photo]}
+                src={frames[photo]}
+                alt={`${active.label} — ${active.city}, ${active.country}`}
+                className="size-full object-cover"
+                loading="lazy"
+              />
+            ) : (
+              <div className="flex size-full items-center justify-center bg-[radial-gradient(60%_60%_at_50%_45%,rgba(255,45,45,.16),rgba(0,0,0,0)_70%)]">
+                {/* eslint-disable-next-line @next/next/no-img-element -- local asset, sized by the frame */}
+                <img
+                  src={RENDER_FALLBACK}
+                  alt={active.label}
+                  className="max-h-[70%] max-w-[70%] object-contain"
+                />
+                <span
+                  aria-hidden
+                  className="pointer-events-none absolute text-[86px] leading-none text-white/[0.04]"
+                >
+                  ⌐◨-◨
+                </span>
+              </div>
+            )}
+
+            <span className="absolute left-3 top-3 rounded-full border border-white/15 bg-black/55 px-2.5 py-1 font-mono text-[9px] font-bold uppercase tracking-[0.1em] text-white/80">
+              {hasPhotos ? t("photoTag") : t("renderTag")}
+            </span>
+            <span className="absolute right-3 top-3 rounded-full bg-black/55 px-2 py-1 font-mono text-[9.5px] text-white/75">
+              {photo + 1} / {frames.length}
+            </span>
+
+            {frames.length > 1 && (
+              <>
+                <button
+                  type="button"
+                  onClick={() => step(-1)}
+                  aria-label={t("prevPhoto")}
+                  className="absolute left-2.5 top-1/2 flex size-8 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full bg-black/55 text-white hover:bg-black/80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#6699cc]"
+                >
+                  <ChevronLeft className="size-4" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => step(1)}
+                  aria-label={t("nextPhoto")}
+                  className="absolute right-2.5 top-1/2 flex size-8 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full bg-black/55 text-white hover:bg-black/80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#6699cc]"
+                >
+                  <ChevronRight className="size-4" />
+                </button>
+                <div className="absolute bottom-3 left-1/2 flex -translate-x-1/2 items-center gap-1.5">
+                  {frames.map((frame, i) => (
+                    <button
+                      key={frame}
+                      type="button"
+                      onClick={() => setPhoto(i)}
+                      aria-label={t("goToPhoto", { n: i + 1 })}
+                      aria-current={i === photo}
+                      className={cn(
+                        "h-[7px] cursor-pointer rounded-full transition-[width,background-color] duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#6699cc]",
+                        i === photo ? "w-[18px] bg-white" : "w-[7px] bg-white/40",
+                      )}
+                    />
+                  ))}
+                </div>
+              </>
+            )}
+          </div>
+
+          <p className="text-pretty text-[13.5px] leading-[1.62] text-neutral-300">
+            {lede(active)}
+          </p>
+
+          <div className="flex flex-wrap gap-1.5">
+            <span className="rounded-md border border-white/10 bg-white/[0.04] px-2.5 py-1.5 text-[11.5px] text-neutral-300">
+              {active.proposal.name}
+            </span>
+            <span className="rounded-md border border-white/10 bg-white/[0.04] px-2.5 py-1.5 font-mono text-[11.5px] text-neutral-400">
+              {active.position[0].toFixed(2)}, {active.position[1].toFixed(2)}
+            </span>
+            <a
+              href={active.proposal.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-md border border-[#6699cc]/35 bg-[#1e3a8a]/[0.18] px-2.5 py-1.5 text-[11.5px] font-medium text-[#9dc0e8] hover:bg-[#1e3a8a]/30"
+            >
+              {t("readProposal")}
+            </a>
+          </div>
+
+          <Link
+            href={`/nogglesrails/${active.slug}`}
+            className="rounded-[9px] bg-neutral-50 py-2.5 text-center text-[13px] font-semibold text-neutral-900 hover:opacity-90"
+          >
+            {t("viewInstallation")}
+          </Link>
+
+          <div className="grid max-h-[260px] grid-cols-2 gap-1.5 overflow-y-auto pr-1 [scrollbar-width:thin]">
+            {NOGGLES_RAILS.map((rail, i) => {
+              const dimmed = filter !== null && rail.continent !== filter;
+              return (
+                <button
+                  key={rail.slug}
+                  type="button"
+                  onClick={() => setIndex(i)}
+                  aria-label={`${rail.label}, ${rail.country}`}
+                  aria-pressed={i === index}
+                  className={cn(
+                    "cursor-pointer rounded-lg border px-3 py-2 text-left transition-opacity focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#6699cc]",
+                    i === index
+                      ? "border-white/40 bg-[#262626]"
+                      : "border-white/10 bg-white/[0.03] hover:bg-white/[0.06]",
+                    dimmed && "opacity-45",
+                  )}
+                >
+                  <span className="block truncate text-[13px] font-semibold text-neutral-100">
+                    {rail.label}
+                  </span>
+                  <span className="block truncate text-[11.5px] text-neutral-400">
+                    {rail.country}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function FilterPill({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={cn(
+        "cursor-pointer rounded-full border px-3.5 py-1.5 text-[12.5px] font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#6699cc]",
+        active
+          ? "border-white/40 bg-[#262626] text-neutral-50"
+          : "border-white/10 bg-transparent text-neutral-400 hover:text-neutral-50",
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/stake/GlobalRewardsLootbox.tsx
+++ b/src/components/stake/GlobalRewardsLootbox.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { MorLootbox } from "@/components/stake/MorLootbox";
+import { usePathname } from "@/i18n/navigation";
+
+/**
+ * The rewards lootbox, site-wide.
+ *
+ * It used to be mounted only by /stake, so anyone with claimable MOR or vault
+ * yield had to already be on that page to find out. Mounting it in the layout
+ * puts the affordance on every route instead.
+ *
+ * /stake is the one exception: `StakePageContent` mounts its own controlled
+ * instance there, because the rows in PositionsHub open the same modal and need
+ * to own its open state. Rendering this one as well would put two floating
+ * buttons in the same corner.
+ */
+export function GlobalRewardsLootbox() {
+  const pathname = usePathname();
+  if (pathname === "/stake" || pathname.startsWith("/stake/")) return null;
+  return <MorLootbox showEnablePrompt />;
+}

--- a/src/components/stake/MorLootbox.tsx
+++ b/src/components/stake/MorLootbox.tsx
@@ -16,12 +16,14 @@ import { Gift } from "lucide-react";
 import { toast } from "sonner";
 import { getAddress, type Address } from "viem";
 import { RewardClaimModal } from "@/components/stake/RewardClaimModal";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useMorDistribute } from "@/hooks/use-mor-distribute";
 import { useMorpheusPosition } from "@/hooks/use-morpheus-position";
 import { useMorpheusStake } from "@/hooks/use-morpheus-stake";
 import { useStakeDeposit } from "@/hooks/use-stake-deposit";
 import { useUserAddress } from "@/hooks/use-user-address";
 import { useVaultRewards } from "@/hooks/use-vault-rewards";
+import { Link } from "@/i18n/navigation";
 import { predictSplitAddress, splitMorBalance, warehouseMorBalance } from "@/lib/mor-split";
 import { MOR_GNARS_RECIPIENT, type MorpheusAsset } from "@/lib/morpheus";
 
@@ -44,9 +46,16 @@ const MOR_GREEN = "#2be58b";
 export function MorLootbox({
   open: openProp,
   onOpenChange,
+  showEnablePrompt = false,
 }: {
   open?: boolean;
   onOpenChange?: (v: boolean) => void;
+  /**
+   * When the wallet has nothing to act on, render a muted button that points at
+   * /stake instead of rendering nothing. Only the site-wide mount asks for this:
+   * on /stake itself the prompt would be inviting you to the page you are on.
+   */
+  showEnablePrompt?: boolean;
 } = {}) {
   const t = useTranslations("stake");
   // Read off the EFFECTIVE user address (EOA for external wallets), not the raw
@@ -232,7 +241,34 @@ export function MorLootbox({
     [morpheus, t],
   );
 
-  if (!you || !hasAction) return null;
+  if (!you) return null;
+
+  // Connected, but nothing accrued yet. The site-wide mount keeps the affordance
+  // on screen so the rewards loop is discoverable from anywhere, rather than only
+  // existing for people who already found /stake.
+  if (!hasAction) {
+    if (!showEnablePrompt) return null;
+    return (
+      <div className="fixed bottom-5 right-5 z-50">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Link
+              href="/stake"
+              aria-label={t("lootbox.enableRewards")}
+              className="relative flex h-14 w-14 cursor-pointer items-center justify-center rounded-2xl opacity-70 shadow-xl transition-opacity hover:opacity-100"
+              style={{
+                background: "linear-gradient(160deg,#123, #04140d)",
+                border: `1px solid ${MOR_GREEN}33`,
+              }}
+            >
+              <Gift className="h-6 w-6" style={{ color: `${MOR_GREEN}aa` }} />
+            </Link>
+          </TooltipTrigger>
+          <TooltipContent side="left">{t("lootbox.enableRewards")}</TooltipContent>
+        </Tooltip>
+      </div>
+    );
+  }
 
   const totalClaimable = claimable.reduce((s, p) => s + p.pendingMor, 0);
   const totalDistributable = distributable.reduce((s, p) => s + (splitBalances[p.asset] ?? 0), 0);


### PR DESCRIPTION
## Summary

- The NogglesRail Globe design as a reusable module: continent filters, photo carousel, story, proposal chips and the full 16-rail location grid, wired to the existing three-globe renderer.
- The rewards lootbox now appears on every route, not only `/stake`, with an "Enable rewards" prompt for wallets that have nothing accrued yet.
- Fixes the globe's Earth textures failing to load, and the two governance panels sitting at different heights.

## Changes

- `src/components/nogglesrails/RailGlobeSection.tsx` — the module
- `src/components/nogglesrails/NogglesRailsGlobe.tsx` — `autoRotate`/`spinSpeed` props, selected-pin halo, `onGlobeReady` gating, reduced-motion handling, https textures
- `src/components/newhome/RailsSection.tsx` — now just heading + module
- `src/components/stake/GlobalRewardsLootbox.tsx` + `MorLootbox.tsx` — site-wide mount and the enable-rewards fallback
- `src/app/[locale]/layout.tsx`, `globals.css`, `GovSection.tsx`, `AuctionPanel.tsx`, `messages/{en,pt-br}/*`

### Deliberate deviations from the spec
- **Pins stay the NogglesRail render, not red dots.** It's the brand mark and still reads as a point at that size; the spec's *selected* treatment (green + pulse) is implemented as a halo behind it.
- **Filtered-out rails dim but stay in the grid** (spec behaviour) rather than being removed — the grid is the index of every rail.
- **The 3D-render fallback is unexercised by current data**: all 16 rails have at least one photo, including local paths. The branch exists for future rails.

### Fixes
- Textures were requested from `//unpkg.com`; on the http dev server that resolves to http, and the redirect to https drops the CORS headers three.js needs, so the Earth silently failed with a console error on every page carrying a globe. Pinned to `https://`.
- `GovSection` used `items-start`, so the auction card and the proposals/feed card ended at different heights. The row stretches now — both measure 806px.

## Test plan

- [x] `pnpm build` 0, `pnpm lint` 0 errors, `pnpm test` 16 files / 133 passing
- [x] Pin click ↔ list click ↔ filter stay in sync; photo resets to 1/N on rail change
- [x] Carousel arrows + dots appear only with 2+ photos (Kenya 1/1 → 0 dots; Praça XV 1/5 → 5 dots)
- [x] Europe filter dims 14 of 16 and they stay clickable
- [x] Single column ≤768px, two column at 1440; rail grid stays 2-col; every button has an accessible name
- [x] No unpkg CORS errors; 0 page errors at 360/768/1440; no horizontal scroll
- [x] Lootbox renders once per page across `/newhome`, `/proposals`, `/treasury`, and is not duplicated on `/stake`
- [x] With no accrued rewards: "Enable rewards" → `/stake`, and `/pt-br` → "Ativar recompensas" → `/pt-br/stake` (verified by temporarily stubbing a connected address; stub removed)

Generated with [Claude Code](https://claude.com/claude-code)